### PR TITLE
Changing Candy Crusher -> Eraser

### DIFF
--- a/json/InforTextItemPetCandyIceBlock.txt
+++ b/json/InforTextItemPetCandyIceBlock.txt
@@ -4,6 +4,6 @@
 		"jp_text": "キャラメルキューブ",
 		"en_text": "Caramel Cube",
 		"jp_explain": "リムーバーとイレイサーを受け付けず\n設置場所からの移動も不可。\nキャラメルクラッシャーで削除可能。",
-		"en_explain": "Immune to Candy Remover and Crusher\nitems, and cannot be moved.\nOnly Caramel Crusher is effective."
+		"en_explain": "Immune to Candy Remover and Eraser\nitems, and cannot be moved.\nOnly Caramel Crusher is effective."
 	}
 ]


### PR DESCRIPTION
After thinking about it, removes confusion between two same-name items. Will update main game patch. Sorry