### PR TITLE
Item updates

### DIFF
--- a/json/Item_Addon_Arm.txt
+++ b/json/Item_Addon_Arm.txt
@@ -1082,7 +1082,7 @@
 		"jp_text": "アーム／フィオガルズ",
 		"tr_text": "Arm/Fiogals",
 		"jp_explain": "腕部ユニット。恐怖を祓う意志の具現。\n射撃、炎、雷、闇属性の耐性と最大ＰＰ\n射撃攻撃、射撃防御を上昇させる。",
-		"tr_explain": "Arm Unit. Embodiment of Will.\nIncreases Ranged, Fire, Dark,\nThunder Resist & PP.\nIncreases R-ATK and R-DEF."
+		"tr_explain": "Arm Unit. Embodiment of Will. Boosts\nShot, Fire, Dark and Thunder Resist,\nas well as PP, R-ATK and R-DEF."
 	},
 	{
 		"assign": "520256",

--- a/json/Item_Addon_Back.txt
+++ b/json/Item_Addon_Back.txt
@@ -674,7 +674,7 @@
 	{
 		"assign": "510114",
 		"jp_text": "リア／キングスパック",
-		"tr_text": "Rear/Kings Pack",
+		"tr_text": "Rear/King's Pack",
 		"jp_explain": "背部ユニット。超弩級パーツの再利用。\n風属性への耐性と打撃防御を\n上昇させる。",
 		"tr_explain": ""
 	},

--- a/json/Item_Addon_Leg.txt
+++ b/json/Item_Addon_Leg.txt
@@ -660,7 +660,7 @@
 	{
 		"assign": "530114",
 		"jp_text": "レッグ／キングスレグス",
-		"tr_text": "Leg/Kings Legs",
+		"tr_text": "Leg/King's Legs",
 		"jp_explain": "脚部ユニット。超弩級パーツの再利用。\n風属性への耐性と打撃防御を\n上昇させる。",
 		"tr_explain": ""
 	},

--- a/json/Item_BaseWear_Female.txt
+++ b/json/Item_BaseWear_Female.txt
@@ -550,7 +550,7 @@
 		"jp_text": "ナギサスイムウェア[Ba]",
 		"tr_text": "Nagisa Swimwear [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nナギサスイムウェア[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Nagisa Swimwear [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Nagisa Swimwear [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "335098",
@@ -1005,105 +1005,105 @@
 		"jp_text": "セクシーモノキニ[Ba]",
 		"tr_text": "Sexy Monokini [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350168",
 		"jp_text": "セクシーモノキニ紅[Ba]",
 		"tr_text": "Sexy Monokini Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350169",
 		"jp_text": "セクシーモノキニ海[Ba]",
 		"tr_text": "Sexy Monokini Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ海[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Sea [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Sea [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350170",
 		"jp_text": "セクシーモノキニ雪[Ba]",
 		"tr_text": "Sexy Monokini Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Snow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350171",
 		"jp_text": "セクシーモノキニ影[Ba]",
 		"tr_text": "Sexy Monokini Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350172",
 		"jp_text": "ハイネックビキニ[Ba]",
 		"tr_text": "High Neck Bikini [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350173",
 		"jp_text": "ハイネックビキニ桜[Ba]",
 		"tr_text": "High Neck Bikini Sakura [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ桜[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sakura [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sakura [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350174",
 		"jp_text": "ハイネックビキニ空[Ba]",
 		"tr_text": "High Neck Bikini Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ空[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sky [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sky [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350175",
 		"jp_text": "ハイネックビキニ月[Ba]",
 		"tr_text": "High Neck Bikini Moon [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ月[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Moon [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Moon [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350176",
 		"jp_text": "ハイネックビキニ萌[Ba]",
 		"tr_text": "High Neck Bikini Sprout [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ萌[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sprout [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Sprout [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350177",
 		"jp_text": "セクシービキニ[Ba]",
 		"tr_text": "Sexy Bikini [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350178",
 		"jp_text": "セクシービキニ空[Ba]",
 		"tr_text": "Sexy Bikini Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ空[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Sky [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Sky [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350179",
 		"jp_text": "セクシービキニ／Ｆ[Ba]",
 		"tr_text": "Sexy Bikini / F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ／Ｆ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350180",
 		"jp_text": "セクシービキニ／Ｆ空[Ba]",
 		"tr_text": "Sexy Bikini / F Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ／Ｆ空[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Sky [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Sky [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350181",
 		"jp_text": "セクシービキニ／Ｆ影[Ba]",
 		"tr_text": "Sexy Bikini / F Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ／Ｆ影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350182",
@@ -1271,21 +1271,21 @@
 		"jp_text": "セクシービキニ影[Ba]",
 		"tr_text": "Sexy Bikini Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350208",
 		"jp_text": "セクシービキニ紅[Ba]",
 		"tr_text": "Sexy Bikini Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350209",
 		"jp_text": "セクシービキニ／Ｆ紅[Ba]",
 		"tr_text": "Sexy Bikini / F Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシービキニ／Ｆ紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Bikini / F Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350210",
@@ -2524,14 +2524,14 @@
 		"jp_text": "ナナフンスタイル[Ba]",
 		"tr_text": "Nanafun Style [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nナナフンスタイル[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Nanafun Style [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Nanafun Style [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350391",
 		"jp_text": "ナナフンスタイル雪[Ba]",
 		"tr_text": "Nanafun Style Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nナナフンスタイル雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Nanafun Style Snow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Nanafun Style Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350392",
@@ -2580,7 +2580,7 @@
 		"jp_text": "ヨルハＡ２・レプカ[Ba]",
 		"tr_text": "YoRHa A2 Repca [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヨルハＡ２・レプカ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"YoRHa A2 Repca [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"YoRHa A2 Repca [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350401",
@@ -3350,42 +3350,42 @@
 		"jp_text": "ラカサシャミール[Ba]",
 		"tr_text": "Raqasa Shamir [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350514",
 		"jp_text": "ラカサシャミール紅[Ba]",
 		"tr_text": "Raqasa Shamir Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350515",
 		"jp_text": "ラカサシャミール海[Ba]",
 		"tr_text": "Raqasa Shamir Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール海[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Sea [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Sea [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350516",
 		"jp_text": "ラカサシャミール雅[Ba]",
 		"tr_text": "Raqasa Shamir Elegance [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール雅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Elegance [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Elegance [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350517",
 		"jp_text": "ラカサシャミール雪[Ba]",
 		"tr_text": "Raqasa Shamir Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Snow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350518",
 		"jp_text": "ラカサシャミール影[Ba]",
 		"tr_text": "Raqasa Shamir Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nラカサシャミール影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Raqasa Shamir Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350519",
@@ -3434,56 +3434,56 @@
 		"jp_text": "レディサーフパンツ[Ba]",
 		"tr_text": "Lady Surf Pants [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350526",
 		"jp_text": "レディサーフパンツ紅[Ba]",
 		"tr_text": "Lady Surf Pants Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350527",
 		"jp_text": "レディサーフパンツ海[Ba]",
 		"tr_text": "Lady Surf Pants Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ海[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Sea [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Sea [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350528",
 		"jp_text": "レディサーフパンツ月[Ba]",
 		"tr_text": "Lady Surf Pants Moon [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ月[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Moon [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Moon [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350529",
 		"jp_text": "レディサーフパンツ雪[Ba]",
 		"tr_text": "Lady Surf Pants Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Snow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350530",
 		"jp_text": "レディサーフパンツ影[Ba]",
 		"tr_text": "Lady Surf Pants Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nレディサーフパンツ影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Lady Surf Pants Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350531",
 		"jp_text": "ゴールドＳビキニ／Ｆ[Ba]",
 		"tr_text": "Gold S Bikini/F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nゴールドＳビキニ／Ｆ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Gold S Bikini/F [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Gold S Bikini/F [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350532",
 		"jp_text": "シルバーＳビキニ／Ｆ[Ba]",
 		"tr_text": "Silver S Bikini/F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nシルバーＳビキニ／Ｆ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Silver S Bikini/F [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Silver S Bikini/F [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350533",
@@ -3917,28 +3917,28 @@
 		"jp_text": "セクシーモノキニ冬[Ba]",
 		"tr_text": "Sexy Monokini Winter [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ冬[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Winter [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Winter [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350609",
 		"jp_text": "セクシーモノキニ玄[Ba]",
 		"tr_text": "Sexy Monokini Mysterious [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nセクシーモノキニ玄[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Mysterious [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Sexy Monokini Mysterious [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350610",
 		"jp_text": "ハイネックビキニ涼[Ba]",
 		"tr_text": "High Neck Bikini Cool [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ涼[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Cool [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Cool [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350611",
 		"jp_text": "ハイネックビキニ雪[Ba]",
 		"tr_text": "High Neck Bikini Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nハイネックビキニ雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Snow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"High Neck Bikini Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350612",
@@ -3980,42 +3980,42 @@
 		"jp_text": "ヤミガラス・レプカ[Ba]",
 		"tr_text": "Yamigarasu Repca [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350623",
 		"jp_text": "ヤミガラス・レプカ紅[Ba]",
 		"tr_text": "Yamigarasu Repca Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Crimson [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350624",
 		"jp_text": "ヤミガラス・レプカ夜[Ba]",
 		"tr_text": "Yamigarasu Repca Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ夜[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Night [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Night [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350625",
 		"jp_text": "ヤミガラス・レプカ茜[Ba]",
 		"tr_text": "Yamigarasu Repca Madder [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ茜[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Madder [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Madder [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350626",
 		"jp_text": "ヤミガラス・レプカ静[Ba]",
 		"tr_text": "Yamigarasu Repca Tranquil [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ静[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Tranquil [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Tranquil [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350627",
 		"jp_text": "ヤミガラス・レプカ影[Ba]",
 		"tr_text": "Yamigarasu Repca Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nヤミガラス・レプカ影[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Shadow [Ba]\".\nOnly usable on female characters."
+		"tr_explain": "Unlocks the new basewear\n\"Yamigarasu Repca Shadow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350628",

--- a/json/Item_BaseWear_Male.txt
+++ b/json/Item_BaseWear_Male.txt
@@ -781,91 +781,91 @@
 		"jp_text": "アロハパンツ[Ba]",
 		"tr_text": "Aloha Shorts [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアロハパンツ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340133",
 		"jp_text": "アロハパンツ紅[Ba]",
 		"tr_text": "Aloha Shorts Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアロハパンツ紅[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Crimson [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Crimson [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340134",
 		"jp_text": "アロハパンツ夜[Ba]",
 		"tr_text": "Aloha Shorts Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアロハパンツ夜[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Night [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Night [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340135",
 		"jp_text": "アロハパンツ雪[Ba]",
 		"tr_text": "Aloha Shorts Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアロハパンツ雪[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Snow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Snow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340136",
 		"jp_text": "アロハパンツ影[Ba]",
 		"tr_text": "Aloha Shorts Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアロハパンツ影[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Shadow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Aloha Shorts Shadow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340137",
 		"jp_text": "ブーメランパンツ[Ba]",
 		"tr_text": "Boomerang Pants [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nブーメランパンツ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340138",
 		"jp_text": "ブーメランパンツ影[Ba]",
 		"tr_text": "Boomerang Pants Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nブーメランパンツ影[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants Shadow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants Shadow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340139",
 		"jp_text": "ブーメランパンツ／Ｆ[Ba]",
 		"tr_text": "Boomerang Pants / F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nブーメランパンツ／Ｆ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants / F [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants / F [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340140",
 		"jp_text": "ブーメランパンツ／Ｆ影[Ba]",
 		"tr_text": "Boomerang Pants / F Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nブーメランパンツ／Ｆ影[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants / F Shadow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Boomerang Pants / F Shadow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340142",
 		"jp_text": "パンサーＶパンツ[Ba]",
 		"tr_text": "Panther V Pants [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nパンサーＶパンツ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340143",
 		"jp_text": "パンサーＶパンツ桜[Ba]",
 		"tr_text": "Panther V Pants Sakura [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nパンサーＶパンツ桜[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants Sakura [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants Sakura [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340144",
 		"jp_text": "パンサーＶパンツ／Ｆ[Ba]",
 		"tr_text": "Panther V Pants /F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nパンサーＶパンツ／Ｆ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants /F [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants /F [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340145",
 		"jp_text": "パンサーＶパンツ／Ｆ桜[Ba]",
 		"tr_text": "Panther V Pants Sakura / F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nパンサーＶパンツ／Ｆ桜[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants Sakura / F [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Panther V Pants Sakura / F [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340147",
@@ -1586,14 +1586,14 @@
 		"jp_text": "フンドシスタイル[Ba]",
 		"tr_text": "Fundoshi Style [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nフンドシスタイル[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Fundoshi Style [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Fundoshi Style [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340254",
 		"jp_text": "フンドシスタイル雪[Ba]",
 		"tr_text": "Fundoshi Style Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nフンドシスタイル雪[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Fundoshi Style Snow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Fundoshi Style Snow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340255",
@@ -2034,56 +2034,56 @@
 		"jp_text": "トレーニングＳウェア[Ba]",
 		"tr_text": "Training S Wear [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340321",
 		"jp_text": "トレーニングＳウェア紅[Ba]",
 		"tr_text": "Training S Wear Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア紅[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Crimson [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Crimson [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340322",
 		"jp_text": "トレーニングＳウェア空[Ba]",
 		"tr_text": "Training S Wear Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア空[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Sky [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Sky [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340323",
 		"jp_text": "トレーニングＳウェア月[Ba]",
 		"tr_text": "Training S Wear Moon [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア月[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Moon [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Moon [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340324",
 		"jp_text": "トレーニングＳウェア雪[Ba]",
 		"tr_text": "Training S Wear Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア雪[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Snow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Snow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340325",
 		"jp_text": "トレーニングＳウェア影[Ba]",
 		"tr_text": "Training S Wear Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nトレーニングＳウェア影[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Shadow [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Training S Wear Shadow [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340326",
 		"jp_text": "ゴールドＶパンツ／Ｆ[Ba]",
 		"tr_text": "Gold V Pants/F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nゴールドＶパンツ／Ｆ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Gold V Pants/F [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Gold V Pants/F [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340327",
 		"jp_text": "シルバーＶパンツ／Ｆ[Ba]",
 		"tr_text": "Silver V Pants/F [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nシルバーＶパンツ／Ｆ[Ba]が選択可能。\n男性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": "Unlocks the new basewear\n\"Silver V Pants/F [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Silver V Pants/F [Ba]\".\nOnly usable on male characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3340328",

--- a/json/Item_Costume_Female.txt
+++ b/json/Item_Costume_Female.txt
@@ -9230,14 +9230,14 @@
 		"jp_text": "ハニュエール・レプカ",
 		"tr_text": "HUnewearl Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201528",
 		"jp_text": "ハニュエール・レプカＣ",
 		"tr_text": "HUnewearl Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201529",
@@ -9797,14 +9797,14 @@
 		"jp_text": "レイキャシール・レプカ",
 		"tr_text": "RAcaseal Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201614",
 		"jp_text": "レイキャシール・レプカＣ",
 		"tr_text": "RAcaseal Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201615",
@@ -9846,14 +9846,14 @@
 		"jp_text": "フォマール・レプカ",
 		"tr_text": "FOmarl Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201621",
 		"jp_text": "フォマール・レプカＣ",
 		"tr_text": "FOmarl Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201622",
@@ -10322,14 +10322,14 @@
 		"jp_text": "ヒューキャシール・レプカ",
 		"tr_text": "HUcaseal Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201692",
 		"jp_text": "ヒューキャシール・レプカＣ",
 		"tr_text": "HUcaseal Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201693",
@@ -10672,14 +10672,14 @@
 		"jp_text": "レイマール・レプカ",
 		"tr_text": "RAmarl Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201742",
 		"jp_text": "レイマール・レプカＣ",
 		"tr_text": "RAmarl Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201744",
@@ -11148,14 +11148,14 @@
 		"jp_text": "フォニュエール・レプカ",
 		"tr_text": "FOnewearl Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201812",
 		"jp_text": "フォニュエール・レプカＣ",
 		"tr_text": "FOnewearl Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2201813",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -8243,42 +8243,42 @@
 		"jp_text": "リュウ・レプカ",
 		"tr_text": "Ryu Repca",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101370",
 		"jp_text": "リュウ・レプカ紅",
 		"tr_text": "Ryu Repca Crimson",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101371",
 		"jp_text": "リュウ・レプカ夜",
 		"tr_text": "Ryu Repca Night",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101372",
 		"jp_text": "リュウ・レプカ雪",
 		"tr_text": "Ryu Repca Snow",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101373",
 		"jp_text": "リュウ・レプカ雅",
 		"tr_text": "Ryu Repca Elegance",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101374",
 		"jp_text": "リュウ・レプカ陽",
 		"tr_text": "Ryu Repca Sun",
 		"jp_explain": "古来より続く隼流忍術を\n現代に受け継ぐ超忍が\n着用する衣装のレプリカ。",
-		"tr_explain": ""
+		"tr_explain": "Replica of the costume worn by the\nSuper Ninja who has inherited the\nancient Hayabusa style ninjutsu."
 	},
 	{
 		"assign": "2101375",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -5506,14 +5506,14 @@
 		"jp_text": "ヒューマー・レプカ",
 		"tr_text": "HUmar Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210952",
 		"jp_text": "ヒューマー・レプカＣ",
 		"tr_text": "HUmar Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210953",
@@ -5772,14 +5772,14 @@
 		"jp_text": "レイキャスト・レプカ",
 		"tr_text": "RAcast Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210992",
 		"jp_text": "レイキャスト・レプカＣ",
 		"tr_text": "RAcast Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210993",
@@ -5814,14 +5814,14 @@
 		"jp_text": "フォーマー・レプカ",
 		"tr_text": "FOmar Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210998",
 		"jp_text": "フォーマー・レプカＣ",
 		"tr_text": "FOmar Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "210999",
@@ -6108,14 +6108,14 @@
 		"jp_text": "ヒューキャスト・レプカ",
 		"tr_text": "HUcast Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101041",
 		"jp_text": "ヒューキャスト・レプカＣ",
 		"tr_text": "HUcast Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nキャストのハンター専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Android Hunters\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101042",
@@ -6269,14 +6269,14 @@
 		"jp_text": "レイマー・レプカ",
 		"tr_text": "RAmar Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101064",
 		"jp_text": "レイマー・レプカＣ",
 		"tr_text": "RAmar Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nヒューマンのレンジャー専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Human Rangers\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101065",
@@ -6430,14 +6430,14 @@
 		"jp_text": "フォニューム・レプカ",
 		"tr_text": "FOnewm Repca",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101088",
 		"jp_text": "フォニューム・レプカＣ",
 		"tr_text": "FOnewm Repca C",
 		"jp_explain": "大型宇宙船パイオニア２に搭乗していた\nニューマンのフォース専用戦闘服。\nハンターズの一員の証でもある。",
-		"tr_explain": ""
+		"tr_explain": "Clothing worn by Newman Forces\naboard Pioneer 2. Shows the wearer\nto be a member of the Hunters."
 	},
 	{
 		"assign": "2101089",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -18,7 +18,7 @@
 		"jp_text": "アドヴェントス",
 		"tr_text": "Adventos",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "2103",
@@ -557,28 +557,28 @@
 		"jp_text": "アドヴェントス影",
 		"tr_text": "Adventos Shadow",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "21092",
 		"jp_text": "アドヴェントス鋼",
 		"tr_text": "Adventos Steel",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "21093",
 		"jp_text": "アドヴェントス銀",
 		"tr_text": "Adventos Silver",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "21094",
 		"jp_text": "アドヴェントス陽",
 		"tr_text": "Adventos Sun",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "21095",
@@ -5086,7 +5086,7 @@
 		"jp_text": "アドヴェントスＣ",
 		"tr_text": "Adventos C",
 		"jp_explain": "試験的に作られたアークス用の戦闘服。\n露出をできるだけ抑え、かつフォトンの\n吸収を阻害しないよう考えられている。",
-		"tr_explain": ""
+		"tr_explain": "Experimental ARKS battle clothing.\nDesigned to maximise coverage while\nnot inhibiting Photon absorption."
 	},
 	{
 		"assign": "210889",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -4104,42 +4104,42 @@
 	{
 		"assign": "210747",
 		"jp_text": "事代守人衣",
-		"tr_text": "Kotoshiro Protector's Clothes",
+		"tr_text": "Kotoshiro's Clothes",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "210748",
 		"jp_text": "事代守人衣　影",
-		"tr_text": "Kotoshiro Protector's Clothes Black",
+		"tr_text": "Kotoshiro's Clothes Shadow",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "210749",
 		"jp_text": "事代守人衣　紅",
-		"tr_text": "Kotoshiro Protector's Clothes Red",
+		"tr_text": "Kotoshiro's Clothes Crimson",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "210750",
 		"jp_text": "事代守人衣　海",
-		"tr_text": "Kotoshiro Protector's Clothes Sea",
+		"tr_text": "Kotoshiro's Clothes Sea",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "210751",
 		"jp_text": "事代守人衣　雅",
-		"tr_text": "Kotoshiro Protector's Clothes Purple",
+		"tr_text": "Kotoshiro's Clothes Elegance",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "210752",
 		"jp_text": "事代守人衣　月",
-		"tr_text": "Kotoshiro Protector's Clothes Moon",
+		"tr_text": "Kotoshiro's Clothes Moon",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
@@ -6666,7 +6666,7 @@
 	{
 		"assign": "2101122",
 		"jp_text": "事代守人衣７１１",
-		"tr_text": "Kotoshiro Protector's Clothes 711",
+		"tr_text": "Kotoshiro's Clothes 711",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
@@ -7646,21 +7646,21 @@
 	{
 		"assign": "2101268",
 		"jp_text": "事代守人衣　雪",
-		"tr_text": "Kotoshiro Protector's Clothes Snow",
+		"tr_text": "Kotoshiro's Clothes Snow",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2101269",
 		"jp_text": "事代守人衣　玄",
-		"tr_text": "Kotoshiro Protector's Clothes Mysterious",
+		"tr_text": "Kotoshiro's Clothes Mysterious",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2101270",
 		"jp_text": "事代守人衣　夜",
-		"tr_text": "Kotoshiro Protector's Clothes Night",
+		"tr_text": "Kotoshiro's Clothes Night",
 		"jp_explain": "灰の神子の守人であるコトシロ用に\nスクナヒメが作り上げた専用の服。\n神子の力で紡ぎ上げられた礼装。",
 		"tr_explain": ""
 	},

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -53,7 +53,7 @@
 		"jp_text": "シャープオーダー",
 		"tr_text": "Sharp Order",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "2108",
@@ -200,28 +200,28 @@
 		"jp_text": "シャープオーダー影",
 		"tr_text": "Sharp Order Shadow",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "21033",
 		"jp_text": "シャープオーダー月",
 		"tr_text": "Sharp Order Moon",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "21034",
 		"jp_text": "シャープオーダー紅",
 		"tr_text": "Sharp Order Crimson",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "21035",
 		"jp_text": "シャープオーダー葉",
 		"tr_text": "Sharp Order Leaf",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "21036",
@@ -6458,7 +6458,7 @@
 		"jp_text": "シャープオーダー雅Ｇ",
 		"tr_text": "Sharp Order Elegance G",
 		"jp_explain": "アークス用戦闘服。レンジャークラスの\n初期支給品で、射撃補助に重点を置いた\n合理的な設計がされている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Designed with\na focus on aim-assistance, and\nsupplied to new Ranger-class ARKS."
 	},
 	{
 		"assign": "2101092",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -11,7 +11,7 @@
 		"jp_text": "ヘヴィスクード",
 		"tr_text": "Heavy Scudo",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "2102",
@@ -725,28 +725,28 @@
 		"jp_text": "ヘヴィスクード葉",
 		"tr_text": "Heavy Scudo Leaf",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "210117",
 		"jp_text": "ヘヴィスクード鋼",
 		"tr_text": "Heavy Scudo Steel",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "210118",
 		"jp_text": "ヘヴィスクード陽",
 		"tr_text": "Heavy Scudo Sun",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "210119",
 		"jp_text": "ヘヴィスクード紅",
 		"tr_text": "Heavy Scudo Crimson",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "210120",
@@ -5093,7 +5093,7 @@
 		"jp_text": "ヘヴィスクードＣ",
 		"tr_text": "Heavy Scudo C",
 		"jp_explain": "戦闘用に作られたアークスの服装。\n衝撃吸収用のアブソーバーが各所に\n取り付けられており、安定性が高い。",
-		"tr_explain": ""
+		"tr_explain": "ARKS clothing built for battle.\nCovered in shock absorbers, making\nit extremely stable."
 	},
 	{
 		"assign": "210890",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -74,7 +74,7 @@
 		"jp_text": "センシアスコート",
 		"tr_text": "Sensuous Coat",
 		"jp_explain": "アークス用戦闘服。フォースクラスの\n初期支給品で、フォトン励起を誘う\n特殊な素材が用いられている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Made to be\nconducive to Photon excitation, and\nsupplied to new Force-class ARKS."
 	},
 	{
 		"assign": "21012",
@@ -228,28 +228,28 @@
 		"jp_text": "センシアスコート桜",
 		"tr_text": "Sensuous Coat Sakura",
 		"jp_explain": "アークス用戦闘服。フォースクラスの\n初期支給品で、フォトン励起を誘う\n特殊な素材が用いられている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Made to be\nconducive to Photon excitation, and\nsupplied to new Force-class ARKS."
 	},
 	{
 		"assign": "21037",
 		"jp_text": "センシアスコート葉",
 		"tr_text": "Sensuous Coat Leaf",
 		"jp_explain": "アークス用戦闘服。フォースクラスの\n初期支給品で、フォトン励起を誘う\n特殊な素材が用いられている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Made to be\nconducive to Photon excitation, and\nsupplied to new Force-class ARKS."
 	},
 	{
 		"assign": "21038",
 		"jp_text": "センシアスコート海",
 		"tr_text": "Sensuous Coat Sea",
 		"jp_explain": "アークス用戦闘服。フォースクラスの\n初期支給品で、フォトン励起を誘う\n特殊な素材が用いられている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Made to be\nconducive to Photon excitation, and\nsupplied to new Force-class ARKS."
 	},
 	{
 		"assign": "21039",
 		"jp_text": "センシアスコート陽",
 		"tr_text": "Sensuous Coat Sun",
 		"jp_explain": "アークス用戦闘服。フォースクラスの\n初期支給品で、フォトン励起を誘う\n特殊な素材が用いられている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Made to be\nconducive to Photon excitation, and\nsupplied to new Force-class ARKS."
 	},
 	{
 		"assign": "21040",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -3441,35 +3441,35 @@
 		"jp_text": "グランコレット",
 		"tr_text": "Gran Colette",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210573",
 		"jp_text": "グランコレット雅",
 		"tr_text": "Gran Colette Elegance",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210574",
 		"jp_text": "グランコレット銀",
 		"tr_text": "Gran Colette Silver",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210575",
 		"jp_text": "グランコレット紅",
 		"tr_text": "Gran Colette Crimson",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210576",
 		"jp_text": "グランコレット海",
 		"tr_text": "Gran Colette Sea",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210577",
@@ -4827,7 +4827,7 @@
 		"jp_text": "グランコレットＣ",
 		"tr_text": "Gran Colette C",
 		"jp_explain": "大きな襟と独特の模様が特徴的な\nアークスの戦闘服。タイトな作りだが\n動きやすく、丈夫な素材でできている。",
-		"tr_explain": ""
+		"tr_explain": "ARKS battle wear notable for its\nlarge collar and distinctive pattern.\nTight-fitting, yet unrestrictive."
 	},
 	{
 		"assign": "210852",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -4,7 +4,7 @@
 		"jp_text": "フロンティアウィング",
 		"tr_text": "Frontier Wing",
 		"jp_explain": "カジュアルウィングスーツ。\n未来に向かって羽ばたく想いが\n込められている。",
-		"tr_explain": ""
+		"tr_explain": "A casual wing suit.\nFilled with feelings of flying\ntowards the future."
 	},
 	{
 		"assign": "2101",
@@ -2538,7 +2538,7 @@
 		"jp_text": "フロンティアウィング紅",
 		"tr_text": "Frontier Wing Crimson",
 		"jp_explain": "カジュアルウィングスーツ。\n未来に向かって羽ばたく想いが\n込められている。",
-		"tr_explain": ""
+		"tr_explain": "A casual wing suit.\nFilled with feelings of flying\ntowards the future."
 	},
 	{
 		"assign": "210432",
@@ -4477,7 +4477,7 @@
 		"jp_text": "フロンティアウィング雪",
 		"tr_text": "Frontier Wing Snow",
 		"jp_explain": "カジュアルウィングスーツ。\n未来に向かって羽ばたく想いが\n込められている。",
-		"tr_explain": ""
+		"tr_explain": "A casual wing suit.\nFilled with feelings of flying\ntowards the future."
 	},
 	{
 		"assign": "210802",
@@ -4505,7 +4505,7 @@
 		"jp_text": "フロンティアウィングＣ",
 		"tr_text": "Frontier Wing C",
 		"jp_explain": "カジュアルウィングスーツ。\n未来に向かって羽ばたく想いが\n込められている。",
-		"tr_explain": ""
+		"tr_explain": "A casual wing suit.\nFilled with feelings of flying\ntowards the future."
 	},
 	{
 		"assign": "210806",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -46,7 +46,7 @@
 		"jp_text": "クローズクォーター",
 		"tr_text": "Close Quarter",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "2107",
@@ -172,28 +172,28 @@
 		"jp_text": "クローズクォーター影",
 		"tr_text": "Close Quarter Shadow",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "21029",
 		"jp_text": "クローズクォーター雪",
 		"tr_text": "Close Quarter Snow",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "21030",
 		"jp_text": "クローズクォーター紅",
 		"tr_text": "Close Quarter Crimson",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "21031",
 		"jp_text": "クローズクォーター鋼",
 		"tr_text": "Close Quarter Steel",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "21032",
@@ -3266,7 +3266,7 @@
 		"jp_text": "クローズクォーター影Ｇ",
 		"tr_text": "Close Quarter Shadow G",
 		"jp_explain": "アークス用戦闘服。ハンタークラスの\n初期支給品で、動きやすさを重視した\n軽装の服となっている。",
-		"tr_explain": ""
+		"tr_explain": "An ARKS combat suit. Light clothing\nthat emphasises mobility, supplied to\nnew Hunter-class ARKS."
 	},
 	{
 		"assign": "210547",

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -2438,16 +2438,16 @@
 	{
 		"assign": "3150395",
 		"jp_text": "クラリスクレイスヘアー",
-		"tr_text": "Klariskrays Hair",
+		"tr_text": "Claris Claes Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nクラリスクレイスヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Klariskrays Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Claris Claes Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150396",
 		"jp_text": "クラリスクレイスヘアー２",
-		"tr_text": "Klariskrays Hair 2",
+		"tr_text": "Claris Claes Hair 2",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nクラリスクレイスヘアー２が選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Klariskrays Hair 2\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Claris Claes Hair 2\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150397",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -5980,42 +5980,42 @@
 	{
 		"assign": "33001051",
 		"jp_text": "咎人囚人男性服セット１",
-		"tr_text": "Prisoner-Issue Male Clothing Set 1",
+		"tr_text": "Prisoner-Issue M Clothing Set 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001052",
 		"jp_text": "咎人囚人男性服セット２",
-		"tr_text": "Prisoner-Issue Male Clothing Set 2",
+		"tr_text": "Prisoner-Issue M Clothing Set 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001053",
 		"jp_text": "咎人囚人男性服セット３",
-		"tr_text": "Prisoner-Issue Male Clothing Set 3",
+		"tr_text": "Prisoner-Issue M Clothing Set 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001054",
 		"jp_text": "咎人囚人男性服セット４",
-		"tr_text": "Prisoner-Issue Male Clothing Set 4",
+		"tr_text": "Prisoner-Issue M Clothing Set 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001055",
 		"jp_text": "咎人囚人男性服セット５",
-		"tr_text": "Prisoner-Issue Male Clothing Set 5",
+		"tr_text": "Prisoner-Issue M Clothing Set 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001056",
 		"jp_text": "咎人囚人男性服セット６",
-		"tr_text": "Prisoner-Issue Male Clothing Set 6",
+		"tr_text": "Prisoner-Issue M Clothing Set 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
@@ -6071,7 +6071,7 @@
 	{
 		"assign": "33001064",
 		"jp_text": "咎人囚人男性服Ｃセット",
-		"tr_text": "Prisoner-Issue Male Clothing C Set",
+		"tr_text": "Prisoner-Issue M Clothing C Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人男性服Ｃ」\n「咎人ショートヘア」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Male Clothing C]\n[Criminal Short Hair]\n[Standard-Issue Headset]"
 	},
@@ -6120,42 +6120,42 @@
 	{
 		"assign": "33001071",
 		"jp_text": "咎人囚人女性服セット１",
-		"tr_text": "Prisoner-Issue Female Clothing Set 1",
+		"tr_text": "Prisoner-Issue F Clothing Set 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001072",
 		"jp_text": "咎人囚人女性服セット２",
-		"tr_text": "Prisoner-Issue Female Clothing Set 2",
+		"tr_text": "Prisoner-Issue F Clothing Set 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001073",
 		"jp_text": "咎人囚人女性服セット３",
-		"tr_text": "Prisoner-Issue Female Clothing Set 3",
+		"tr_text": "Prisoner-Issue F Clothing Set 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001074",
 		"jp_text": "咎人囚人女性服セット４",
-		"tr_text": "Prisoner-Issue Female Clothing Set 4",
+		"tr_text": "Prisoner-Issue F Clothing Set 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001075",
 		"jp_text": "咎人囚人女性服セット５",
-		"tr_text": "Prisoner-Issue Female Clothing Set 5",
+		"tr_text": "Prisoner-Issue F Clothing Set 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
 	{
 		"assign": "33001076",
 		"jp_text": "咎人囚人女性服セット６",
-		"tr_text": "Prisoner-Issue Female Clothing Set 6",
+		"tr_text": "Prisoner-Issue F Clothing Set 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
@@ -6211,7 +6211,7 @@
 	{
 		"assign": "33001084",
 		"jp_text": "咎人囚人女性服Ｃセット",
-		"tr_text": "Prisoner-Issue Female Clothing C Set",
+		"tr_text": "Prisoner-Issue F Clothing C Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「咎人囚人女性服Ｃ」\n「咎人ポニーテール」\n「配給通信機器」",
 		"tr_explain": "Use to receive the following items:\n[Prisoner-Issue Female Clothing C]\n[Criminal Ponytail]\n[Standard-Issue Headset]"
 	},
@@ -18664,56 +18664,56 @@
 	{
 		"assign": "33002873",
 		"jp_text": "☆帝国華撃団　隊員服箱",
-		"tr_text": "☆Imperial Assault Uniform Box",
+		"tr_text": "☆I.A.F. Uniform Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002874",
 		"jp_text": "☆帝国華撃団　隊員服　雅箱",
-		"tr_text": "☆Imperial Assault Uniform Purple Box",
+		"tr_text": "☆I.A.F. Uniform Purple Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　雅」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Purple]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002875",
 		"jp_text": "☆帝国華撃団　隊員服　月箱",
-		"tr_text": "☆Imperial Assault Uniform Moon Box",
+		"tr_text": "☆I.A.F. Uniform Moon Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　月」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Moon]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002876",
 		"jp_text": "☆帝国華撃団　隊員服　紅箱",
-		"tr_text": "☆Imperial Assault Uniform Red Box",
+		"tr_text": "☆I.A.F. Uniform Red Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　紅」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Red]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002877",
 		"jp_text": "☆帝国華撃団　隊員服　海箱",
-		"tr_text": "☆Imperial Assault Uniform Sea Box",
+		"tr_text": "☆I.A.F. Uniform Sea Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　海」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Sea]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002878",
 		"jp_text": "☆帝国華撃団　隊員服　影箱",
-		"tr_text": "☆Imperial Assault Uniform Black Box",
+		"tr_text": "☆I.A.F. Uniform Black Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　影」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Shadow]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002879",
 		"jp_text": "☆帝国華撃団　隊員服　春箱",
-		"tr_text": "☆Imperial Assault Uniform Spring Box",
+		"tr_text": "☆I.A.F. Uniform Spring Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　春」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Spring]\n[Sakura's Ribbon]"
 	},
 	{
 		"assign": "33002880",
 		"jp_text": "☆帝国華撃団　隊員服　葉箱",
-		"tr_text": "☆Imperial Assault Uniform Sprout Box",
+		"tr_text": "☆I.A.F. Uniform Sprout Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「帝国華撃団　隊員服　葉」\n「さくらリボン」",
 		"tr_explain": "Use to receive the following items:\n[Imperial Assault Uniform Sprout]\n[Sakura's Ribbon]"
 	},

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -32867,16 +32867,16 @@
 	{
 		"assign": "33004908",
 		"jp_text": "☆リングチャンプＭ箱Ｂ１",
-		"tr_text": "",
+		"tr_text": "☆Ring Champ M Box B 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「リングチャンプＭ[Ou]」\n「リングチャンプＭ玄[Ba]」\n「レッドレザーカラー」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ring Champ M [Ou]]\nRing Champ M Mysterious [Ba]\n[Red Leather Collar]"
 	},
 	{
 		"assign": "33004909",
 		"jp_text": "☆リングチャンプＭ箱Ｂ２",
-		"tr_text": "",
+		"tr_text": "☆Ring Champ M Box B 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「リングチャンプＭ[Ou]」\n「リングチャンプＭ冬[Ba]」\n「レッドレザーカラー」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ring Champ M [Ou]]\nRing Champ M Winter [Ba]\n[Red Leather Collar]"
 	},
 	{
 		"assign": "33004910",
@@ -33077,51 +33077,51 @@
 	{
 		"assign": "33004938",
 		"jp_text": "ツェルハトゥール冬セット",
-		"tr_text": "",
+		"tr_text": "Zell Hatoule Winter Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール冬[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""
+		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Winter [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004939",
 		"jp_text": "ツェルハトゥール影セット",
-		"tr_text": "",
+		"tr_text": "Zell Hatoule Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール影[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""
+		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Shadow [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004940",
 		"jp_text": "ツェルハトゥール茜セット",
-		"tr_text": "",
+		"tr_text": "Zell Hatoule Madder Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール茜[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""
+		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Madder [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004941",
 		"jp_text": "☆セクシースタイル冬箱",
-		"tr_text": "",
+		"tr_text": "☆Sexy Style Winter Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「セクシースタイル冬」\n「チョコケーキハットＢ」\n「ラブリーアイパッチ　桃」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Sexy Style Winter]\n[Chocolate Cake Hat B]\n[Peach Lovely Eyepatch]"
 	},
 	{
 		"assign": "33004942",
 		"jp_text": "☆セクシースタイル春箱",
-		"tr_text": "",
+		"tr_text": "☆Sexy Style Spring Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「セクシースタイル春」\n「チョコケーキハットＢ」\n「ラブリーアイパッチ　桃」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Sexy Style Spring]\n[Chocolate Cake Hat B]\n[Peach Lovely Eyepatch]"
 	},
 	{
 		"assign": "33004943",
 		"jp_text": "☆セクシースタイル空箱",
-		"tr_text": "",
+		"tr_text": "☆Sexy Style Sky Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「セクシースタイル空」\n「チョコケーキハットＢ」\n「ラブリーアイパッチ　桃」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Sexy Style Sky]\n[Chocolate Cake Hat B]\n[Peach Lovely Eyepatch]"
 	},
 	{
 		"assign": "33004944",
 		"jp_text": "☆ノルノロゼット紅セット",
-		"tr_text": "",
+		"tr_text": "☆Norno Rosette Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノルノロゼット紅」\n「ロゼットキャップ紅」\n「ホワイトファーイヤリング」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Norno Rosette Crimson]\n[Rosette Cap Crimson]\n[White Fur Earrings]"
 	},
 	{
 		"assign": "33004945",
@@ -33133,9 +33133,9 @@
 	{
 		"assign": "33004946",
 		"jp_text": "オークゥスタイルセット",
-		"tr_text": "",
+		"tr_text": "Och Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「オークゥヘアー２」\n「フェリチェカチューシャ」\n「ホワイトストールマフラー」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Och Hair 2]\n[Felice Headband]\n[White Stole Scarf]"
 	},
 	{
 		"assign": "33004947",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -5469,42 +5469,42 @@
 	{
 		"assign": "3300978",
 		"jp_text": "事代守人衣セット",
-		"tr_text": "Kotoshiro's Clothes Set",
+		"tr_text": "Kotoshiro Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300979",
 		"jp_text": "事代守人衣　影セット",
-		"tr_text": "Kotoshiro's Clothes Shadow Set",
+		"tr_text": "Kotoshiro Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　影」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Shadow]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300980",
 		"jp_text": "事代守人衣　紅セット",
-		"tr_text": "Kotoshiro's Clothes Crimson Set",
+		"tr_text": "Kotoshiro Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　紅」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Crimson]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300981",
 		"jp_text": "事代守人衣　海セット",
-		"tr_text": "Kotoshiro's Clothes Sea Set",
+		"tr_text": "Kotoshiro Sea Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　海」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Sea]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300982",
 		"jp_text": "事代守人衣　雅セット",
-		"tr_text": "Kotoshiro's Clothes Elegance Set",
+		"tr_text": "Kotoshiro Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　雅」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Elegance]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300983",
 		"jp_text": "事代守人衣　月セット",
-		"tr_text": "Kotoshiro's Clothes Moon Set",
+		"tr_text": "Kotoshiro Moon Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　月」\n「コトシロの顎当て」\n「コトシロの眼帯」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Moon]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
@@ -23060,21 +23060,21 @@
 	{
 		"assign": "33003501",
 		"jp_text": "☆事代守人衣　雪セット",
-		"tr_text": "☆Kotoshiro's Clothes Snow Set",
+		"tr_text": "☆Kotoshiro Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　雪」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Snow]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
 	},
 	{
 		"assign": "33003502",
 		"jp_text": "☆事代守人衣　玄セット",
-		"tr_text": "☆Kotoshiro's Clothes Mysterious Set",
+		"tr_text": "☆Kotoshiro Mysterious Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　玄」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Mysterious]\n[Kotoshiro's Chin Guard\nB] [Kotoshiro's Eye Pad B]"
 	},
 	{
 		"assign": "33003503",
 		"jp_text": "☆事代守人衣　夜セット",
-		"tr_text": "☆Kotoshiro's Clothes Night Set",
+		"tr_text": "☆Kotoshiro Night Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　夜」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
 		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Night]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
 	},

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -33079,21 +33079,21 @@
 		"jp_text": "ツェルハトゥール冬セット",
 		"tr_text": "Zell Hatoule Winter Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール冬[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Winter [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
+		"tr_explain": "Use to receive the following items:\n[Zell Hatoule Winter [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004939",
 		"jp_text": "ツェルハトゥール影セット",
 		"tr_text": "Zell Hatoule Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール影[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Shadow [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
+		"tr_explain": "Use to receive the following items:\n[Zell Hatoule Shadow [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004940",
 		"jp_text": "ツェルハトゥール茜セット",
 		"tr_text": "Zell Hatoule Madder Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ツェルハトゥール茜[Ba]」\n「ハトゥールキャップＢ」\n「ハトゥールサイドユニットＢ」",
-		"tr_explain": ""Use to receive the following items:\n[Zell Hatoule Madder [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
+		"tr_explain": "Use to receive the following items:\n[Zell Hatoule Madder [Ba]]\n[Hatoule Cap B]\n[Hatoule Side Unit B]"
 	},
 	{
 		"assign": "33004941",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -5469,44 +5469,44 @@
 	{
 		"assign": "3300978",
 		"jp_text": "事代守人衣セット",
-		"tr_text": "Kotoshiro Protector's Clothes Set",
+		"tr_text": "Kotoshiro's Clothes Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300979",
 		"jp_text": "事代守人衣　影セット",
-		"tr_text": "Kotoshiro Protector's Clothes Black Set",
+		"tr_text": "Kotoshiro's Clothes Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　影」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes\nShadow] [Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Shadow]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300980",
 		"jp_text": "事代守人衣　紅セット",
-		"tr_text": "Kotoshiro Protector's Clothes Red Set",
+		"tr_text": "Kotoshiro's Clothes Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　紅」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes\nCrimson] [Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Crimson]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300981",
 		"jp_text": "事代守人衣　海セット",
-		"tr_text": "Kotoshiro Protector's Clothes Sea Set",
+		"tr_text": "Kotoshiro's Clothes Sea Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　海」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes Sea]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Sea]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300982",
 		"jp_text": "事代守人衣　雅セット",
-		"tr_text": "Kotoshiro Protector's Clothes Purple Set",
+		"tr_text": "Kotoshiro's Clothes Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　雅」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes\nElegance] [Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Elegance]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300983",
 		"jp_text": "事代守人衣　月セット",
-		"tr_text": "Kotoshiro Protector's Clothes Moon Set",
+		"tr_text": "Kotoshiro's Clothes Moon Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　月」\n「コトシロの顎当て」\n「コトシロの眼帯」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes Moon]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Moon]\n[Kotoshiro's Chin Guard]\n[Kotoshiro's Eye Pad]"
 	},
 	{
 		"assign": "3300984",
@@ -23060,23 +23060,23 @@
 	{
 		"assign": "33003501",
 		"jp_text": "☆事代守人衣　雪セット",
-		"tr_text": "☆Kotoshiro Protector's Clothes Snow Set",
+		"tr_text": "☆Kotoshiro's Clothes Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　雪」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes Snow]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Snow]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
 	},
 	{
 		"assign": "33003502",
 		"jp_text": "☆事代守人衣　玄セット",
-		"tr_text": "☆Kotoshiro Protector's Clothes Mysterious Set",
+		"tr_text": "☆Kotoshiro's Clothes Mysterious Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　玄」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes\nMysterious] [Kotoshiro's Chin Guard\nB] [Kotoshiro's Eye Pad B]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Mysterious]\n[Kotoshiro's Chin Guard\nB] [Kotoshiro's Eye Pad B]"
 	},
 	{
 		"assign": "33003503",
 		"jp_text": "☆事代守人衣　夜セット",
-		"tr_text": "☆Kotoshiro Protector's Clothes Night Set",
+		"tr_text": "☆Kotoshiro's Clothes Night Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「事代守人衣　夜」\n「コトシロの顎当てＢ」\n「コトシロの眼帯Ｂ」",
-		"tr_explain": "Use to receive the following items:\n[Kotoshiro Protector's Clothes Night]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
+		"tr_explain": "Use to receive the following items:\n[Kotoshiro's Clothes Night]\n[Kotoshiro's Chin Guard B]\n[Kotoshiro's Eye Pad B]"
 	},
 	{
 		"assign": "33003504",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -767,7 +767,7 @@
 		"jp_text": "ノクスシュタヤー",
 		"tr_text": "Nox Shooteyr",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長銃。装者も\n恐怖する力でもって、敵を撃ち抜く。",
-		"tr_explain": ""
+		"tr_explain": "A black rifle produced in an illicit\nritual. It shoots the enemy with\npower that terrifies even its wielder."
 	},
 	{
 		"assign": "180197",
@@ -1068,7 +1068,7 @@
 		"jp_text": "ノクスシュタヤー-NT",
 		"tr_text": "Nox Shooteyr-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長銃。装者も\n恐怖する力でもって、敵を撃ち抜く。",
-		"tr_explain": ""
+		"tr_explain": "A black rifle produced in an illicit\nritual. It shoots the enemy with\npower that terrifies even its wielder."
 	},
 	{
 		"assign": "180268",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -4,7 +4,7 @@
 		"jp_text": "ライフル",
 		"tr_text": "Rifle",
 		"jp_explain": "アークスで正式採用されている長銃。\n連射による行動阻害に重きを置いた\nレンジャーのための武器。",
-		"tr_explain": "ARKS standard issue rifle.\nA weapon for Rangers that\nputs emphasis on rapid fire."
+		"tr_explain": "A rifle adopted by ARKS. A weapon\nfor Rangers who focus on pinning the\nenemy down with rapid-fire shots."
 	},
 	{
 		"assign": "1801",
@@ -963,7 +963,7 @@
 		"jp_text": "ライフル-NT",
 		"tr_text": "Rifle-NT",
 		"jp_explain": "アークスで正式採用されている長銃。\n連射による行動阻害に重きを置いた\nレンジャーのための武器。",
-		"tr_explain": ""
+		"tr_explain": "A rifle adopted by ARKS. A weapon\nfor Rangers who focus on pinning the\nenemy down with rapid-fire shots."
 	},
 	{
 		"assign": "180253",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -585,7 +585,7 @@
 		"jp_text": "ライブトライナー",
 		"tr_text": "Live Triner",
 		"jp_explain": "最先端の生体工学を応用し開発された\n長銃。高純度培養液の作用で腕に馴染む\n砲身は手振れを補正し命中力を高める。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A rifle made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "180127",
@@ -690,7 +690,7 @@
 		"jp_text": "ネメシスシューター",
 		"tr_text": "Nemesis Shooter",
 		"jp_explain": "古の時代に封印された聖なる長銃。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "180166",
@@ -1187,7 +1187,7 @@
 		"jp_text": "ネメシスシューター-NT",
 		"tr_text": "Nemesis Shooter-NT",
 		"jp_explain": "古の時代に封印された聖なる長銃。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "180330",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -291,7 +291,7 @@
 		"jp_text": "アンチＡライフル／ナハト",
 		"tr_text": "Anti Android Rifle / Nacht",
 		"jp_explain": "闇夜の色を抱く長銃。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A rifle painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "18046",
@@ -480,7 +480,7 @@
 		"jp_text": "Ｆシューター／ナハト",
 		"tr_text": "Frozen Shooter / Nacht",
 		"jp_explain": "闇夜の色を抱く長銃。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A rifle painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "18099",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -1117,7 +1117,7 @@
 		"jp_text": "アストラトレンブ",
 		"tr_text": "Astra Tremb",
 		"jp_explain": "マザーの残滓たる、幻創の長銃。\n撃つ度に戦意を削られているかのようで\n埋めようのない虚しさが手の中に残る。",
-		"tr_explain": "A Phantom Rifle imbued with\nMother's power. Each use in combat,\nslowly makes its user detached from\nreality."
+		"tr_explain": "A Phantom rifle imbued with Mother's\npower. Erodes the user's soul, leaving\na void that can never be filled."
 	},
 	{
 		"assign": "180282",

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -963,7 +963,7 @@
 		"jp_text": "アストラスナール",
 		"tr_text": "Astra Snarl",
 		"jp_explain": "マザーの残滓たる、幻創の強弓。\n放たれた矢の音は遙か彼方まで\n響き、生ある者全てを竦ませるという。",
-		"tr_explain": "A Phantom bow imbued with Mother's\npower. Its snarl echoes far and wide,\ncausing all to cower in fear."
+		"tr_explain": "A phantom bullet bow imbued with\nMother's power. Its snarl echoes far\nand wide, terrorizing all that lives."
 	},
 	{
 		"assign": "1150254",

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -438,7 +438,7 @@
 		"jp_text": "ライブベルド",
 		"tr_text": "Live Beld",
 		"jp_explain": "最先端の生体工学を応用し開発された\n強弓。高純度培養液が矢の射出直前まで\n機能向上を促し破壊力を高める。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A bullet bow made with state-of-\nthe-art bioengineering. Enhanced with\na high-purity culture solution."
 	},
 	{
 		"assign": "115094",
@@ -592,7 +592,7 @@
 		"jp_text": "ネメシスフェザー",
 		"tr_text": "Nemesis Feather",
 		"jp_explain": "古の時代に封印された聖なる強弓。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1150144",
@@ -1033,7 +1033,7 @@
 		"jp_text": "ネメシスフェザー-NT",
 		"tr_text": "Nemesis Feather-NT",
 		"jp_explain": "古の時代に封印された聖なる強弓。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1150282",

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -963,7 +963,7 @@
 		"jp_text": "アストラスナール",
 		"tr_text": "Astra Snarl",
 		"jp_explain": "マザーの残滓たる、幻創の強弓。\n放たれた矢の音は遙か彼方まで\n響き、生ある者全てを竦ませるという。",
-		"tr_explain": "A phantom bullet bow imbued with\nMother's power. Its snarl echoes far\nand wide, terrorizing all that lives."
+		"tr_explain": "A Phantom bullet bow imbued with\nMother's power. Its snarl echoes far\nand wide, terrorizing all that lives."
 	},
 	{
 		"assign": "1150254",

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -492,7 +492,7 @@
 	{
 		"assign": "1150112",
 		"jp_text": "ビブラスボウ",
-		"tr_text": "Vibras Bow",
+		"tr_text": "Vibrace Bow",
 		"jp_explain": "ダーク・ビブラスの外骨格を加工して\n作られた強弓。素材の外骨格を細かく\n複雑に組み合わせたデザインが特徴的。",
 		"tr_explain": "A Bow made from the exoskeleton of\nDark Vibrace. The distinctive\nmaterial allows for a complex design."
 	},

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -963,7 +963,7 @@
 		"jp_text": "アストラスナール",
 		"tr_text": "Astra Snarl",
 		"jp_explain": "マザーの残滓たる、幻創の強弓。\n放たれた矢の音は遙か彼方まで\n響き、生ある者全てを竦ませるという。",
-		"tr_explain": "A Phantom Bow imbued with\nMother's power. Its snarling arrow\nreminds you of its benevolence of life."
+		"tr_explain": "A Phantom bow imbued with Mother's\npower. Its snarl echoes far and wide,\ncausing all to cower in fear."
 	},
 	{
 		"assign": "1150254",

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -662,7 +662,7 @@
 		"jp_text": "ノクスレクシオ",
 		"tr_text": "Nox Lexio",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き強弓。装者も恐怖を\n抱くほどの威力を宿すという。",
-		"tr_explain": ""
+		"tr_explain": "A black bow produced in an illicit\nritual. It is said that its sheer power\nterrifies even its wielder."
 	},
 	{
 		"assign": "1150172",
@@ -907,7 +907,7 @@
 		"jp_text": "ノクスレクシオ-NT",
 		"tr_text": "Nox Lexio-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き強弓。装者も恐怖を\n抱くほどの威力を宿すという。",
-		"tr_explain": ""
+		"tr_explain": "A black bow produced in an illicit\nritual. It is said that its sheer power\nterrifies even its wielder."
 	},
 	{
 		"assign": "1150233",

--- a/json/Item_Weapon_DoubleSaber.txt
+++ b/json/Item_Weapon_DoubleSaber.txt
@@ -1026,7 +1026,7 @@
 		"jp_text": "アストラディレン",
 		"tr_text": "Astra Diren",
 		"jp_explain": "マザーの残滓たる、幻創の両剣。\n秩序あるもの全てを、この刃で\n掻き乱したいという衝動に駆られる。",
-		"tr_explain": "A Phantom Double Saber imbued with\nMother's power. It's fueled by a\ncarnal desire to disturb order."
+		"tr_explain": "A Phantom double saber imbued with\nMother's power. It is fuelled by a\nderanged need to spread chaos."
 	},
 	{
 		"assign": "150274",

--- a/json/Item_Weapon_DoubleSaber.txt
+++ b/json/Item_Weapon_DoubleSaber.txt
@@ -508,7 +508,7 @@
 		"jp_text": "ライブゼクト",
 		"tr_text": "Live Zect",
 		"jp_explain": "最先端の生体工学を応用し開発された\n両剣。高純度培養液が装者との一体化を\n促し、微細な動きまで制御が可能。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A double saber made with state-of-\nthe-art bioengineering. Enhanced with\na high-purity culture solution."
 	},
 	{
 		"assign": "15096",
@@ -669,7 +669,7 @@
 		"jp_text": "ネメシスセイバー",
 		"tr_text": "Nemesis Saber",
 		"jp_explain": "古の時代に封印された聖なる両剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "150147",
@@ -1089,7 +1089,7 @@
 		"jp_text": "ネメシスセイバー-NT",
 		"tr_text": "Nemesis Saber-NT",
 		"jp_explain": "古の時代に封印された聖なる両剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "150337",

--- a/json/Item_Weapon_DoubleSaber.txt
+++ b/json/Item_Weapon_DoubleSaber.txt
@@ -704,7 +704,7 @@
 		"jp_text": "ノクスカディナ",
 		"tr_text": "Nox Cadina",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き両剣。\n装者も畏怖するほどの力を宿している。",
-		"tr_explain": ""
+		"tr_explain": "A black double saber produced in an\nillicit ritual. The sheer power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "150169",
@@ -963,7 +963,7 @@
 		"jp_text": "ノクスカディナ-NT",
 		"tr_text": "Nox Cadina-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き両剣。\n装者も畏怖するほどの力を宿している。",
-		"tr_explain": ""
+		"tr_explain": "A black double saber produced in an\nillicit ritual. The sheer power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "150252",

--- a/json/Item_Weapon_DualBlade.txt
+++ b/json/Item_Weapon_DualBlade.txt
@@ -522,7 +522,7 @@
 		"jp_text": "ノクスディナス",
 		"tr_text": "Nox Dinas",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き飛翔剣。\n装者も恐怖を抱くほどの切れ味を持つ。",
-		"tr_explain": ""
+		"tr_explain": "Black dual blades produced in an illicit\nritual. Their sheer cutting power\nterrifies even their wielder."
 	},
 	{
 		"assign": "1170154",
@@ -781,7 +781,7 @@
 		"jp_text": "ノクスディナス-NT",
 		"tr_text": "Nox Dinas-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き飛翔剣。\n装者も恐怖を抱くほどの切れ味を持つ。",
-		"tr_explain": ""
+		"tr_explain": "Black dual blades produced in an illicit\nritual. Their sheer cutting power\nterrifies even their wielder."
 	},
 	{
 		"assign": "1170246",

--- a/json/Item_Weapon_DualBlade.txt
+++ b/json/Item_Weapon_DualBlade.txt
@@ -809,7 +809,7 @@
 		"jp_text": "アストラエンド",
 		"tr_text": "Astra End",
 		"jp_explain": "マザーの残滓たる、幻創の飛翔剣。\nその刃が絶つは希望。流された\n血と涙を啜り、悲嘆を喰らう剣。",
-		"tr_explain": "Phantom Dual Blades imbued with\nMother's power. It's fueled by\nsorrow, devouring tears as it spills\nblood."
+		"tr_explain": "Phantom dual blades imbued with\nMother's power. The blades sever\nhope, spill blood and feast on grief."
 	},
 	{
 		"assign": "1170256",

--- a/json/Item_Weapon_DualBlade.txt
+++ b/json/Item_Weapon_DualBlade.txt
@@ -417,7 +417,7 @@
 		"jp_text": "ライブリブジール",
 		"tr_text": "Live Ribzeal",
 		"jp_explain": "最先端の生体工学を応用し開発された\n飛翔剣。高純度培養液によって\n刃先は常に最良の状態に保たれる。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "Dual blades made with state-of-the-\nart bioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "1170112",
@@ -438,14 +438,14 @@
 		"jp_text": "ネメシスデュアル",
 		"tr_text": "Nemesis Dual",
 		"jp_explain": "古の時代に封印された聖なる飛翔剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": ""
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1170115",
 		"jp_text": "スレイヴデュアル",
 		"tr_text": "Slave Dual",
 		"jp_explain": "古の時代に封印された邪なる飛翔剣。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": ""
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "1170119",
@@ -914,7 +914,7 @@
 		"jp_text": "ネメシスデュアル-NT",
 		"tr_text": "Nemesis Dual-NT",
 		"jp_explain": "古の時代に封印された聖なる飛翔剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1170313",

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -711,7 +711,7 @@
 		"jp_text": "ノクスシュディクス",
 		"tr_text": "Nox Schdyx",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き銃剣。\n装者も畏怖するほどの莫大な力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black gunslash produced in an illicit\nritual. The vast power that it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "170185",
@@ -942,7 +942,7 @@
 		"jp_text": "ノクスシュディクス-NT",
 		"tr_text": "Nox Schdyx-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き銃剣。\n装者も畏怖するほどの莫大な力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black gunslash produced in an illicit\nritual. The vast power that it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "170245",

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -375,7 +375,7 @@
 		"jp_text": "ロードアキシオン／ナハト",
 		"tr_text": "Lord Axeon / Nacht",
 		"jp_explain": "闇夜の色を抱く銃剣。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A gunslash painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "17057",
@@ -452,7 +452,7 @@
 		"jp_text": "Ａライザー／ナハト",
 		"tr_text": "Astral Riser / Nacht",
 		"jp_explain": "闇夜の色を抱く銃剣。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A gunslash painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "17080",
@@ -501,7 +501,7 @@
 		"jp_text": "セレスタレイザー／ナハト",
 		"tr_text": "Celesta Laser / Nacht",
 		"jp_explain": "闇夜の色を抱く銃剣。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A gunslash painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "17099",

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -543,7 +543,7 @@
 		"jp_text": "ライブスリドゥン",
 		"tr_text": "Live Slidawn",
 		"jp_explain": "最先端の生体工学を応用し開発された\n銃剣。高純度培養液の働きで安定した\n形状を保ち、素速く攻撃態勢を整える。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A gunslash made with state-of-the-\nart bioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "170110",
@@ -655,7 +655,7 @@
 		"jp_text": "ネメシススラッシュ",
 		"tr_text": "Nemesis Slash",
 		"jp_explain": "古の時代に封印された聖なる銃剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "170162",
@@ -1054,7 +1054,7 @@
 		"jp_text": "ネメシススラッシュ-NT",
 		"tr_text": "Nemesis Slash-NT",
 		"jp_explain": "古の時代に封印された聖なる銃剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "170296",

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -977,7 +977,7 @@
 		"jp_text": "アストラディフィ",
 		"tr_text": "Astra Diffie",
 		"jp_explain": "マザーの残滓たる、幻創の銃剣。\n銃撃と斬撃で破壊の嵐を振りまき\nいかなる敵をも破る、憤怒の表出。",
-		"tr_explain": "A Gunslash imbued with Mother's\npower. Channel your fury to crush\nfoes with a cataclysmic bladestorm."
+		"tr_explain": "A Phantom gunslash imbued with\nMother's power. Defeat all before\nyou in a fury of blades and bullets."
 	},
 	{
 		"assign": "170254",

--- a/json/Item_Weapon_JetBoots.txt
+++ b/json/Item_Weapon_JetBoots.txt
@@ -284,7 +284,7 @@
 		"jp_text": "ライブリアクト",
 		"tr_text": "Live React",
 		"jp_explain": "最先端の生体工学を応用し開発された\n魔装脚。高純度培養液の循環により\n摩耗が軽減され、耐久性が増した。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "Jet boots made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "116056",
@@ -333,7 +333,7 @@
 		"jp_text": "ネメシスシューズ",
 		"tr_text": "Nemesis Shoes",
 		"jp_explain": "古の時代に封印された聖なる魔装脚。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "116073",
@@ -921,7 +921,7 @@
 		"jp_text": "ネメシスシューズ-NT",
 		"tr_text": "Nemesis Shoes-NT",
 		"jp_explain": "古の時代に封印された聖なる魔装脚。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1160262",

--- a/json/Item_Weapon_JetBoots.txt
+++ b/json/Item_Weapon_JetBoots.txt
@@ -550,7 +550,7 @@
 		"jp_text": "ノクスプラシス",
 		"tr_text": "Nox Placis",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き魔装脚。装者も\n恐怖するほどの法撃性能を宿す。",
-		"tr_explain": ""
+		"tr_explain": "Black jet boots produced in an illicit\nritual. Their Technique performance\nterrifies even their wielder."
 	},
 	{
 		"assign": "1160146",
@@ -795,7 +795,7 @@
 		"jp_text": "ノクスプラシス-NT",
 		"tr_text": "Nox Plasis-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き魔装脚。装者も\n恐怖するほどの法撃性能を宿す。",
-		"tr_explain": ""
+		"tr_explain": "Black jet boots produced in an illicit\nritual. Their Technique performance\nterrifies even their wielder."
 	},
 	{
 		"assign": "1160215",

--- a/json/Item_Weapon_JetBoots.txt
+++ b/json/Item_Weapon_JetBoots.txt
@@ -793,7 +793,7 @@
 	{
 		"assign": "1160214",
 		"jp_text": "ノクスプラシス-NT",
-		"tr_text": "Nox Plasis-NT",
+		"tr_text": "Nox Placis-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き魔装脚。装者も\n恐怖するほどの法撃性能を宿す。",
 		"tr_explain": "Black jet boots produced in an illicit\nritual. Their Technique performance\nterrifies even their wielder."
 	},

--- a/json/Item_Weapon_JetBoots.txt
+++ b/json/Item_Weapon_JetBoots.txt
@@ -858,7 +858,7 @@
 		"jp_text": "アストラドライブ",
 		"tr_text": "Astra Drive",
 		"jp_explain": "マザーの残滓たる、幻創の魔装脚。\n身につけていると、衝動的にどこか\n遠く暗い所へ行ってしまいそうになる。",
-		"tr_explain": "Jet Boots imbued with Mother's\npower. It forces the user to revisit\nthe darkest corners of their minds."
+		"tr_explain": "Phantom boots imbued with Mother's\npower. They drive their wearer into\nthe darkest corners of their mind."
 	},
 	{
 		"assign": "1160236",

--- a/json/Item_Weapon_Katana.txt
+++ b/json/Item_Weapon_Katana.txt
@@ -382,7 +382,7 @@
 		"jp_text": "ライブジャネン",
 		"tr_text": "Live Janen",
 		"jp_explain": "最先端の生体工学を応用し開発された\n抜剣。高純度培養液が刀身の劣化を防ぎ\n鞘に収めると鋭さに一層磨きがかかる。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A katana made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "114072",
@@ -571,7 +571,7 @@
 		"jp_text": "ネメシスクーガ",
 		"tr_text": "Nemesis Kuuga",
 		"jp_explain": "古の時代に封印された聖なる抜剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1140131",
@@ -1005,7 +1005,7 @@
 		"jp_text": "ネメシスクーガ-NT",
 		"tr_text": "Nemesis Kuuga-NT",
 		"jp_explain": "古の時代に封印された聖なる抜剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1140321",

--- a/json/Item_Weapon_Katana.txt
+++ b/json/Item_Weapon_Katana.txt
@@ -655,7 +655,7 @@
 		"jp_text": "ノクスサジェフス",
 		"tr_text": "Nox Sagephus",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き抜剣。装者も\n恐怖する強大な力で敵を両断する。",
-		"tr_explain": ""
+		"tr_explain": "A katana produced in an illicit ritual.\nIts power to cut any enemy in half\nterrifies even its wielder."
 	},
 	{
 		"assign": "1140184",
@@ -907,7 +907,7 @@
 		"jp_text": "ノクスサジェフス-NT",
 		"tr_text": "Nox Sagephus-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き抜剣。装者も\n恐怖する強大な力で敵を両断する。",
-		"tr_explain": ""
+		"tr_explain": "A katana produced in an illicit ritual.\nIts power to cut any enemy in half\nterrifies even its wielder."
 	},
 	{
 		"assign": "1140250",

--- a/json/Item_Weapon_Katana.txt
+++ b/json/Item_Weapon_Katana.txt
@@ -963,7 +963,7 @@
 		"jp_text": "アストラリープ",
 		"tr_text": "Astra Reap",
 		"jp_explain": "マザーの残滓たる、幻創の抜剣。\n技量の足りぬ者が持てば心を侵し\n命という命を無差別に刈り取るという。",
-		"tr_explain": "A Phantom Katana imbued with\nMother's power. It possesses the\nweak, then reaps their soul without\nmercy."
+		"tr_explain": "A Phantom katana imbued with\nMother's power. When held by the\nweak, it reaps even its wielder's life."
 	},
 	{
 		"assign": "1140265",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -333,7 +333,7 @@
 		"jp_text": "ドリルナックル／ナハト",
 		"tr_text": "Drill Knuckle / Nacht",
 		"jp_explain": "闇夜の色を抱く鋼拳。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "Knuckles painted black as night. Their\norigins are unknown, but they inspire\ngreatness in their owner."
 	},
 	{
 		"assign": "16051",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -4,7 +4,7 @@
 		"jp_text": "ナックル",
 		"tr_text": "Knuckle",
 		"jp_explain": "アークスで正式採用されている鋼拳。\n攻撃力は標準的だが衝撃吸収に優れ\n初心者でも腕を痛めにくい。",
-		"tr_explain": ""
+		"tr_explain": "Knuckles adopted by ARKS. High\nshock absorption means beginners\ncan use them without risk of injury."
 	},
 	{
 		"assign": "1601",
@@ -25,7 +25,7 @@
 		"jp_text": "クランチャー",
 		"tr_text": "Cruncher",
 		"jp_explain": "アークスで正式採用されている鋼拳。\n初心者向けに衝撃吸収力をさらに\n向上させた普及モデル。",
-		"tr_explain": ""
+		"tr_explain": "Knuckles adopted by ARKS. A\npopular model that further improves\nshock absorption for beginners."
 	},
 	{
 		"assign": "1604",
@@ -46,7 +46,7 @@
 		"jp_text": "ブレスティン",
 		"tr_text": "Bracetin",
 		"jp_explain": "アークスで正式採用されている鋼拳。\n無駄な装飾を廃し基本性能の強化に\nこだわったシンプルモデル。",
-		"tr_explain": ""
+		"tr_explain": "Knuckles adopted by ARKS. A simple\nmodel that improves performance by\nremoving wasteful decoration."
 	},
 	{
 		"assign": "1607",
@@ -858,7 +858,7 @@
 		"jp_text": "ナックル-NT",
 		"tr_text": "Knuckle-NT",
 		"jp_explain": "アークスで正式採用されている鋼拳。\n攻撃力は標準的だが衝撃吸収に優れ\n初心者でも腕を痛めにくい。",
-		"tr_explain": ""
+		"tr_explain": "Knuckles adopted by ARKS. High\nshock absorption means beginners\ncan use them without risk of injury."
 	},
 	{
 		"assign": "160219",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -529,7 +529,7 @@
 		"jp_text": "ライブドゴルト",
 		"tr_text": "Live Dogault",
 		"jp_explain": "最先端の生体工学を応用し開発された\n鋼拳。高純度培養液から養分が補給され\n使用中も強度が進化し続ける。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "Knuckles made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "160101",
@@ -634,7 +634,7 @@
 		"jp_text": "ネメシスフィスト",
 		"tr_text": "Nemesis Fist",
 		"jp_explain": "古の時代に封印された聖なる鋼拳。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "160141",
@@ -1075,7 +1075,7 @@
 		"jp_text": "ネメシスフィスト-NT",
 		"tr_text": "Nemesis Fist-NT",
 		"jp_explain": "古の時代に封印された聖なる鋼拳。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "160285",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -704,7 +704,7 @@
 		"jp_text": "ノクスデスティム",
 		"tr_text": "Nox Destime",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き鋼拳。装者も恐怖する\nその力で敵を打ち砕くという。",
-		"tr_explain": ""
+		"tr_explain": "Black knuckles produced in an illicit\nritual. Their power to shatter the\nenemy terrifies even their wielder."
 	},
 	{
 		"assign": "160167",
@@ -963,7 +963,7 @@
 		"jp_text": "ノクスデスティム-NT",
 		"tr_text": "Nox Destime-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き鋼拳。装者も恐怖する\nその力で敵を打ち砕くという。",
-		"tr_explain": ""
+		"tr_explain": "Black knuckles produced in an illicit\nritual. Their power to shatter the\nenemy terrifies even their wielder."
 	},
 	{
 		"assign": "160234",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -1033,7 +1033,7 @@
 		"jp_text": "アストラブレイク",
 		"tr_text": "Astra Break",
 		"jp_explain": "マザーの残滓たる、幻創の鋼拳。\n浅薄な知恵によって築かれた文明の\n一切を打ち砕く破壊の象徴。",
-		"tr_explain": "Knuckles imbued with Mother's\npower. Awaken as an icon of ruin\nfated to annihilate the delusive\naxiom."
+		"tr_explain": "Phantom knuckles imbued with\nMother's power. A symbol of the\nbreakdown of all civilizations."
 	},
 	{
 		"assign": "160265",

--- a/json/Item_Weapon_Launcher.txt
+++ b/json/Item_Weapon_Launcher.txt
@@ -823,7 +823,7 @@
 		"jp_text": "ノクスクラード",
 		"tr_text": "Nox Crahd",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き大砲。装者も恐怖を\n抱くほどの強力な弾丸で敵を撃つ。",
-		"tr_explain": ""
+		"tr_explain": "A black launcher produced in an illicit\nritual. It fires bullets so powerful that\nit terrifies even its wielder."
 	},
 	{
 		"assign": "190211",
@@ -1054,7 +1054,7 @@
 		"jp_text": "ノクスクラード-NT",
 		"tr_text": "Nox Crahd-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き大砲。装者も恐怖を\n抱くほどの強力な弾丸で敵を撃つ。",
-		"tr_explain": ""
+		"tr_explain": "A black launcher produced in an illicit\nritual. It fires bullets so powerful that\nit terrifies even its wielder."
 	},
 	{
 		"assign": "190273",

--- a/json/Item_Weapon_Launcher.txt
+++ b/json/Item_Weapon_Launcher.txt
@@ -1110,7 +1110,7 @@
 		"jp_text": "アストラベロウ",
 		"tr_text": "Astra Bellow",
 		"jp_explain": "マザーの残滓たる、幻創の大砲。\n心の弱い者が使えば、轟音に宿った\n激しい怨みに、精神をへし折られる。",
-		"tr_explain": "A launcher imbued with Mother's\npower. In the hands of the weak, its\nbellow breaks their very soul."
+		"tr_explain": "A Phantom launcher imbued with\nMother's power. When held by the\nweak, its bellow shatters their soul."
 	},
 	{
 		"assign": "190307",

--- a/json/Item_Weapon_Launcher.txt
+++ b/json/Item_Weapon_Launcher.txt
@@ -646,7 +646,7 @@
 	{
 		"assign": "190139",
 		"jp_text": "ビブラスキャノン",
-		"tr_text": "Vibras Cannon",
+		"tr_text": "Vibrace Cannon",
 		"jp_explain": "ダーク・ビブラスの角を加工して\n作られた大砲。熱に弱かったが\n特殊処理により改善された。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Launcher.txt
+++ b/json/Item_Weapon_Launcher.txt
@@ -599,7 +599,7 @@
 		"jp_text": "ライブスパット",
 		"tr_text": "Live Spat",
 		"jp_explain": "最先端の生体工学を応用し開発された\n大砲。高純度培養液の作用で射出口の\n状態が一定に保たれ正確な攻撃を実現。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A launcher made with state-of-the-\nart bioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "190125",
@@ -711,7 +711,7 @@
 		"jp_text": "ウェトムジオン",
 		"tr_text": "Vetumsion",
 		"jp_explain": "遺跡で発見されたデータを基に再現した\n大砲。データの解析が進み、原型により\n近づいた。驚異的な火力を持つ。",
-		"tr_explain": "A launcher based on data found at\nthe Ruins. Data analyis has brought\nthis model much closer to the original."
+		"tr_explain": "A launcher based on data found at\nthe Ruins. Data analysis has brought\nthis model much closer to the original."
 	},
 	{
 		"assign": "190156",
@@ -739,7 +739,7 @@
 		"jp_text": "ネメシスキャノン",
 		"tr_text": "Nemesis Cannon",
 		"jp_explain": "古の時代に封印された聖なる大砲。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "190170",
@@ -1152,7 +1152,7 @@
 		"jp_text": "ネメシスキャノン-NT",
 		"tr_text": "Nemesis Cannon-NT",
 		"jp_explain": "古の時代に封印された聖なる大砲。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "190326",

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -1019,7 +1019,7 @@
 		"jp_text": "アストラゴージ",
 		"tr_text": "Astra Gorge",
 		"jp_explain": "マザーの残滓たる、幻創の長槍。\n対象を形作る秩序に傷を穿ち\nその存在を否定すると言われている。",
-		"tr_explain": "Partisan imbued with Mother's power.\nWith a mere scratch, it is able to\nextinguish the spark of existence."
+		"tr_explain": "A Phantom partizan imbued with\nMother's power. With a mere scratch,\nit negates everything you are."
 	},
 	{
 		"assign": "130276",

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -326,7 +326,7 @@
 		"jp_text": "ガエボルグ／ナハト",
 		"tr_text": "Gae Bolg / Nacht",
 		"jp_explain": "闇夜の色を抱く長槍。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": "A Partizan that embraces\nthe color of the night sky.\nIt bestows its user with great power."
+		"tr_explain": "A partizan painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "13048",

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -725,7 +725,7 @@
 		"jp_text": "ノクスロザン",
 		"tr_text": "Nox Rozan",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長槍。装者も\n恐怖するほどの力で、敵を葬り去る。",
-		"tr_explain": ""
+		"tr_explain": "A black partizan produced in an illicit\nritual. Its power to utterly vanquish\nenemies terrifies even its wielder."
 	},
 	{
 		"assign": "130185",
@@ -954,9 +954,9 @@
 	{
 		"assign": "130246",
 		"jp_text": "ノクスロザン-NT",
-		"tr_text": "Nox Loshan-NT",
+		"tr_text": "Nox Rozan-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長槍。装者も\n恐怖するほどの力で、敵を葬り去る。",
-		"tr_explain": ""
+		"tr_explain": "A black partizan produced in an illicit\nritual. Its power to utterly vanquish\nenemies terrifies even its wielder."
 	},
 	{
 		"assign": "130247",

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -543,7 +543,7 @@
 		"jp_text": "ライブステイド",
 		"tr_text": "Live Staid",
 		"jp_explain": "最先端の生体工学を応用し開発された\n長槍。グリップから手首を包む高純度\n培養液が安定した装着感を与える。",
-		"tr_explain": "A weapon that was designed from a\nstate-of-the-art bio-engineering\nprocess, enhancing its photon source."
+		"tr_explain": "A partizan made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "130106",
@@ -648,7 +648,7 @@
 		"jp_text": "ネメシスランス",
 		"tr_text": "Nemesis Lance",
 		"jp_explain": "古の時代に封印された聖なる長槍。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "130151",
@@ -1110,7 +1110,7 @@
 		"jp_text": "ネメシスランス-NT",
 		"tr_text": "Nemesis Lance-NT",
 		"jp_explain": "古の時代に封印された聖なる長槍。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "130321",

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -368,7 +368,7 @@
 		"jp_text": "ピコピコハンマー／ナハト",
 		"tr_text": "Pico Pico Hammer / Nacht",
 		"jp_explain": "闇夜の色を抱く長杖。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A rod painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "111054",

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -1194,7 +1194,7 @@
 		"jp_text": "アストラリディ",
 		"tr_text": "Astra Ridi",
 		"jp_explain": "マザーの残滓たる、幻創の長杖。\n手にしていると、杖が装者の無知を\n嘲笑っているような錯覚に囚われる。",
-		"tr_explain": "A Rod imbued with Mother's power.\nIt is said to trap ignorant hosts\nwithin a grim veil of illusions."
+		"tr_explain": "A Phantom rod imbued with Mother's\npower. Said to trap ignorant users\nwithin an illusion of ridicule."
 	},
 	{
 		"assign": "1110316",

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -879,7 +879,7 @@
 		"jp_text": "ノクスリフェル",
 		"tr_text": "Nox Lipher",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長杖。装者も恐怖を\n抱くほどの強大な法撃力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black rod produced in an illicit\nritual. The mighty power of its\nTechniques terrifies even its wielder."
 	},
 	{
 		"assign": "1110232",
@@ -1159,7 +1159,7 @@
 		"jp_text": "ノクスリフェル-NT",
 		"tr_text": "Nox Lipher-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き長杖。装者も恐怖を\n抱くほどの強大な法撃力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black rod produced in an illicit\nritual. The mighty power of its\nTechniques terrifies even its wielder."
 	},
 	{
 		"assign": "1110305",

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -716,7 +716,7 @@
 	{
 		"assign": "1110150",
 		"jp_text": "ビブラスロッド",
-		"tr_text": "Vibras Rod",
+		"tr_text": "Vibrace Rod",
 		"jp_explain": "ダーク・ビブラスの角を加工して\n作られた長杖。先端に装着された\n二股の角が特徴的。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -641,7 +641,7 @@
 		"jp_text": "ライブリアス",
 		"tr_text": "Live Rias",
 		"jp_explain": "最先端の生体工学を応用し開発された\n長杖。無機的形状ながら高純度培養液が\n極めて有機的に反応し法撃力を増強。",
-		"tr_explain": "Rod made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "A rod made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "1110126",
@@ -802,14 +802,14 @@
 		"jp_text": "ネメシスセイジ",
 		"tr_text": "Nemesis Sage",
 		"jp_explain": "古の時代に封印された聖なる長杖。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Rod from ancient past.\nIt releases it's hidden power of\npurification in tandem with the user's\nwill."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1110198",
 		"jp_text": "スレイヴセイジ",
 		"tr_text": "Slave Sage",
 		"jp_explain": "古の時代に封印された邪なる長杖。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Rod from ancient past. \nThe user's struggles will call out the \npower of destruction sealed within."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "1110199",
@@ -1341,7 +1341,7 @@
 		"jp_text": "ネメシスセイジ-NT",
 		"tr_text": "Nemesis Sage-NT",
 		"jp_explain": "古の時代に封印された聖なる長杖。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1110384",

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -312,7 +312,7 @@
 		"jp_text": "トラディシオン／ナハト",
 		"tr_text": "Tradicion / Nacht",
 		"jp_explain": "闇夜の色を抱く大剣。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": "A Sword that embraces the color of\nthe night. Its creation is unknown,\nbut it features high performance."
+		"tr_explain": "A rifle painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "11047",

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -200,7 +200,7 @@
 		"jp_text": "アカツキ",
 		"tr_text": "Akatsuki",
 		"jp_explain": "刀匠による自己封印がかけられた大剣。\n選ばれし者の前に姿を現し、さらなる\n選別を経て、真の姿を見せるという。",
-		"tr_explain": ""
+		"tr_explain": "A sword sealed away by its maker. It\nchooses its owner, and reveals its\ntrue form only to the worthy."
 	},
 	{
 		"assign": "11030",
@@ -347,7 +347,7 @@
 		"jp_text": "アーレスソード",
 		"tr_text": "Ares Sword",
 		"jp_explain": "一角獣の幻獣の力を宿した大剣。装者に\nフォトンブラストの効果で貫く力を\n与え、敵を即座に切り裂く。",
-		"tr_explain": ""
+		"tr_explain": "A sword harboring the power of a\nPhoton Blast. It slices through the\nenemy with penetrating power."
 	},
 	{
 		"assign": "11052",

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -809,7 +809,7 @@
 		"jp_text": "ノクスクヴェル",
 		"tr_text": "Nox Kvelle",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き大剣。装者も\n畏怖するほどの強大な力を宿す。",
-		"tr_explain": "A black sword produced in an illicit\nritual, bordering on illegal. The\nwielder will obtain terrifying power."
+		"tr_explain": "A black sword produced in an illicit\nritual. The mighty power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "110228",
@@ -1054,14 +1054,14 @@
 		"jp_text": "ノクスクヴェル-NT",
 		"tr_text": "Nox Kvelle-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き大剣。装者も\n畏怖するほどの強大な力を宿す。",
-		"tr_explain": "A black sword produced in an illicit\nritual, bordering on illegal. The\nwielder will obtain terrifying power."
+		"tr_explain": "A black sword produced in an illicit\nritual. The mighty power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "110300",
 		"jp_text": "アストラセパル",
 		"tr_text": "Astra Separ",
 		"jp_explain": "マザーの残滓たる、幻創の大剣。\n人と人の絆を残酷に別ち\n無へ帰すという意志を帯びる。",
-		"tr_explain": "A Phantom Sword imbued with\nMother's power. It separates the\nbonds people hold, their will to live."
+		"tr_explain": "A Phantom sword imbued with\nMother's power. It separates the\nbonds people hold, their will to live."
 	},
 	{
 		"assign": "110301",

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -571,7 +571,7 @@
 		"jp_text": "ライブグリオン",
 		"tr_text": "Live Glion",
 		"jp_explain": "最先端の生体工学を応用し開発された\n大剣。高純度培養液の働きで自己再生が\n可能な棘刃は切れ味が鈍ることがない。",
-		"tr_explain": "Sword made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "A sword made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "110120",
@@ -746,14 +746,14 @@
 		"jp_text": "ネメシスキャリバー",
 		"tr_text": "Nemesis Calibur",
 		"jp_explain": "古の時代に封印された聖なる大剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Sword from ancient\npast. It releases it's hidden power of\npurification in tandem with the user's\nwill."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "110192",
 		"jp_text": "スレイヴキャリバー",
 		"tr_text": "Slave Calibur",
 		"jp_explain": "古の時代に封印された邪なる大剣。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Sword from ancient\npast. The user's struggles will call\nout the power of destruction sealed\nwithin."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "110193",
@@ -1236,7 +1236,7 @@
 		"jp_text": "ネメシスキャリバー-NT",
 		"tr_text": "Nemesis Calibur-NT",
 		"jp_explain": "古の時代に封印された聖なる大剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "110384",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -634,7 +634,7 @@
 		"jp_text": "ライブビロリア",
 		"tr_text": "Live Biloria",
 		"jp_explain": "最先端の生体工学を応用し開発された\n導具。高純度培養液を含む生体部品が\n敵の組織を蝕むダメージを与える。",
-		"tr_explain": "Talis made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "A talis made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "1120134",
@@ -760,14 +760,14 @@
 		"jp_text": "ネメシスシンボル",
 		"tr_text": "Nemesis Symbol",
 		"jp_explain": "古の時代に封印された聖なる導具。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Talis from ancient\npast. It releases it's hidden power of\npurification in tandem with the user's\nwill."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1120176",
 		"jp_text": "スレイヴシンボル",
 		"tr_text": "Slave Symbol",
 		"jp_explain": "古の時代に封印された邪なる導具。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Talis from ancient past.\nThe user's struggles will call out the\npower of destruction sealed within."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "1120178",
@@ -1208,7 +1208,7 @@
 		"jp_text": "ネメシスシンボル-NT",
 		"tr_text": "Nemesis Symbol-NT",
 		"jp_explain": "古の時代に封印された聖なる導具。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1120328",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -823,7 +823,7 @@
 		"jp_text": "ノクスクリーグ",
 		"tr_text": "Nox Krieg",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き導具。\n装者も戦慄するほどの法撃力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black talis produced in an illicit\nritual. The power of its Techniques\nterrifies even its wielder."
 	},
 	{
 		"assign": "1120202",
@@ -1075,7 +1075,7 @@
 		"jp_text": "ノクスクリーグ-NT",
 		"tr_text": "Nox Krieg-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き導具。\n装者も戦慄するほどの法撃力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black talis produced in an illicit\nritual. The power of its Techniques\nterrifies even its wielder."
 	},
 	{
 		"assign": "1120265",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -1124,7 +1124,7 @@
 		"jp_text": "アストラヘイト",
 		"tr_text": "Astra Hate",
 		"jp_explain": "マザーの残滓たる、幻創の導具。\n常人には理解できぬ膨大な知識と\n底なしの憎悪が封じられている。",
-		"tr_explain": "A Talis imbued with Mother's power.\nThe vast ocean of knowledge within\ncontains nothing but eternal scorn."
+		"tr_explain": "A Phantom talis imbued with Mother's\npower. None can understand its vast\nknowledge, or its equally vast hatred."
 	},
 	{
 		"assign": "1120272",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -557,7 +557,7 @@
 		"jp_text": "ガルウィンド／ナハト",
 		"tr_text": "Gal Wind / Nacht",
 		"jp_explain": "闇夜の色を抱く導具。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A talis painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "1120115",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -312,7 +312,7 @@
 		"jp_text": "ブラッディアート／ナハト",
 		"tr_text": "Bloody Art / Nacht",
 		"jp_explain": "闇夜の色を抱く双小剣。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "Twin daggers painted black as night.\nTheir origins are unknown, but they\ninspire greatness in their owner."
 	},
 	{
 		"assign": "14047",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -571,7 +571,7 @@
 		"jp_text": "ライブスローク",
 		"tr_text": "Live Sloque",
 		"jp_explain": "最先端の生体工学を応用し開発された\n双小剣。高純度培養液が成長を促し常に\n安定した最良の状態で使用が可能。",
-		"tr_explain": "Twin Daggers made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "Twin daggers made with state-of-\nthe-art bioengineering. Enhanced\nwith a high-purity culture solution."
 	},
 	{
 		"assign": "140115",
@@ -690,14 +690,14 @@
 		"jp_text": "ネメシスダガー",
 		"tr_text": "Nemesis Dagger",
 		"jp_explain": "古の時代に封印された聖なる双小剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Twin Dagger from \nancient past. It releases it's hidden  \npower of purification in tandem with \nthe user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "140154",
 		"jp_text": "スレイヴダガー",
 		"tr_text": "Slave Dagger",
 		"jp_explain": "古の時代に封印された邪なる双小剣。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Twin Dagger from\nancient past. The user's struggles\nwill call out the power of destruction\nsealed within."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "140157",
@@ -1110,7 +1110,7 @@
 		"jp_text": "ネメシスダガー-NT",
 		"tr_text": "Nemesis Dagger-NT",
 		"jp_explain": "古の時代に封印された聖なる双小剣。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "140311",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -1047,7 +1047,7 @@
 		"jp_text": "アストラパニシュ",
 		"tr_text": "Astra Punish",
 		"jp_explain": "マザーの残滓たる、幻創の双小剣。\n断罪の意志が刃に込められている。\nそれは正義感でなく、焼け付く復讐心。",
-		"tr_explain": "A Phantom pair of Daggers imbued\nwith Mother's power. Its blades hold\nits sense of justice, corrupted by\nrevenge."
+		"tr_explain": "Phantom twin daggers imbued with\nMother's power. The blades condemn\nthe guilty and demand punishment."
 	},
 	{
 		"assign": "140288",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -739,7 +739,7 @@
 		"jp_text": "ノクスネシス",
 		"tr_text": "Nox Nesis",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き双小剣。装者も\n戦慄するほどの恐るべき力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "Black daggers produced in an illicit\nritual. The formidable power they\nhold terrifies even their wielder."
 	},
 	{
 		"assign": "140188",
@@ -991,7 +991,7 @@
 		"jp_text": "ノクスネシス-NT",
 		"tr_text": "Nox Nesis-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き双小剣。装者も\n戦慄するほどの恐るべき力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "Black daggers produced in an illicit\nritual. The formidable power they\nhold terrifies even their wielder."
 	},
 	{
 		"assign": "140249",

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -1236,7 +1236,7 @@
 		"jp_text": "アストラスクリー",
 		"tr_text": "Astra Screa",
 		"jp_explain": "マザーの残滓たる、幻創の双機銃。\n標的は銃声と共に、心を締め付ける\n悲鳴を聞く。それはマザーの嘆きか。",
-		"tr_explain": "A set of machineguns imbued with\nMother's power. With each shot, the\nscream of Mother's regret echoes."
+		"tr_explain": "Phantom machineguns imbued with\nMother's power. Each shot echoes\nwith the scream of Mother's regrets."
 	},
 	{
 		"assign": "1100327",

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -368,14 +368,14 @@
 		"jp_text": "Ｈ１０ミズーリＴ／ナハト",
 		"tr_text": "H10 Missouri T / Nacht",
 		"jp_explain": "闇夜の色を抱く双機銃。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": "Twin machineguns painted black as\nnight. Their origins are unknown, but\nthey inspire greatness in its owner."
+		"tr_explain": "Twin machineguns painted black as\nnight. Their origins are unknown, but\nthey inspire greatness in their owner."
 	},
 	{
 		"assign": "110055",
 		"jp_text": "Ｌ＆Ｋコンバット／ナハト",
 		"tr_text": "L&K Combat / Nacht",
 		"jp_explain": "闇夜の色を抱く双機銃。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "Twin machineguns painted black as\nnight. Their origins are unknown, but\nthey inspire greatness in their owner."
 	},
 	{
 		"assign": "110056",

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -865,7 +865,7 @@
 		"jp_text": "ノクスシャリオ",
 		"tr_text": "Nox Chario",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き双機銃。\n装者が戦慄するほどの精度を誇る。",
-		"tr_explain": ""
+		"tr_explain": "Black machineguns produced in an\nillicit ritual. The accuracy they boast\nterrifies even their wielder."
 	},
 	{
 		"assign": "1100216",
@@ -1187,7 +1187,7 @@
 		"jp_text": "ノクスシャリオ-NT",
 		"tr_text": "Nox Chario-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き双機銃。\n装者が戦慄するほどの精度を誇る。",
-		"tr_explain": ""
+		"tr_explain": "Black machineguns produced in an\nillicit ritual. The accuracy they boast\nterrifies even their wielder."
 	},
 	{
 		"assign": "1100313",

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -634,7 +634,7 @@
 		"jp_text": "ライブファンガー",
 		"tr_text": "Live Fanger",
 		"jp_explain": "最先端の生体工学を応用し開発された\n双機銃。高純度培養液が贅沢に充填され\n使えば使うほど進化を続ける。",
-		"tr_explain": "WPN made from a State of the Art\nBio-engineering application process,\nit's photons were enhanced by a\npure source in material."
+		"tr_explain": "Twin machineguns made with state-\nof-the-art bioengineering. Enhanced\nwith a high-purity culture solution."
 	},
 	{
 		"assign": "1100124",
@@ -802,14 +802,14 @@
 		"jp_text": "ネメシスバレット",
 		"tr_text": "Nemesis Bullet",
 		"jp_explain": "古の時代に封印された聖なる双機銃。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy pair of Machineguns\nfrom an ancient past. It releases its\npurifying power with the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1100185",
 		"jp_text": "スレイヴバレット",
 		"tr_text": "Slave Bullet",
 		"jp_explain": "古の時代に封印された邪なる双機銃。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Twin Machinegun from\nancient past. The user's struggles\nwill call out the power of destruction\nsealed within."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "1100186",
@@ -1313,7 +1313,7 @@
 		"jp_text": "ネメシスバレット-NT",
 		"tr_text": "Nemesis Bullet-NT",
 		"jp_explain": "古の時代に封印された聖なる双機銃。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1100369",

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -1117,7 +1117,7 @@
 		"jp_text": "アストラデプリ",
 		"tr_text": "Astra Depri",
 		"jp_explain": "マザーの残滓たる、幻創の短杖。\n装者は、杖からテクニックを使うための\n道具とされているかのように感じる。",
-		"tr_explain": "A Phantom Wand imbued with\nMother's power. Users of this wand,\nfeel they're being deprived of free\nwill."
+		"tr_explain": "A Phantom wand imbued with\nMother's power. It makes tools of its\nusers, depriving them of volition."
 	},
 	{
 		"assign": "1130316",

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -606,7 +606,7 @@
 		"jp_text": "ライブパイラス",
 		"tr_text": "Live Pyrus",
 		"jp_explain": "最先端の生体工学を応用し開発された\n短杖。充填された高純度培養液が常に\n法撃力を蓄積し爆発的攻撃を仕掛ける。",
-		"tr_explain": "Wand made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "A wand made with state-of-the-art\nbioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "1130126",
@@ -760,14 +760,14 @@
 		"jp_text": "ネメシスクロス",
 		"tr_text": "Nemesis Cross",
 		"jp_explain": "古の時代に封印された聖なる短杖。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Wand from ancient\npast. It releases it's hidden power of\npurification in tandem with the user's\nwill."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1130187",
 		"jp_text": "スレイヴクロス",
 		"tr_text": "Slave Cross",
 		"jp_explain": "古の時代に封印された邪なる短杖。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Wand from ancient\npast. The user's struggles will call\nout the power of destruction sealed\nwithin."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "1130188",
@@ -1194,7 +1194,7 @@
 		"jp_text": "ネメシスクロス-NT",
 		"tr_text": "Nemesis Cross-NT",
 		"jp_explain": "古の時代に封印された聖なる短杖。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "1130387",

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -802,7 +802,7 @@
 		"jp_text": "ノクスキュクロス",
 		"tr_text": "Nox Qucross",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き短杖。\n装者も恐怖するほどの強大な力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black wand produced in an illicit\nritual. The mighty power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "1130213",
@@ -1082,7 +1082,7 @@
 		"jp_text": "ノクスキュクロス-NT",
 		"tr_text": "Nox Qucross-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き短杖。\n装者も恐怖するほどの強大な力を宿す。",
-		"tr_explain": ""
+		"tr_explain": "A black wand produced in an illicit\nritual. The mighty power it holds\nterrifies even its wielder."
 	},
 	{
 		"assign": "1130300",

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -291,7 +291,7 @@
 		"jp_text": "ウィンドミル／ナハト",
 		"tr_text": "Windmill / Nacht",
 		"jp_explain": "闇夜の色を抱く短杖。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": ""
+		"tr_explain": "A wand painted black as night. Its\norigins are unknown, but it inspires\ngreatness in its owner."
 	},
 	{
 		"assign": "113044",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -18,7 +18,7 @@
 		"jp_text": "ヴィタランス",
 		"tr_text": "Vita Lance",
 		"jp_explain": "基礎モデルに改良を加えた自在槍。\nフォトン固着率の改良と性能向上を両立\n多くのアークスの要望に応えたモデル。",
-		"tr_explain": "Wired lances that further improve\nupon the base models. These models\nare the response to high demand\namong ARKS for better performance."
+		"tr_explain": "Wired lances that further improve\nupon the base model. This model is\na response to high demand."
 	},
 	{
 		"assign": "1203",
@@ -39,7 +39,7 @@
 		"jp_text": "ヴィタゲイン",
 		"tr_text": "Vita Gain",
 		"jp_explain": "基礎モデルに改良を加えた自在槍。\n投げやすさにこだわりながら、さらなる\n大型化により攻撃力向上を実現した。",
-		"tr_explain": "Wired lances that further improve\nupon the base models. While they\nwere made to be easy to throw,\ntheir power was improved as well."
+		"tr_explain": "Wired lances that further improve\nupon the base model. Enlarged for\npower, but just as easy to throw."
 	},
 	{
 		"assign": "1206",
@@ -60,7 +60,7 @@
 		"jp_text": "ヴィタオーバー",
 		"tr_text": "Vita Over",
 		"jp_explain": "基礎モデルに改良を加えた自在槍。\n刃を極限まで伸張し、標的を容易に\n深くとらえる操作性を実現した。",
-		"tr_explain": "Wired lances that further improve\nupon the base models. The blades\nwere extended to their limits,\nallowing easy capture of targets."
+		"tr_explain": "Wired lances that further improve\nupon the base model. The blades have\nbeen extended to their absolute limit."
 	},
 	{
 		"assign": "1209",
@@ -907,7 +907,7 @@
 		"jp_text": "ヴィタランス-NT",
 		"tr_text": "Vita Lance-NT",
 		"jp_explain": "基礎モデルに改良を加えた自在槍。\nフォトン固着率の改良と性能向上を両立\n多くのアークスの要望に応えたモデル。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances that further improve\nupon the base model. This model is\na response to high demand."
 	},
 	{
 		"assign": "120230",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -11,7 +11,7 @@
 		"jp_text": "アルバランス",
 		"tr_text": "Alva Lance",
 		"jp_explain": "アークスで使用される改良型自在槍。\n刃の部分のみの出力効率化を行い\nコストの変動なく威力を増強させた。",
-		"tr_explain": "Improved wired lances used by\nARKS. The new efficient blades are\nmore powerful for the same energy\ncost."
+		"tr_explain": "Improved wired lances used by ARKS.\nThe new efficient blades are more\npowerful for the same energy cost."
 	},
 	{
 		"assign": "1202",
@@ -32,7 +32,7 @@
 		"jp_text": "アルバゲイン",
 		"tr_text": "Alva Gain",
 		"jp_explain": "アークスで使用される改良型自在槍。\n刃の「返し」が大きくなったことで\nより大きなダメージを標的に与える。",
-		"tr_explain": "Improved wired lances used by\nARKS. The blades' enlarged barbs\ndeal more damage to targets."
+		"tr_explain": "Improved wired lances used by ARKS.\nThe blades' enlarged barbs deal more\ndamage to targets."
 	},
 	{
 		"assign": "1205",
@@ -53,7 +53,7 @@
 		"jp_text": "アルバオーバー",
 		"tr_text": "Alva Over",
 		"jp_explain": "アークスで使用される改良型自在槍。\n刃をさらに伸張し、槍としての\n攻撃性能を向上させたモデル。",
-		"tr_explain": "Improved wired lances used by\nARKS. The blades have been\nlengthened further, increasing attack\npower."
+		"tr_explain": "Improved wired lances used by ARKS.\nThe blades have been lengthened\nfurther, increasing attack power."
 	},
 	{
 		"assign": "1208",
@@ -900,7 +900,7 @@
 		"jp_text": "アルバランス-NT",
 		"tr_text": "Alva Lance-NT",
 		"jp_explain": "アークスで使用される改良型自在槍。\n刃の部分のみの出力効率化を行い\nコストの変動なく威力を増強させた。",
-		"tr_explain": "Improved wired lances used by\nARKS. The new efficient blades are\nmore powerful for the same energy\ncost."
+		"tr_explain": "Improved wired lances used by ARKS.\nThe new efficient blades are more\npowerful for the same energy cost."
 	},
 	{
 		"assign": "120229",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -109,7 +109,7 @@
 		"jp_text": "クシャネビュラ",
 		"tr_text": "Kuscha Nebula",
 		"jp_explain": "二叉に分けられた刃が特徴的な自在槍。\n既定のフォルムにとらわれない\n威力と効率重視の一つの答えである。",
-		"tr_explain": "Wired lances whose signature traits\nare their double forked blades.\nUnrestrained power with stress on\nefficiency."
+		"tr_explain": "Wired lances known for their double-\nforked blades. Unrestrained power\nwith a focus on efficiency."
 	},
 	{
 		"assign": "12016",
@@ -144,7 +144,7 @@
 		"jp_text": "ジャグリアス",
 		"tr_text": "Jagriath",
 		"jp_explain": "従来の概念を覆した大型の自在槍。\n近距離攻撃用に開発された装着武器を\n投擲武器として転用している。",
-		"tr_explain": "Wired lances made with methods\nthat have, until now, been rejected.\nOriginally developed as close-range\nweapons, they are now thrown."
+		"tr_explain": "Wired lances that defy convention.\nOriginally designed as a close-range\nweapon, but is now thrown."
 	},
 	{
 		"assign": "12021",
@@ -193,7 +193,7 @@
 		"jp_text": "デイライトスカー",
 		"tr_text": "Daylight Scar",
 		"jp_explain": "六爪の刃で全てを切り裂く自在槍。\n交差するフォトンの銀光こそ\n犠牲者が最後に見る光景となる。",
-		"tr_explain": "Wired lances that tear everything to\npieces with their six-pointed blades.\nThe intersecting photons' lights\nare the last thing the victims will see."
+		"tr_explain": "Wired lances that tear everything to\npieces with their six claws. Their light\nis the last thing their victims see."
 	},
 	{
 		"assign": "12028",
@@ -214,14 +214,14 @@
 		"jp_text": "ディアボリックガント",
 		"tr_text": "Diabolic Gauntlet",
 		"jp_explain": "地獄に住む悪魔の宿りし自在槍。\n切り裂かれた相手は、死の間際に\n快感すら覚えるという。",
-		"tr_explain": "Wired lances housing a demon from\nhell. It is said that those are killed by\nthis weapon feel nothing but intense\npleasure as they die."
+		"tr_explain": "Wired lances housing a demon from\nhell. It is said that its victims feel\nonly intense pleasure as they die."
 	},
 	{
 		"assign": "12031",
 		"jp_text": "アサシンクロー",
 		"tr_text": "Assassin Claw",
 		"jp_explain": "ある暗殺者が愛用していた自在槍。\n無拍子で繰り出される攻撃は\n瞬時に相手の命を絶つ。",
-		"tr_explain": "Wired lances favored by a certain\nassassin. Their arrhythmic strikes can\ncut short an opponent's life in an\ninstant."
+		"tr_explain": "Wired lances favored by an assassin.\nTheir wild, offbeat strikes can cut\nshort an opponent's life in an instant."
 	},
 	{
 		"assign": "12032",
@@ -298,7 +298,7 @@
 		"jp_text": "ラズライル",
 		"tr_text": "Razrail",
 		"jp_explain": "クォーツ・ドラゴンの鋭角を利用して\n作られた巨大な自在槍。綺麗に輝く\nその刃は触れたものを容易に斬り刻む。",
-		"tr_explain": "Gigantic wired lances made from a\nQuartz Dragon's pointed horns. The\nbeautifully glittering blades can easily\nmangle enemies with just a touch."
+		"tr_explain": "Gigantic wired lances made from a\nQuartz Dragon's horns. The glittering\nblades mangle foes with just a touch."
 	},
 	{
 		"assign": "12044",
@@ -956,14 +956,14 @@
 		"jp_text": "クシャネビュラ-NT",
 		"tr_text": "Kuscha Nebula-NT",
 		"jp_explain": "二叉に分けられた刃が特徴的な自在槍。\n既定のフォルムにとらわれない\n威力と効率重視の一つの答えである。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances known for their double-\nforked blades. Unrestrained power\nwith a focus on efficiency."
 	},
 	{
 		"assign": "120237",
 		"jp_text": "ジャグリアス-NT",
 		"tr_text": "Jagriath-NT",
 		"jp_explain": "従来の概念を覆した大型の自在槍。\n近距離攻撃用に開発された装着武器を\n投擲武器として転用している。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances that defy convention.\nOriginally designed as a close-range\nweapon, but is now thrown."
 	},
 	{
 		"assign": "120238",
@@ -977,7 +977,7 @@
 		"jp_text": "ディアボリックガント-NT",
 		"tr_text": "Diabolic Gauntlet-NT",
 		"jp_explain": "地獄に住む悪魔の宿りし自在槍。\n切り裂かれた相手は、死の間際に\n快感すら覚えるという。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances housing a demon from\nhell. It is said that its victims feel\nonly intense pleasure as they die."
 	},
 	{
 		"assign": "120240",
@@ -1005,7 +1005,7 @@
 		"jp_text": "ラズライルVer2",
 		"tr_text": "Razrail Ver2",
 		"jp_explain": "クォーツ・ドラゴンの鋭角を利用して\n作られた巨大な自在槍。綺麗に輝く\nその刃は触れたものを容易に斬り刻む。",
-		"tr_explain": ""
+		"tr_explain": "Gigantic wired lances made from a\nQuartz Dragon's horns. The glittering\nblades mangle foes with just a touch."
 	},
 	{
 		"assign": "120244",
@@ -1061,14 +1061,14 @@
 		"jp_text": "デイライトスカー-NT",
 		"tr_text": "Daylight Scar-NT",
 		"jp_explain": "六爪の刃で全てを切り裂く自在槍。\n交差するフォトンの銀光こそ\n犠牲者が最後に見る光景となる。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances that tear everything to\npieces with their six claws. Their light\nis the last thing their victims see."
 	},
 	{
 		"assign": "120272",
 		"jp_text": "アサシンクロー-NT",
 		"tr_text": "Assassin Claw-NT",
 		"jp_explain": "ある暗殺者が愛用していた自在槍。\n無拍子で繰り出される攻撃は\n瞬時に相手の命を絶つ。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances favored by an assassin.\nTheir wild, offbeat strikes can cut\nshort an opponent's life in an instant."
 	},
 	{
 		"assign": "120275",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -564,7 +564,7 @@
 		"jp_text": "ライブレードル",
 		"tr_text": "Live Radle",
 		"jp_explain": "最先端の生体工学を応用し開発された\n自在槍。高純度培養液が固形化と液化を\n瞬時にくり返し高速攻撃を可能にする。",
-		"tr_explain": "Wired Lance made from a State of\nthe Art Bio-engineering application\nprocess, it's photons were enhanced\nby a pure source in material."
+		"tr_explain": "Wired lances made with state-of-the-\nart bioengineering. Enhanced with a\nhigh-purity culture solution."
 	},
 	{
 		"assign": "120115",
@@ -662,14 +662,14 @@
 		"jp_text": "ネメシスチェイン",
 		"tr_text": "Nemesis Chain",
 		"jp_explain": "古の時代に封印された聖なる自在槍。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed Holy Wired Lance from \nancient past. It releases it's hidden  \npower of purification in tandem with \nthe user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "120144",
 		"jp_text": "スレイヴチェイン",
 		"tr_text": "Slave Chain",
 		"jp_explain": "古の時代に封印された邪なる自在槍。\n装者の闘争本能に呼応して\n封じられた破壊の力を発揮する。",
-		"tr_explain": "A sealed Evil Wire Lance from\nancient past. The user's struggles\nwill call out the power of destruction\nsealed within."
+		"tr_explain": "A sealed devil weapon from an early\nera. The user's hardships will call the\npower of destruction sealed within."
 	},
 	{
 		"assign": "120145",
@@ -1089,7 +1089,7 @@
 		"jp_text": "ネメシスチェイン-NT",
 		"tr_text": "Nemesis Chain-NT",
 		"jp_explain": "古の時代に封印された聖なる自在槍。\n装者の精神と同調することで\n秘められた浄化の力を発揮する。",
-		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npowers in tandem to the user's will."
+		"tr_explain": "A sealed holy weapon from an early\nera. It releases its hidden purifying\npower in tandem with the user's will."
 	},
 	{
 		"assign": "120285",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -4,7 +4,7 @@
 		"jp_text": "ワイヤードランス",
 		"tr_text": "Wired Lance",
 		"jp_explain": "アークスで正式採用されている自在槍。\nワイヤーでつながれた刃を自在に操作し\n多様な距離での交戦を可能としている。",
-		"tr_explain": "ARKS standard issue wired lances.\nWired blades that can move freely\nand allow combat from a variety of\ndistances."
+		"tr_explain": "Wired lances adopted by ARKS. The\nblades move freely, allowing the user\nto fight at a variety of distances."
 	},
 	{
 		"assign": "1201",
@@ -25,7 +25,7 @@
 		"jp_text": "ワイヤードゲイン",
 		"tr_text": "Wired Gain",
 		"jp_explain": "アークスで正式採用されている自在槍。\nワイヤーでつながれた刃の操作性と\n攻撃力を向上させた中型モデル。",
-		"tr_explain": "ARKS standard issue wired lances.\nMidsized models of wired blades\nwhose handling and offensive abilities\nhave been increased."
+		"tr_explain": "Wired lances adopted by ARKS. A\nmid-size model that improves the\nblades' attack power and mobility."
 	},
 	{
 		"assign": "1204",
@@ -46,7 +46,7 @@
 		"jp_text": "ワイヤードオーバー",
 		"tr_text": "Wired Over",
 		"jp_explain": "アークスで正式採用されている自在槍。\nワイヤーでつながれた刃を伸張し\n命中精度を向上させた中型モデル。",
-		"tr_explain": "ARKS standard issue wired lances.\nMidsized models with increased\naccuracy and lengthened blades."
+		"tr_explain": "Wired lances adopted by ARKS. A\nmid-size model that lengthens the\nblades for improved accuracy."
 	},
 	{
 		"assign": "1207",
@@ -893,7 +893,7 @@
 		"jp_text": "ワイヤードランス-NT",
 		"tr_text": "Wired Lance-NT",
 		"jp_explain": "アークスで正式採用されている自在槍。\nワイヤーでつながれた刃を自在に操作し\n多様な距離での交戦を可能としている。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances adopted by ARKS. The\nblades move freely, allowing the user\nto fight at a variety of distances."
 	},
 	{
 		"assign": "120228",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -67,42 +67,42 @@
 		"jp_text": "ワイヤードトライ",
 		"tr_text": "Wired Tri",
 		"jp_explain": "鋭角シルエットにこだわった自在槍。\n遠距離攻撃に適した抵抗の少ない形状で\n操作性の向上を目指した高級モデル。",
-		"tr_explain": "Wired lances with silhouettes shaped\nlike sharp horns. High-grade models\nthat aim to capitalize on an\naerodynamic form for long range."
+		"tr_explain": "Wired lances shaped like sharp horns.\nA high-grade, aerodynamic model\nsuitable for long-range attacks."
 	},
 	{
 		"assign": "12010",
 		"jp_text": "アルバトライ",
 		"tr_text": "Alva Tri",
 		"jp_explain": "高級モデル自在槍の改良型。\n抵抗の少ない形状そのままに大型化し\nさらなる攻撃力の向上を実現した。",
-		"tr_explain": "An improved version of high-grade\nWPN. Their aerodynamic shape\nremains untouched, but these models\nare even bigger and powerful."
+		"tr_explain": "Improved high-grade wired lances.\nMade larger to improve attack\npower, but no less aerodynamic."
 	},
 	{
 		"assign": "12011",
 		"jp_text": "ヴィタトライ",
 		"tr_text": "Vita Tri",
 		"jp_explain": "高級モデル自在槍の超大型バージョン。\n全体的に性能も向上しているが\n量産が困難なレアモデル。",
-		"tr_explain": "High-end models of wired lances that\nare extra-large. Their performance\nwas totally improved, but mass\nproducing these models is difficult."
+		"tr_explain": "Extra-large high-end wired lances.\nPerformance is improved, but this\nmodel is difficult to mass-produce."
 	},
 	{
 		"assign": "12012",
 		"jp_text": "ワイヤードアーチ",
 		"tr_text": "Wired Arch",
 		"jp_explain": "伸張性能を向上させた自在槍。\n独特のアーチ形状でなめらかな軌跡を\n描きながら標的を捉える。",
-		"tr_explain": "Wired lances with improved elasticity.\nTheir peculiar arch shapes carve\nsmooth trails through the air as they\ncapture their target."
+		"tr_explain": "Wired lances with improved elasticity.\nThe unique shape traces curves\nthrough the air as they grab foes."
 	},
 	{
 		"assign": "12013",
 		"jp_text": "アルバアーチ",
 		"tr_text": "Alva Arch",
 		"jp_explain": "伸張性能を向上させた自在槍の改良型。\n先端部の突起が重心を安定させ\n基礎モデルより確実に標的を捉える。",
-		"tr_explain": "An improved version of wired lances\nwith higher elasticity. The pointed\ntips stabilize the center of gravity,\nallowing them to be more reliable."
+		"tr_explain": "Improved high-elasticity wired lances.\nTheir pointed tips stabilize them,\nmaking grabbing foes more reliable."
 	},
 	{
 		"assign": "12014",
 		"jp_text": "ヴィタアーチ",
 		"tr_text": "Vita Arch",
 		"jp_explain": "アーチ形状の自在槍の大型モデル。\n弧に並べられた突起により、従来の\n安定した伸張性能を確保した。",
-		"tr_explain": "Large models of arch-shaped wired\nlances. The existing stability of their\nextension performance is ensured by\nthe parallel arced protrusions."
+		"tr_explain": "A large model of arch-shaped wired\nlances. The multiple protrusions along\nthe arch ensure extension stability."
 	},
 	{
 		"assign": "12015",
@@ -914,42 +914,42 @@
 		"jp_text": "ワイヤードトライ-NT",
 		"tr_text": "Wired Tri-NT",
 		"jp_explain": "鋭角シルエットにこだわった自在槍。\n遠距離攻撃に適した抵抗の少ない形状で\n操作性の向上を目指した高級モデル。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances shaped like sharp horns.\nA high-grade, aerodynamic model\nsuitable for long-range attacks."
 	},
 	{
 		"assign": "120231",
 		"jp_text": "アルバトライ-NT",
 		"tr_text": "Alva Tri-NT",
 		"jp_explain": "高級モデル自在槍の改良型。\n抵抗の少ない形状そのままに大型化し\nさらなる攻撃力の向上を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Improved high-grade wired lances.\nMade larger to improve attack\npower, but no less aerodynamic."
 	},
 	{
 		"assign": "120232",
 		"jp_text": "ヴィタトライ-NT",
 		"tr_text": "Vita Tri-NT",
 		"jp_explain": "高級モデル自在槍の超大型バージョン。\n全体的に性能も向上しているが\n量産が困難なレアモデル。",
-		"tr_explain": ""
+		"tr_explain": "Extra-large high-end wired lances.\nPerformance is improved, but this\nmodel is difficult to mass-produce."
 	},
 	{
 		"assign": "120233",
 		"jp_text": "ワイヤードアーチ-NT",
 		"tr_text": "Wired Arch-NT",
 		"jp_explain": "伸張性能を向上させた自在槍。\n独特のアーチ形状でなめらかな軌跡を\n描きながら標的を捉える。",
-		"tr_explain": ""
+		"tr_explain": "Wired lances with improved elasticity.\nThe unique shape traces curves\nthrough the air as they grab foes."
 	},
 	{
 		"assign": "120234",
 		"jp_text": "アルバアーチ-NT",
 		"tr_text": "Alva Arch-NT",
 		"jp_explain": "伸張性能を向上させた自在槍の改良型。\n先端部の突起が重心を安定させ\n基礎モデルより確実に標的を捉える。",
-		"tr_explain": ""
+		"tr_explain": "Improved high-elasticity wired lances.\nTheir pointed tips stabilize them,\nmaking grabbing foes more reliable."
 	},
 	{
 		"assign": "120235",
 		"jp_text": "ヴィタアーチ-NT",
 		"tr_text": "Vita Arch-NT",
 		"jp_explain": "アーチ形状の自在槍の大型モデル。\n弧に並べられた突起により、従来の\n安定した伸張性能を確保した。",
-		"tr_explain": ""
+		"tr_explain": "A large model of arch-shaped wired\nlances. The multiple protrusions along\nthe arch ensure extension stability."
 	},
 	{
 		"assign": "120236",
@@ -984,7 +984,7 @@
 		"jp_text": "ヘレティックエンド-NT",
 		"tr_text": "Heretic End-NT",
 		"jp_explain": "悪魔のかぎ爪のようなおぞましい\nフォルムを持つ自在槍。これにより\nついた傷は生涯治らないとされる。",
-		"tr_explain": ""
+		"tr_explain": "Terrifying wired lances that look like\na demon's claws. The wounds these\nweapons inflict can never heal."
 	},
 	{
 		"assign": "120241",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -319,14 +319,14 @@
 		"jp_text": "ロケットパンチ／ナハト",
 		"tr_text": "Rocket Punch / Nacht",
 		"jp_explain": "闇夜の色を抱く自在槍。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": "Powerfists that bear the color of the\nmoonless night. It is unknown how or\nwhy these weapons were created,\nbut their performance is amazing."
+		"tr_explain": "Wired lances painted black as night.\nTheir origins are unknown, but they\ninspire greatness in their owner."
 	},
 	{
 		"assign": "12049",
 		"jp_text": "ネイクロー／ナハト",
 		"tr_text": "Neiclaw / Nacht",
 		"jp_explain": "闇夜の色を抱く自在槍。\n出自の仔細は不明だが、性能は高く\n所有者に大きな力を抱かせる。",
-		"tr_explain": "Wired lances that bear the color of\nthe moonless night. It is unknown how\nor why these weapons were created,\nbut their performance is amazing."
+		"tr_explain": "Wired lances painted black as night.\nTheir origins are unknown, but they\ninspire greatness in their owner."
 	},
 	{
 		"assign": "12050",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -739,7 +739,7 @@
 		"jp_text": "ノクスジラーク",
 		"tr_text": "Nox Jirak",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き自在槍。装者も恐怖を\n抱くほどの強大な力で敵を斬り伏せる。",
-		"tr_explain": ""
+		"tr_explain": "Black wired lances produced in an\nillicit ritual. Their foe-felling force\nterrifies even their wielder."
 	},
 	{
 		"assign": "120176",
@@ -998,7 +998,7 @@
 		"jp_text": "ノクスジラーク-NT",
 		"tr_text": "Nox Jirak-NT",
 		"jp_explain": "外法にも近い特別な儀式によって\n生み出された黒き自在槍。装者も恐怖を\n抱くほどの強大な力で敵を斬り伏せる。",
-		"tr_explain": ""
+		"tr_explain": "Black wired lances produced in an\nillicit ritual. Their foe-felling force\nterrifies even their wielder."
 	},
 	{
 		"assign": "120243",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -1054,7 +1054,7 @@
 		"jp_text": "アストラアドム",
 		"tr_text": "Astra Adom",
 		"jp_explain": "マザーの残滓たる、幻創の自在槍。\n立ち上がり前進する人々の意志を挫き\n歩みを徒労に帰さんとする妄執の戒め。",
-		"tr_explain": "A Phantom pair Wired Lances imbued\nwith Mother's Power. Its said that it\nconquers and enslaves its user's will."
+		"tr_explain": "Phantom Wired Lances imbued with\nMother's power. Said to enslave their\nuser, dominating their will."
 	},
 	{
 		"assign": "120271",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -1054,7 +1054,7 @@
 		"jp_text": "アストラアドム",
 		"tr_text": "Astra Adom",
 		"jp_explain": "マザーの残滓たる、幻創の自在槍。\n立ち上がり前進する人々の意志を挫き\n歩みを徒労に帰さんとする妄執の戒め。",
-		"tr_explain": "Phantom Wired Lances imbued with\nMother's power. Said to enslave their\nuser, dominating their will."
+		"tr_explain": "Phantom wired lances imbued with\nMother's power. Said to enslave their\nuser, dominating their will."
 	},
 	{
 		"assign": "120271",


### PR DESCRIPTION
- Basewears
- - Adds the fourth line to certain basewear tickets indicating that the basewear hides innerwear when worn.
- Costumes
- - Translates descriptions for the Ragol Memory "Repca" costumes.
- - Translates descriptions for Frontier Wing, Heavy Scudo, Adventos, Close Quarter, Sharp Order, Sensuous Coat, Gran Colette and Ryu Repca + all variants.
- - Renames "Kotoshiro Protector's Clothes" and all variants to "Kotoshiro's Clothes". Restores original colour names where they had been replaced with shorter words (ie Purple for Elegance) as the more correct words now fit.
- Hairstyles
- - Renames Klariskrays Hair to Claris Claes Hair.
- Item sets
- - Shortens the names of Kotoshiro's Clothes Set, Prisoner-Issue Male Clothing Set, Prisoner-Issue Female Clothing Set and Imperial Assault Uniform Box + all variants.
- - Translates Och Style Set and several upcoming recolour sets.
- Weapons
- - Translates the Nox and /Nacht series descriptions.
- - Translates 1* knuckles and a couple of top-end swords
- - Standardises the Live, Slave and Nemesis series descriptions.
- - Retranslates most Astra series descriptions.
- - Corrects the name of the Vibras series to Vibrace.
- - Retranslates descriptions of 1-6* wired lances, as well as 7*+ wired lances with NT/Ver2 counterparts, to cut them down to three lines. Copies the new descriptions to their NT versions. Also copies Heretic End's description to Heretic End-NT.
- - Retranslates Rifle's description as it was the last of the "ARKS standard-issue weapon" descriptions from Cirnopedia. Copies the new description to Rifle-NT.
- Units
- - Corrects the name of Kings Pack and Kings Legs to King's Pack and King's Legs.
- - Shortens the description of Fiogals.