### PR TITLE
Items, chips, fluff chat, tiny amount of story

### DIFF
--- a/_tools/normalize.py
+++ b/_tools/normalize.py
@@ -52,6 +52,12 @@ blacklist_files += [
     for f in fnmatch.filter(files, 'ChipExplain_ActiveExplain.txt')
 ]
 
+blacklist_files += [
+    os.path.join(dirpath, f)
+    for dirpath, dirnames, files in os.walk(dir)
+    for f in fnmatch.filter(files, 'ChipExplain_SupportExplain.txt')
+]
+
 bl = {"!", "＊", "†", "-", "士", "1", "2", "3", "4", "5"}
 
 

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -198,128 +198,128 @@
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Damage Boost + HP recovery",
+		"tr_explainShort": "Damage boost + HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Attack Power.\n② Recover HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Damage Boost + Greater HP Recovery",
+		"tr_explainShort": "Large damage boost + HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Attack Power.\n② Greatly recover HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
 		"jp_explainShort": "定期的にＨＰを小回復",
-		"tr_explainShort": "Fixed HP Recovery",
+		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recover HP over time.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "定期的にＨＰを小回復",
-		"tr_explainShort": "Fixed HP Recovery",
+		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recover HP over time.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
-		"tr_explainShort": "Quickens Actions + ATK Boost",
+		"tr_explainShort": "Actions quickened + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases Attack Power greatly.\n② Increases Movement and Attack Speed.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Greatly increases attack power.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
-		"tr_explainShort": "Quickens Actions + ATK Boost",
+		"tr_explainShort": "Actions quickened + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Attack Power greatly.\n② Increases Movement and Attack Speed.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Greatly increases attack power.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Mechs",
+		"tr_explainShort": "Deal additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Mechs",
+		"tr_explainShort": "Deal additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Darkers",
+		"tr_explainShort": "Deal additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Darkers",
+		"tr_explainShort": "Deal additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30007",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
-		"tr_explainShort": "Quickens Actions + Damage against Weak Attribute.",
+		"tr_explainShort": "Actions quickened + weakness elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly increase weak point damage and increased\nmovement and attacking speed for a long duration."
+		"tr_explainLong": "① Dramatically increases elements\n    that targetted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30008",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Actions quickened + weakness elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase normal attack speed and\nmovement speed. Dramatically strengthen\nthe element the target enemy is weak to."
+		"tr_explainLong": "① Dramatically increases elements\n    that targetted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Dragons",
+		"tr_explainShort": "Deal additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Dragons",
+		"tr_explainShort": "Deal additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Darkers",
+		"tr_explainShort": "Deal additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Darkers",
+		"tr_explainShort": "Deal additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30017",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Power boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Dramatically boosts attack power,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Power boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Dramatically boosts attack power,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30027",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -310,56 +310,56 @@
 	{
 		"assign": "30017",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "Power boost based on remaining CP",
+		"tr_explainShort": "ATK boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "Power boost based on remaining CP",
+		"tr_explainShort": "ATK boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Wind chips",
+		"tr_explainShort": "ATK boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Wind chips",
+		"tr_explainShort": "ATK boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Ice chips",
+		"tr_explainShort": "ATK boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Ice chips",
+		"tr_explainShort": "ATK boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Lightning chips",
+		"tr_explainShort": "ATK boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Power boost x # of Lightning chips",
+		"tr_explainShort": "ATK boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
@@ -436,16 +436,16 @@
 	{
 		"assign": "30067",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost proportional to Chips equipped",
+		"tr_explainShort": "ATK & DEF boost x # elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK and DEF proportional to\nthe different amount of chips currently\nequipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost proportional to Chips equipped",
+		"tr_explainShort": "ATK & DEF boost x # elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK and DEF proportional to\nthe different amount of chips elements\ncurrently equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30071",
@@ -464,44 +464,44 @@
 	{
 		"assign": "30081",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increases ATK proportional to Light Chips equipped",
+		"tr_explainShort": "ATK boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nLight Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30082",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Light Chips equipped",
+		"tr_explainShort": "ATK boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nLight Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30083",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Dark Chips equipped",
+		"tr_explainShort": "ATK boost x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nDark Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30084",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Dark Chips equipped",
+		"tr_explainShort": "ATK boost x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nDark Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30085",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Fire Chips equipped",
+		"tr_explainShort": "ATK boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nFire Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30086",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Fire Chips equipped",
+		"tr_explainShort": "ATK boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nFire Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30089",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -2,86 +2,86 @@
 	{
 		"assign": "110",
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Element Boosted+ATK Boost",
+		"tr_explainShort": "Fire Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Element Boosted+ATK Boost",
+		"tr_explainShort": "Fire Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Element Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Element Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Element Boosted + ATK Boost",
+		"tr_explainShort": "Lightning Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Element Boosted + ATK Boost",
+		"tr_explainShort": "Lightning Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Element Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Element Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Element Boosted + ATK Boost",
+		"tr_explainShort": "Light Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Element Boosted + ATK Boost",
+		"tr_explainShort": "Light Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Element Boosted + ATK Boost",
+		"tr_explainShort": "Dark Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Element Boosted + ATK Boost",
+		"tr_explainShort": "Dark Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "910",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -366,30 +366,30 @@
 	{
 		"assign": "30033",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
-		"tr_explainShort": "Imbues [Panic] + ATK Boost",
+		"tr_explainShort": "Normal attacks can [Panic] + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "Greatly boosts ATK and gives chance of [Panic]\non normal attacks for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
-		"tr_explainShort": "Imbues [Panic] + ATK Boost",
+		"tr_explainShort": "Normal attacks can [Panic] + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK and gives chance of [Panic]\non normal attacks for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1690",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
-		"tr_explainShort": "Fire Attribute. Boosted + ATK Boost inversely of HP",
+		"tr_explainShort": "Fire damage + ATK boost inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts Fire Attribute. and increases\nATK inversely to HP remaining for a long duration."
+		"tr_explainLong": "[Damage Bomb]\n① Boosts ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1700",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
-		"tr_explainShort": "Fire Attri. Boosted + ATk Boost inversely of HP",
+		"tr_explainShort": "Fire damage + ATK boost inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts Fire Attribute. and increases\nATK inversely to HP remaining for a long duration."
+		"tr_explainLong": "[Damage Bomb]\n① Boosts ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30043",
@@ -422,16 +422,16 @@
 	{
 		"assign": "30053",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
-		"tr_explainShort": "Boost ATK & Knockdown Immunity",
+		"tr_explainShort": "ATK boost + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, boosts ATK\nand grants knockdown immunity."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
-		"tr_explainShort": "Boost ATK & Knockdown Immunity",
+		"tr_explainShort": "ATK boost + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, boosts ATK\nand grants knockdown immunity."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30067",
@@ -450,16 +450,16 @@
 	{
 		"assign": "30071",
 		"jp_explainShort": "定期的に攻撃力を上昇",
-		"tr_explainShort": "",
+		"tr_explainShort": "Regular ATK boosts",
 		"jp_explainLong": "① 定期的に攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly increases ATK for a long duration.\n※ATK is slowly increased over time."
+		"tr_explainLong": "① Greatly boosts ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30072",
 		"jp_explainShort": "定期的に攻撃力を上昇",
-		"tr_explainShort": "Increases ATK over time",
+		"tr_explainShort": "Regular ATK boosts",
 		"jp_explainLong": "① 定期的に攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly increases ATK for a long duration.\n※ATK is slowly increased over time."
+		"tr_explainLong": "① Dramatically boosts ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30081",
@@ -506,44 +506,44 @@
 	{
 		"assign": "30089",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
-		"tr_explainShort": "ATK Boost + HP Recovery over time",
+		"tr_explainShort": "ATK boost + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Reduces current HP by 90%.\nDrastically increases ATK and gives a\nHP Recovery over time effect for a long duration."
+		"tr_explainLong": "① Reduces current HP by 90%.\n② Dramatically boosts ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
-		"tr_explainShort": "ATK Boost + HP Recovery over time",
+		"tr_explainShort": "ATK boost + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Reduces current HP by 90%.\nDrastically increases ATK and gives a\nHP Recovery over time effect for a long duration."
+		"tr_explainLong": "① Reduces current HP by 90%.\n② Dramatically boosts ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31009",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
-		"tr_explainShort": "Increased CP recovery + Increased maximum CP",
+		"tr_explainShort": "Increased max CP + boosted CP regen",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Drastically increase recovery of CP and increase\nmaximum CP for a long duration."
+		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31010",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
-		"tr_explainShort": "Increased CP recovery + Increased maximum CP",
+		"tr_explainShort": "Increased max CP + boosted CP regen",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Drastically increase recovery of CP and increase\nmaximum CP for a long duration."
+		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31011",
 		"jp_explainShort": "ダーカー以外にダメージ増加",
-		"tr_explainShort": "Damage Boost against all except Darkers",
+		"tr_explainShort": "Damage boost against non-Darkers",
 		"jp_explainLong": "① 原生種、龍族、機甲種、海王種に\n　　 与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase damage done to natives, dragonkin,\nmechs, oceanids for a long duration."
+		"tr_explainLong": "① Boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31012",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
-		"tr_explainShort": "Damage Boost against all except Darkers",
+		"tr_explainShort": "Damage boost against non-Darkers",
 		"jp_explainLong": "① 原生種、龍族、機甲種、海王種に\n　　 与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly increase damage done to natives,\ndragonkin, mechs, oceanids for a long duration."
+		"tr_explainLong": "① Greatly boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31025",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -632,30 +632,30 @@
 	{
 		"assign": "31061",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Wind Attribute.",
+		"tr_explainShort": "ATK boost proportional to Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nWind Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Wind Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Wind Attribute.",
+		"tr_explainShort": "ATK boost proportional to Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the\namount of Wind Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Wind Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Ice Attribute.",
+		"tr_explainShort": "ATK boost proportional to Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nIce Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Ice Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Ice Attribute.",
+		"tr_explainShort": "ATK boost proportional to Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nIce Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Ice Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
@@ -688,30 +688,30 @@
 	{
 		"assign": "31085",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Dark Attribute.",
+		"tr_explainShort": "ATK boost proportional to Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nDark Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Dark Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Dark Attribute.",
+		"tr_explainShort": "ATK boost proportional to Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nDark Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Dark Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Fire Attribute.",
+		"tr_explainShort": "ATK boost proportional to Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nFire Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Fire Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "Increase ATK proportional to Fire Attribute.",
+		"tr_explainShort": "ATK boost proportional to Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK proportional to the amount of\nFire Attribute. for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Fire Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -730,14 +730,14 @@
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
-		"tr_explainShort": "Damage boosted + Katanas boosted",
+		"tr_explainShort": "ATK boosted + Katana ATK boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Greatly boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
-		"tr_explainShort": "Damage boosted + Katanas boosted",
+		"tr_explainShort": "ATK boosted + Katana ATK boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Dramatically boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
 	},

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -4,84 +4,84 @@
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases attack power.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "910",
@@ -102,14 +102,14 @@
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "ATK boost + DEF lowered",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Greatly increases attack power.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces Defense.\n② Greatly increases ATK.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
 		"tr_explainShort": "ATK boost + DEF lowered",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases attack power.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases ATK.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1310",
@@ -130,42 +130,42 @@
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Light damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Light damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Ice damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Ice Element damage.\n[Effect Duration] Long."
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Ice Element damage.\n[Effect Duration] Long."
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Ice damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Ice Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Ice Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Wind damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Wind damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1570",
@@ -186,28 +186,28 @@
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Fire damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Immense Fire damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boost + HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Large damage boost + HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases ATK.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
@@ -228,14 +228,14 @@
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases attack power.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases attack power.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30003",
@@ -312,56 +312,56 @@
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "Power boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "Power boost based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "Power boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30033",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -394,30 +394,30 @@
 	{
 		"assign": "30043",
 		"jp_explainShort": "ダメージ軽減＋長槍の必殺技を大強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from enemies.\nGreatly strengthen Partizan Skills."
+		"tr_explainLong": "① Greatly strengthens Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30044",
 		"jp_explainShort": "ダメージ大軽減＋長槍の必殺技を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from enemies.\nDramatically strengthen Partizan Skills."
+		"tr_explainLong": "① Dramatically strengthens Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30047",
 		"jp_explainShort": "ダメージ軽減＋長銃の必殺技を大強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from enemies.\nGreatly strengthen Assault Rifle Skills."
+		"tr_explainLong": "① Greatly strengthens Assault Rifle PA.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30048",
 		"jp_explainShort": "ダメージ大軽減＋長銃の必殺技を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from enemies.\nDramatically strengthen Assault Rifle Skills."
+		"tr_explainLong": "① Dramatically strengthens Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30053",
@@ -548,30 +548,30 @@
 	{
 		"assign": "31025",
 		"jp_explainShort": "ダメージ軽減＋飛翔剣の必殺技を大強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from\nenemies. Greatly increases the power of\nDual Blade Skills."
+		"tr_explainLong": "① Greatly strengthens Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31026",
 		"jp_explainShort": "ダメージ大軽減＋飛翔剣の必殺技を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from\nenemies. Dramatically increases the\npower of Dual Blade Skills."
+		"tr_explainLong": "① Dramatically strengthens Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31029",
 		"jp_explainShort": "ダメージ軽減＋双機銃の必殺技を大強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Machinegun PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from\nenemies. Greatly increases the power of\nTwin Machinegun Skills."
+		"tr_explainLong": "① Greatly strengthens Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31030",
 		"jp_explainShort": "ダメージ大軽減＋双機銃の必殺技を劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage reduced + Machinegun PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce damage from\nenemies. Dramatically increases the\npower of Twin Machinegun Skills."
+		"tr_explainLong": "① Dramatically strengthens Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31045",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -128,44 +128,44 @@
 	{
 		"assign": "1510",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Light Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Light damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Light Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Light damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Ice Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Ice damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Element.\n[Effect Duration] Long."
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Ice Element damage.\n[Effect Duration] Long."
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Ice Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Ice damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Ice Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Wind Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Wind damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Wind Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Wind damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1570",
@@ -184,16 +184,16 @@
 	{
 		"assign": "1590",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Fire Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Fire damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Fire Element Boosted + ATK Boost",
+		"tr_explainShort": "Immense Fire damage + ATK boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases attack power.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11050",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -270,14 +270,14 @@
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements\n    that targetted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases elements\n    that targeted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30008",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements\n    that targetted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases elements\n    that targeted enemy is weak to.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30013",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -240,30 +240,30 @@
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Armored",
+		"tr_explainShort": "Deal Add. Damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Armored-species.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal Add. Damage to Armored",
+		"tr_explainShort": "Deal Add. Damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Armored-species.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deal Add. Damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Darkers, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deal Add. Damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Darkers, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30007",
@@ -282,30 +282,30 @@
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Deal Add. Damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Dragons, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Deal Add. Damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Dragons, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Deal Add. Damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Darkers, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Deal Add. Damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "When attacking Darkers, deal\nadditional damage for a long duration."
+		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30017",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -324,44 +324,44 @@
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Wind Chips equipped",
+		"tr_explainShort": "Power boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nWind Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Wind Chips equipped",
+		"tr_explainShort": "Power boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nWind Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Ice Chips equipped",
+		"tr_explainShort": "Power boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nIce Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Ice Chips equipped",
+		"tr_explainShort": "Power boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nIce Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Lightning Chips equipped",
+		"tr_explainShort": "Power boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nLightning Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "Increase ATK proportional to Lightning Chips equipped",
+		"tr_explainShort": "Power boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Increase ATK based on the number of\nLightning Chips equipped for a long duration."
+		"tr_explainLong": "① Boosts attack power based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30033",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -2,86 +2,86 @@
 	{
 		"assign": "110",
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Attribute. Boosted+ATK Boost",
+		"tr_explainShort": "Fire Element Boosted+ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Fire Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Attribute. Boosted+ATK Boost",
+		"tr_explainShort": "Fire Element Boosted+ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Fire Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Ice Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Ice Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Lightning Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Lightning Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Lightning Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Lightning Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Wind Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Wind Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Light Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Light Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Light Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Light Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Dark Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Dark Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Dark Element Boosted + ATK Boost",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Dark Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases Attack.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "910",
@@ -128,44 +128,44 @@
 	{
 		"assign": "1510",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Light Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Light Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Light Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Light Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Ice Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Attribute.\n[Effect Duration] Long."
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Element.\n[Effect Duration] Long."
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Ice Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Ice Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Wind Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Wind Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Wind Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1570",
@@ -184,16 +184,16 @@
 	{
 		"assign": "1590",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Fire Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Fire Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Fire Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Fire Element Boosted + ATK Boost",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Attribute.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases Attack.\n② Immensely boosts Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11050",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -86,44 +86,44 @@
 	{
 		"assign": "910",
 		"jp_explainShort": "全体に大ダメージ＋確率で「バーン」",
-		"tr_explainShort": "Damages all enemies + chance of inflicting [Burn]",
+		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Gives enormous damage to all enemies.\n② Increases the chance of inflicting [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals enormous damage to all enemies.\n② Has a fixed chance to inflict [Burn]."
 	},
 	{
 		"assign": "920",
 		"jp_explainShort": "全体に特大ダメージ＋確率で「バーン」",
-		"tr_explainShort": "Damages all enemies + chance of inflicting [Burn]",
+		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に特大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Gives immense damage to all enemies.\n② Increases the chance of inflicting [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals immense damage to all enemies.\n② Has a fixed chance to inflict [Burn]."
 	},
 	{
 		"assign": "1110",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
-		"tr_explainShort": "ATK Boost + DEF lowered",
+		"tr_explainShort": "ATK boost + DEF lowered",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Greatly increases Attack.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Reduces Defense.\n② Greatly increases attack power.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
-		"tr_explainShort": "ATK Boost + DEF lowered",
+		"tr_explainShort": "ATK boost + DEF lowered",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases Attack.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases attack power.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
-		"tr_explainShort": "Damage against weak element is boosted",
+		"tr_explainShort": "Damage against element weaknesses up",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases damage against the enemy's weak\nattributes.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Increases damage against\n    enemy element weaknesses.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
-		"tr_explainShort": "Damage against weak attributes boosted",
+		"tr_explainShort": "Damage against element weaknesses up",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases damage against the enemy's weak\nattributes.\n[Effect Duration] Fixed Interval"
+		"tr_explainLong": "① Increases damage against\n    enemy element weaknesses.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1510",
@@ -172,14 +172,14 @@
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Damages yourself and enemies with\na Fire-attribute Attack."
+		"tr_explainLong": "[Damage Bomb]\n① Damages yourself and all enemies with\n    a massive Fire Element Tech attack."
 	},
 	{
 		"assign": "1580",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Damages yourself and enemies with\na Fire-attribute Attack."
+		"tr_explainLong": "[Damage Bomb]\n① Damages yourself and all enemies with\n    a massive Fire Element Tech attack."
 	},
 	{
 		"assign": "1590",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -235,7 +235,7 @@
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30003",
@@ -368,7 +368,7 @@
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "Normal attacks can [Panic] + ATK boost",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30034",
@@ -436,14 +436,14 @@
 	{
 		"assign": "30067",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost x # elements equipped",
+		"tr_explainShort": "ATK & DEF boost x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost x # elements equipped",
+		"tr_explainShort": "ATK & DEF boost x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
@@ -660,30 +660,30 @@
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
-		"tr_explainShort": "Boost ATK + Status Immunity",
+		"tr_explainShort": "ATK boost + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts ATK and grants status effect\nimmunity for a long duration."
+		"tr_explainLong": "① Boosts ATK.\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
-		"tr_explainShort": "Boost ATK + Status Immunity",
+		"tr_explainShort": "ATK boost + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK and grants status\neffect immunity for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
-		"tr_explainShort": "Converts highest Attribute. element as Enemy's weak Attribute.",
+		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "Converts highest Attribute. element as the targeted\nenemy's weak Attribute. for a long duration.\n(This change affects normal attacks and PAs.)"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's Element weakness.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31072",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
-		"tr_explainShort": "Converts highest Attribute. element as Enemy's weak Attribute.",
+		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "Converts highest Attribute. element as the targeted\nenemy's weak Attribute. for a long duration.\n(This change affects normal attacks and PAs.)"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's Element weakness.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31085",
@@ -716,114 +716,114 @@
 	{
 		"assign": "31093",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
-		"tr_explainShort": "Inflicts [Burn] + Increased [Burn] damage",
+		"tr_explainShort": "Inflicts [Burn] + damage up vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "Inflicts [Burn] on targeted enemy and\ngreatly boosts damage dealt by [Burn]."
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts ATK against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
-		"tr_explainShort": "Inflicts [Burn] + Increased [Burn] damage",
+		"tr_explainShort": "Inflicts [Burn] + damage up vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "Inflicts [Burn] on targeted enemy and\ndramatically boosts damage dealt by [Burn]."
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boosted + Katanas boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly increase\ndamage to an enemy. Deal additional\ndamage if a Sword is equipped."
+		"tr_explainLong": "① Greatly boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boosted + Katanas boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nincrease damage to an enemy. Deal\nadditional damage if a Sword is equipped."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31099",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
-		"tr_explainShort": "Decreases CP Consumption",
+		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "Decreases the consumption of CP for a period of time."
+		"tr_explainLong": "① Decreases CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31100",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
-		"tr_explainShort": "Decreases CP Consumption",
+		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "Decreases the consumption of CP for a period of time."
+		"tr_explainLong": "① Decreases CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31119",
 		"jp_explainShort": "追加で大ダメージ",
-		"tr_explainShort": "Additional Damage on Hit",
+		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Deals additional damage when attacking\nan enemy for a long duration."
+		"tr_explainLong": "① Deals additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "追加で特大ダメージ",
-		"tr_explainShort": "Additional Damage on Hit",
+		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Deals additional damage greatly when\nattacking an enemy for a long duration. "
+		"tr_explainLong": "① Deals large additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31131",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
-		"tr_explainShort": "ATK Boost Based on Ability Level",
+		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boost\nATK according to ability level of chip."
+		"tr_explainLong": "① Greatly boosts ATK based on chip's ability level.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
-		"tr_explainShort": "Attack Power Boost Based on Ability Level",
+		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts attack power dramatically\nbased on the chip’s ability level."
+		"tr_explainLong": "① Dramatically boosts ATK based on chip's ability level.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
-		"tr_explainShort": "Boosts ATK proportional to Chips equipped + Periodic CP recovery",
+		"tr_explainShort": "ATK boost x # Elems + CP Recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK proportional to the different\namount of Chip elements equipped and recovers CP\nperiodically for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK based on the number\n    of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
-		"tr_explainShort": "Boosts ATK proportional to Chips equipped + Periodic CP recovery",
+		"tr_explainShort": "ATK boost x # Elems + CP Recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK proportional to the different\namount of Chip elements equipped and recovers CP\nperiodically for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK based on the number\n    of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
-		"tr_explainShort": "Boosts ATK proportional to Chips equipped + Damage Protection",
+		"tr_explainShort": "ATK boost x # Elems + damage reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK proportional to the different\namount of Chip elements equipped and grants a fixed\namount of damage protection for a long duration."
+		"tr_explainLong": "① Greatly boosts ATK based on the number\n    of different chip elements equipped.\n② Reduces damage taken based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
-		"tr_explainShort": "Boosts ATK proportional to Chips equipped + Damage Protection",
+		"tr_explainShort": "ATK boost x # Elems + damage reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK proportional to the different\namount of Chip elements equipped and grants a fixed\namount of damage protection for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK based on the number\n    of different chip elements equipped.\n② Reduces damage taken based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
-		"tr_explainShort": "Inflicts [Freeze] + Increased [Freeze] damage",
+		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "Inflicts [Freeze] on enemies and greatly boosts\ndamage done to Frozen enemies for a period of time."
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
-		"tr_explainShort": "Inflicts [Freeze] + Increased [Freeze] damage",
+		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "Inflicts [Freeze] on enemies and greatly boosts\ndamage done to Frozen enemies for a period of time."
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31153",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -3252,14 +3252,14 @@
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Silghtly raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] A fixed time"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] A fixed time"
 	},
 	{
 		"assign": "31537",

--- a/json/Condition_Group.txt
+++ b/json/Condition_Group.txt
@@ -2,12 +2,12 @@
 	{
 		"assign": "2519901",
 		"jp_text": "es/ACスクラッチのアイテム・チップ",
-		"tr_text": "es/AC Scratch Item - Chip"
+		"tr_text": "es/AC Scratch Item/Chip"
 	},
 	{
 		"assign": "2519902",
 		"jp_text": "es/ACスクラッチ以外のアイテム・チップ",
-		"tr_text": "Item or Chip other than es/AC Scratch"
+		"tr_text": "Non-es/AC Scratch Item/Chip"
 	},
 	{
 		"assign": "2519903",
@@ -17,17 +17,17 @@
 	{
 		"assign": "2519904",
 		"jp_text": "es/ACスクラッチ以外のアイテム",
-		"tr_text": ""
+		"tr_text": "Non-es/AC Scratch Item"
 	},
 	{
 		"assign": "2519905",
 		"jp_text": "es/ACスクラッチのチップ",
-		"tr_text": ""
+		"tr_text": "es/AC Scratch Chip"
 	},
 	{
 		"assign": "2519906",
 		"jp_text": "es/ACスクラッチ以外のチップ",
-		"tr_text": ""
+		"tr_text": "Non-es/AC Scratch Chip"
 	},
 	{
 		"assign": "2519800",
@@ -112,32 +112,32 @@
 	{
 		"assign": "2519702",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "2519703",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "2519704",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "2519705",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "2519706",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "2519707",
 		"jp_text": "特定の解放用素材チップ",
-		"tr_text": ""
+		"tr_text": "Specific Release Material Chip"
 	},
 	{
 		"assign": "602401",

--- a/json/Condition_Group_Apple.txt
+++ b/json/Condition_Group_Apple.txt
@@ -2,31 +2,31 @@
 	{
 		"assign": "2519901",
 		"jp_text": "esスクラッチのアイテム・チップ",
-		"tr_text": ""
+		"tr_text": "es Scratch Item/Chip"
 	},
 	{
 		"assign": "2519902",
 		"jp_text": "esスクラッチ以外のアイテム・チップ",
-		"tr_text": ""
+		"tr_text": "Non-es Scratch Item/Chip"
 	},
 	{
 		"assign": "2519903",
 		"jp_text": "esスクラッチのアイテム",
-		"tr_text": ""
+		"tr_text": "es Scratch Item"
 	},
 	{
 		"assign": "2519904",
 		"jp_text": "esスクラッチ以外のアイテム",
-		"tr_text": ""
+		"tr_text": "Non-es Scratch Item"
 	},
 	{
 		"assign": "2519905",
 		"jp_text": "esスクラッチのチップ",
-		"tr_text": ""
+		"tr_text": "es Scratch Chip"
 	},
 	{
 		"assign": "2519906",
 		"jp_text": "esスクラッチ以外のチップ",
-		"tr_text": ""
+		"tr_text": "Non-es Scratch Chip"
 	}
 ]

--- a/json/Item_BaseWear_Female.txt
+++ b/json/Item_BaseWear_Female.txt
@@ -5324,126 +5324,126 @@
 		"jp_text": "ビハインドザダスク[Ba]",
 		"tr_text": "Behind The Dusk [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350829",
 		"jp_text": "ビハインドザダスク雪[Ba]",
 		"tr_text": "Behind The Dusk Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク雪[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk Snow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350830",
 		"jp_text": "ビハインドザダスク夜[Ba]",
 		"tr_text": "Behind The Dusk Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク夜[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk Night [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350831",
 		"jp_text": "ビハインドザダスク影[Ba]",
 		"tr_text": "Behind The Dusk Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク影[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk Shadow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350832",
 		"jp_text": "ビハインドザダスク海[Ba]",
 		"tr_text": "Behind The Dusk Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク海[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk Sea [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350833",
 		"jp_text": "ビハインドザダスク紅[Ba]",
 		"tr_text": "Behind The Dusk Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nビハインドザダスク紅[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Behind The Dusk Crimson [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350834",
 		"jp_text": "スエットミニデニム[Ba]",
 		"tr_text": "Sweat Mini Denim [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350835",
 		"jp_text": "スエットミニデニム雪[Ba]",
 		"tr_text": "Sweat Mini Denim Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム雪[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim Snow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350836",
 		"jp_text": "スエットミニデニム夜[Ba]",
 		"tr_text": "Sweat Mini Denim Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム夜[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim Night [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350837",
 		"jp_text": "スエットミニデニム影[Ba]",
 		"tr_text": "Sweat Mini Denim Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム影[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim Shadow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350838",
 		"jp_text": "スエットミニデニム紅[Ba]",
 		"tr_text": "Sweat Mini Denim Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム紅[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim Crimson [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350839",
 		"jp_text": "スエットミニデニム空[Ba]",
 		"tr_text": "Sweat Mini Denim Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスエットミニデニム空[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Sweat Mini Denim Sky [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350840",
 		"jp_text": "アークマチャーム[Ba]",
 		"tr_text": "Arkuma Charm [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350841",
 		"jp_text": "アークマチャーム雪[Ba]",
 		"tr_text": "Arkuma Charm Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム雪[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm Snow [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350842",
 		"jp_text": "アークマチャーム海[Ba]",
 		"tr_text": "Arkuma Charm Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム海[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm Sea [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350843",
 		"jp_text": "アークマチャーム桜[Ba]",
 		"tr_text": "Arkuma Charm Sakura [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム桜[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm Sakura [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350844",
 		"jp_text": "アークマチャーム空[Ba]",
 		"tr_text": "Arkuma Charm Sky [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム空[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm Sky [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350845",
 		"jp_text": "アークマチャーム紅[Ba]",
 		"tr_text": "Arkuma Charm Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nアークマチャーム紅[Ba]が選択可能。\n女性のみ使用可能。\n<yellow>※着用時はインナーが非表示になります。<c>",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Arkuma Charm Crimson [Ba]\".\nOnly usable on female characters.\n<yellow>※Hides innerwear when worn.<c>"
 	},
 	{
 		"assign": "3350846",
@@ -5541,139 +5541,139 @@
 		"jp_text": "ステラメモリーズ[Ba]",
 		"tr_text": "Stella Memories [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350860",
 		"jp_text": "ステラメモリーズ影[Ba]",
 		"tr_text": "Stella Memories Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ影[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories Shadow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350861",
 		"jp_text": "ステラメモリーズ紅[Ba]",
 		"tr_text": "Stella Memories Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ紅[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories Crimson [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350862",
 		"jp_text": "ステラメモリーズ海[Ba]",
 		"tr_text": "Stella Memories Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ海[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories Sea [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350863",
 		"jp_text": "ステラメモリーズ桜[Ba]",
 		"tr_text": "Stella Memories Sakura [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ桜[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories Sakura [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350864",
 		"jp_text": "ステラメモリーズ栗[Ba]",
 		"tr_text": "Stella Memories Chestnut [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nステラメモリーズ栗[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Stella Memories Chestnut [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350865",
 		"jp_text": "スミスサロペット[Ba]",
 		"tr_text": "Smith Salopette [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350866",
 		"jp_text": "スミスサロペット雪[Ba]",
 		"tr_text": "Smith Salopette Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット雪[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette Snow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350867",
 		"jp_text": "スミスサロペット影[Ba]",
 		"tr_text": "Smith Salopette Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット影[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette Shadow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350868",
 		"jp_text": "スミスサロペット夜[Ba]",
 		"tr_text": "Smith Salopette Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット夜[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette Night [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350869",
 		"jp_text": "スミスサロペット紅[Ba]",
 		"tr_text": "Smith Salopette Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット紅[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette Crimson [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350870",
 		"jp_text": "スミスサロペット月[Ba]",
 		"tr_text": "Smith Salopette Moon [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミスサロペット月[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smith Salopette Moon [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350871",
 		"jp_text": "ダメージジーンズ[Ba]",
 		"tr_text": "Ripped Jeans [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350872",
 		"jp_text": "ダメージジーンズ夜[Ba]",
 		"tr_text": "Ripped Jeans Night [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ夜[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans Night [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350873",
 		"jp_text": "ダメージジーンズ影[Ba]",
 		"tr_text": "Ripped Jeans Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ影[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans Shadow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350874",
 		"jp_text": "ダメージジーンズ雪[Ba]",
 		"tr_text": "Ripped Jeans Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ雪[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans Snow [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350875",
 		"jp_text": "ダメージジーンズ陽[Ba]",
 		"tr_text": "Ripped Jeans Sun [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ陽[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans Sun [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350876",
 		"jp_text": "ダメージジーンズ紅[Ba]",
 		"tr_text": "Ripped Jeans Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nダメージジーンズ紅[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Ripped Jeans Crimson [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350877",
 		"jp_text": "タンクトップデニム玄[Ba]",
 		"tr_text": "Tank Top Denim Mysterious [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nタンクトップデニム玄[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Tank Top Denim Mysterious [Ba]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3350878",
 		"jp_text": "タンクトップデニム冬[Ba]",
 		"tr_text": "Tank Top Denim Winter [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nタンクトップデニム冬[Ba]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Tank Top Denim Winter [Ba]\".\nOnly usable on female characters."
 	}
 ]

--- a/json/Item_BaseWear_Male.txt
+++ b/json/Item_BaseWear_Male.txt
@@ -3420,83 +3420,83 @@
 		"jp_text": "上なしカーゴパンツ[Ba]",
 		"tr_text": "Topless Cargo [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340548",
 		"jp_text": "上なしカーゴパンツ葉[Ba]",
 		"tr_text": "Topless Cargo Leaf [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ葉[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo Leaf [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340549",
 		"jp_text": "上なしカーゴパンツ海[Ba]",
 		"tr_text": "Topless Cargo Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ海[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo Sea [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340550",
 		"jp_text": "上なしカーゴパンツ陽[Ba]",
 		"tr_text": "Topless Cargo Sun [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ陽[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo Sun [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340551",
 		"jp_text": "上なしカーゴパンツ雪[Ba]",
 		"tr_text": "Topless Cargo Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ雪[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo Snow [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340552",
 		"jp_text": "上なしカーゴパンツ影[Ba]",
 		"tr_text": "Topless Cargo Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n上なしカーゴパンツ影[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Topless Cargo Shadow [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340553",
 		"jp_text": "スミシークロース[Ba]",
 		"tr_text": "Smithy Clothes [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340554",
 		"jp_text": "スミシークロース雪[Ba]",
 		"tr_text": "Smithy Clothes Snow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース雪[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes Snow [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340555",
 		"jp_text": "スミシークロース影[Ba]",
 		"tr_text": "Smithy Clothes Shadow [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース影[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes Shadow [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340556",
 		"jp_text": "スミシークロース海[Ba]",
 		"tr_text": "Smithy Clothes Sea [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース海[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes Sea [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340557",
 		"jp_text": "スミシークロース紅[Ba]",
 		"tr_text": "Smithy Clothes Crimson [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース紅[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes Crimson [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340558",
 		"jp_text": "スミシークロース葉[Ba]",
 		"tr_text": "Smithy Clothes Leaf [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\nスミシークロース葉[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new basewear\n\"Smithy Clothes Leaf [Ba]\".\nOnly usable on male characters."
 	}
 ]

--- a/json/Item_BaseWear_Male.txt
+++ b/json/Item_BaseWear_Male.txt
@@ -3110,9 +3110,9 @@
 	{
 		"assign": "3340500",
 		"jp_text": "浪漫義士袴　雅[Ba]",
-		"tr_text": "Romanticist Hak. Elegant [Ba]",
+		"tr_text": "Romanticist Hak. Elegance [Ba]",
 		"jp_explain": "使用すると、新しいベースウェアの\n浪漫義士袴　雅[Ba]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": "Unlocks the new basewear\n\"Romanticist Hak. Elegant [Ba]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new basewear\n\"Romanticist Hak. Elegance [Ba]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3340503",

--- a/json/Item_Costume_Female.txt
+++ b/json/Item_Costume_Female.txt
@@ -14954,7 +14954,7 @@
 	{
 		"assign": "2202376",
 		"jp_text": "グラスフォーアネーム雅",
-		"tr_text": "Glas Vornehm Elegant",
+		"tr_text": "Glas Vornehm Elegance",
 		"jp_explain": "女の子らしさを極めたアークススーツ。\n戦場に舞う可憐な蝶を思わせるその姿に\n見る者は思わず守ってあげたくなる。",
 		"tr_explain": ""
 	},
@@ -15101,7 +15101,7 @@
 	{
 		"assign": "2202397",
 		"jp_text": "エイディルールＲ雅",
-		"tr_text": "Adieloure R Elegant",
+		"tr_text": "Adieloure R Elegance",
 		"jp_explain": "女性アークス用の特別仕様戦闘服。\nどのような戦場でも自由に動けるよう\n軽量化を重視した服装。",
 		"tr_explain": ""
 	},

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -8521,7 +8521,7 @@
 	{
 		"assign": "2101410",
 		"jp_text": "ヴィテスシュタルク雅",
-		"tr_text": "Vitesse Stark Elegant",
+		"tr_text": "Vitesse Stark Elegance",
 		"jp_explain": "正義の味方を気取るアークススーツ。\nそこにいるだけで子どもたちに信頼され\n熱い眼差しで見つめられること確実。",
 		"tr_explain": ""
 	},

--- a/json/Item_InnerWear_Female.txt
+++ b/json/Item_InnerWear_Female.txt
@@ -2496,167 +2496,167 @@
 		"jp_text": "ビハインドザダスク[In]",
 		"tr_text": "Behind The Dusk [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370391",
 		"jp_text": "ビハインドザダスク雅[In]",
 		"tr_text": "Behind The Dusk Elegance [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク雅[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk Elegance [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370392",
 		"jp_text": "ビハインドザダスク夜[In]",
 		"tr_text": "Behind The Dusk Night [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク夜[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk Night [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370393",
 		"jp_text": "ビハインドザダスク月[In]",
 		"tr_text": "Behind The Dusk Moon [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク月[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk Moon [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370394",
 		"jp_text": "ビハインドザダスク海[In]",
 		"tr_text": "Behind The Dusk Sea [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク海[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk Sea [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370395",
 		"jp_text": "ビハインドザダスク影[In]",
 		"tr_text": "Behind The Dusk Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク影[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Behind The Dusk Shadow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370396",
 		"jp_text": "ステラメモリーズ[In]",
 		"tr_text": "Stella Memories [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370397",
 		"jp_text": "ステラメモリーズ影[In]",
 		"tr_text": "Stella Memories Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ影[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories Shadow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370398",
 		"jp_text": "ステラメモリーズ紅[In]",
 		"tr_text": "Stella Memories Crimson [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ紅[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories Crimson [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370399",
 		"jp_text": "ステラメモリーズ海[In]",
 		"tr_text": "Stella Memories Sea [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ海[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories Sea [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370400",
 		"jp_text": "ステラメモリーズ桜[In]",
 		"tr_text": "Stella Memories Sakura [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ桜[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories Sakura [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370401",
 		"jp_text": "ステラメモリーズ月[In]",
 		"tr_text": "Stella Memories Moon [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nステラメモリーズ月[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Stella Memories Moon [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370402",
 		"jp_text": "スミスサロペット[In]",
 		"tr_text": "Smith Salopette [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370403",
 		"jp_text": "スミスサロペット雪[In]",
 		"tr_text": "Smith Salopette Snow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット雪[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette Snow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370404",
 		"jp_text": "スミスサロペット影[In]",
 		"tr_text": "Smith Salopette Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット影[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette Shadow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370405",
 		"jp_text": "スミスサロペット夜[In]",
 		"tr_text": "Smith Salopette Night [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット夜[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette Night [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370406",
 		"jp_text": "スミスサロペット紅[In]",
 		"tr_text": "Smith Salopette Crimson [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット紅[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette Crimson [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370407",
 		"jp_text": "スミスサロペット月[In]",
 		"tr_text": "Smith Salopette Moon [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミスサロペット月[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smith Salopette Moon [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370408",
 		"jp_text": "ダンサーズビキニ[In]",
 		"tr_text": "Dancer Bikini [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370409",
 		"jp_text": "ダンサーズビキニ夜[In]",
 		"tr_text": "Dancer Bikini Night [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ夜[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini Night [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370410",
 		"jp_text": "ダンサーズビキニ影[In]",
 		"tr_text": "Dancer Bikini Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ影[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini Shadow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370411",
 		"jp_text": "ダンサーズビキニ雪[In]",
 		"tr_text": "Dancer Bikini Snow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ雪[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini Snow [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370412",
 		"jp_text": "ダンサーズビキニ陽[In]",
 		"tr_text": "Dancer Bikini Sun [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ陽[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini Sun [In]\".\nOnly usable on female characters."
 	},
 	{
 		"assign": "3370413",
 		"jp_text": "ダンサーズビキニ紅[In]",
 		"tr_text": "Dancer Bikini Crimson [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nダンサーズビキニ紅[In]が選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Dancer Bikini Crimson [In]\".\nOnly usable on female characters."
 	}
 ]

--- a/json/Item_InnerWear_Female.txt
+++ b/json/Item_InnerWear_Female.txt
@@ -2501,7 +2501,7 @@
 	{
 		"assign": "3370391",
 		"jp_text": "ビハインドザダスク雅[In]",
-		"tr_text": "Behind The Dusk Elegant [In]",
+		"tr_text": "Behind The Dusk Elegance [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nビハインドザダスク雅[In]が選択可能。\n女性のみ使用可能。",
 		"tr_explain": ""
 	},

--- a/json/Item_InnerWear_Male.txt
+++ b/json/Item_InnerWear_Male.txt
@@ -1418,83 +1418,83 @@
 		"jp_text": "ペイントタンク[In]",
 		"tr_text": "Painted Tank Top [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360222",
 		"jp_text": "ペイントタンク夜[In]",
 		"tr_text": "Painted Tank Top Night [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク夜[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top Night [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360223",
 		"jp_text": "ペイントタンク雪[In]",
 		"tr_text": "Painted Tank Top Snow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク雪[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top Snow [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360224",
 		"jp_text": "ペイントタンク月[In]",
 		"tr_text": "Painted Tank Top Moon [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク月[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top Moon [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360225",
 		"jp_text": "ペイントタンク影[In]",
 		"tr_text": "Painted Tank Top Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク影[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top Shadow [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360226",
 		"jp_text": "ペイントタンク桜[In]",
 		"tr_text": "Painted Tank Top Sakura [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nペイントタンク桜[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Painted Tank Top Sakura [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360227",
 		"jp_text": "スミシークロース[In]",
 		"tr_text": "Smithy Clothes [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360228",
 		"jp_text": "スミシークロース雪[In]",
 		"tr_text": "Smithy Clothes Snow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース雪[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes Snow [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360229",
 		"jp_text": "スミシークロース影[In]",
 		"tr_text": "Smithy Clothes Shadow [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース影[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes Shadow [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360230",
 		"jp_text": "スミシークロース海[In]",
 		"tr_text": "Smithy Clothes Sea [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース海[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes Sea [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360231",
 		"jp_text": "スミシークロース紅[In]",
 		"tr_text": "Smithy Clothes Crimson [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース紅[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes Crimson [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360232",
 		"jp_text": "スミシークロース葉[In]",
 		"tr_text": "Smithy Clothes Leaf [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nスミシークロース葉[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the new innerwear\n\"Smithy Clothes Leaf [In]\".\nOnly usable on male characters."
 	}
 ]

--- a/json/Item_InnerWear_Male.txt
+++ b/json/Item_InnerWear_Male.txt
@@ -772,9 +772,9 @@
 	{
 		"assign": "3360125",
 		"jp_text": "ヴァルザライズ雅[In]",
-		"tr_text": "Varza Rise Elegant [In]",
+		"tr_text": "Varza Rise Elegance [In]",
 		"jp_explain": "使用すると、新しいインナーウェアの\nヴァルザライズ雅[In]が選択可能。\n男性のみ使用可能。",
-		"tr_explain": "Unlocks the new innerwear\n\"Varza Rise Elegant [In]\".\nOnly usable on male characters."
+		"tr_explain": "Unlocks the new innerwear\n\"Varza Rise Elegance [In]\".\nOnly usable on male characters."
 	},
 	{
 		"assign": "3360126",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -19490,9 +19490,9 @@
 	{
 		"assign": "3803008",
 		"jp_text": "エレガントウィング",
-		"tr_text": "Elegance Wings",
+		"tr_text": "Elegant Wings",
 		"jp_explain": "使用すると、新しいアクセサリーの\nエレガントウィングが選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Elegance Wings\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Elegant Wings\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803009",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -1213,9 +1213,9 @@
 	{
 		"assign": "380179",
 		"jp_text": "アルフマスク雅",
-		"tr_text": "Alph Mask Elegant",
+		"tr_text": "Alph Mask Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアルフマスク雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Alph Mask Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Alph Mask Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "380180",
@@ -6512,9 +6512,9 @@
 	{
 		"assign": "3801023",
 		"jp_text": "アルゴンクラウン雅",
-		"tr_text": "Argon Crown Elegant",
+		"tr_text": "Argon Crown Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアルゴンクラウン雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Argon Crown Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Argon Crown Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801024",
@@ -6526,9 +6526,9 @@
 	{
 		"assign": "3801025",
 		"jp_text": "アリシアサークレット雅",
-		"tr_text": "Alicia Circlet Elegant",
+		"tr_text": "Alicia Circlet Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアリシアサークレット雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Alicia Circlet Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Alicia Circlet Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801026",
@@ -6540,9 +6540,9 @@
 	{
 		"assign": "3801027",
 		"jp_text": "カグヤカンザシ雅",
-		"tr_text": "Kaguya Hairpin Elegant",
+		"tr_text": "Kaguya Hairpin Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nカグヤカンザシ雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Kaguya Hairpin Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Kaguya Hairpin Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801028",
@@ -6554,9 +6554,9 @@
 	{
 		"assign": "3801029",
 		"jp_text": "カムイズキン雅",
-		"tr_text": "Kamui Hood Elegant",
+		"tr_text": "Kamui Hood Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nカムイズキン雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Kamui Hood Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Kamui Hood Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801030",
@@ -7590,9 +7590,9 @@
 	{
 		"assign": "3801179",
 		"jp_text": "キャナリィリボン雅",
-		"tr_text": "Canary Ribbon Elegant",
+		"tr_text": "Canary Ribbon Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nキャナリィリボン雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Canary Ribbon Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Canary Ribbon Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801180",
@@ -7604,9 +7604,9 @@
 	{
 		"assign": "3801181",
 		"jp_text": "ロビンキャップ雅",
-		"tr_text": "Robin Cap Elegant",
+		"tr_text": "Robin Cap Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nロビンキャップ雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Robin Cap Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Robin Cap Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801182",
@@ -9459,9 +9459,9 @@
 	{
 		"assign": "3801457",
 		"jp_text": "コレットキャップ雅",
-		"tr_text": "Colette Cap Elegant",
+		"tr_text": "Colette Cap Elegance",
 		"jp_explain": "使用すると、新しいアクセサリーの\nコレットキャップ雅が選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Colette Cap Elegant\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Colette Cap Elegance\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3801458",
@@ -19490,9 +19490,9 @@
 	{
 		"assign": "3803008",
 		"jp_text": "エレガントウィング",
-		"tr_text": "Elegant Wings",
+		"tr_text": "Elegance Wings",
 		"jp_explain": "使用すると、新しいアクセサリーの\nエレガントウィングが選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Elegant Wings\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Elegance Wings\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803009",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -14998,7 +14998,7 @@
 		"jp_text": "アクセルバイザーＢ",
 		"tr_text": "Accel Visor B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアクセルバイザーＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Accel Visor B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3802315",
@@ -20731,21 +20731,21 @@
 		"jp_text": "アクセルガードＢ",
 		"tr_text": "Accel Guard B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアクセルガードＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Accel Guard B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803203",
 		"jp_text": "レーススカーフＢ　黒",
 		"tr_text": "Black Lace Scarf B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nレーススカーフＢ　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Lace Scarf B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803204",
 		"jp_text": "ヴィヴィアンパニッシャーＢ",
 		"tr_text": "Vivienne Punisher B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nヴィヴィアンパニッシャーＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Vivienne Punisher B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803205",
@@ -20766,14 +20766,14 @@
 		"jp_text": "三連星ピアスＢ",
 		"tr_text": "Three Star Earrings B",
 		"jp_explain": "使用すると、新しいアクセサリーの\n三連星ピアスＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Three Star Earrings B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803208",
 		"jp_text": "ロングノーズマスク　金",
 		"tr_text": "Gold Long Nose Mask",
 		"jp_explain": "使用すると、新しいアクセサリーの\nロングノーズマスク　金が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Gold Long Nose Mask\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803209",
@@ -20843,14 +20843,14 @@
 		"jp_text": "ラビットガスマスク　黒",
 		"tr_text": "Black Rabbit Gas Mask",
 		"jp_explain": "使用すると、新しいアクセサリーの\nラビットガスマスク　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Rabbit Gas Mask\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803219",
 		"jp_text": "ラビットガスマスク　白",
 		"tr_text": "White Rabbit Gas Mask",
 		"jp_explain": "使用すると、新しいアクセサリーの\nラビットガスマスク　白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"White Rabbit Gas Mask\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803220",
@@ -20864,63 +20864,63 @@
 		"jp_text": "ダスクマフラー",
 		"tr_text": "Dusk Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\nダスクマフラーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Dusk Scarf\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803222",
 		"jp_text": "ダスクスカート",
 		"tr_text": "Dusk Skirt",
 		"jp_explain": "使用すると、新しいアクセサリーの\nダスクスカートが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Dusk Skirt\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803223",
 		"jp_text": "アークマカチューシャ",
 		"tr_text": "Arkuma Headband",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアークマカチューシャが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Arkuma Headband\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803224",
 		"jp_text": "アークマシュシュ",
 		"tr_text": "Arkuma Scrunchie",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアークマシュシュが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Arkuma Scrunchie\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803225",
 		"jp_text": "ショルダーキャノンＡ",
 		"tr_text": "Shoulder Cannon A",
 		"jp_explain": "使用すると、新しいアクセサリーの\nショルダーキャノンＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Shoulder Cannon A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803226",
 		"jp_text": "ショルダーキャノンＢ",
 		"tr_text": "Shoulder Cannon B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nショルダーキャノンＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Shoulder Cannon B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803227",
 		"jp_text": "メタルクローＬ",
 		"tr_text": "Metal Claw L",
 		"jp_explain": "使用すると、新しいアクセサリーの\nメタルクローＬが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Metal Claw L\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803228",
 		"jp_text": "メタルクローＲ",
 		"tr_text": "Metal Claw R",
 		"jp_explain": "使用すると、新しいアクセサリーの\nメタルクローＲが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Metal Claw R\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803229",
 		"jp_text": "フォトンラジエーター",
 		"tr_text": "Photon Radiator",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフォトンラジエーターが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Photon Radiator\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803230",
@@ -20976,21 +20976,21 @@
 		"jp_text": "細ベルト　白",
 		"tr_text": "White Small Belt",
 		"jp_explain": "使用すると、新しいアクセサリーの\n細ベルト　白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"White Small Belt\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803238",
 		"jp_text": "細ベルト　黒",
 		"tr_text": "Black Small Belt",
 		"jp_explain": "使用すると、新しいアクセサリーの\n細ベルト　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Small Belt\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803239",
 		"jp_text": "細ベルト　茶",
 		"tr_text": "Brown Small Belt",
 		"jp_explain": "使用すると、新しいアクセサリーの\n細ベルト　茶が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Brown Small Belt\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803240",
@@ -21025,28 +21025,28 @@
 		"jp_text": "首領マフラー",
 		"tr_text": "Boss Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\n首領マフラーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Boss Scarf\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803245",
 		"jp_text": "首領マフラー　黒",
 		"tr_text": "Black Boss Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\n首領マフラー　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Boss Scarf\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803246",
 		"jp_text": "首領マフラー　白",
 		"tr_text": "White Boss Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\n首領マフラー　白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"White Boss Scarf\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803247",
 		"jp_text": "首領マフラー　赤",
 		"tr_text": "Red Boss Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\n首領マフラー　赤が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Red Boss Scarf\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803248",
@@ -21088,21 +21088,21 @@
 		"jp_text": "フィルディアパーツ",
 		"tr_text": "Fildia Parts",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフィルディアパーツが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Fildia Parts\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803254",
 		"jp_text": "イズナの髪飾り",
 		"tr_text": "Izuna Hair Ornament",
 		"jp_explain": "使用すると、新しいアクセサリーの\nイズナの髪飾りが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Izuna Hair Ornament\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803255",
 		"jp_text": "ルティナの髪飾り",
 		"tr_text": "Lutina Hair Ornament",
 		"jp_explain": "使用すると、新しいアクセサリーの\nルティナの髪飾りが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Lutina Hair Ornament\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803257",
@@ -21170,253 +21170,253 @@
 	{
 		"assign": "3803266",
 		"jp_text": "肩乗せお雛様リリーパ",
-		"tr_text": "Shoulder Riding Lillipan",
+		"tr_text": "Shoulder Empress Lillipan",
 		"jp_explain": "使用すると、新しいアクセサリーの\n肩乗せお雛様リリーパが選択可能。",
-		"tr_explain": "By using this ticket, the accessory\n\"Shoulder Riding Lillipan\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the accessory\n\"Shoulder Empress Lillipan\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803267",
 		"jp_text": "肩乗せお内裏様リリーパ",
-		"tr_text": "",
+		"tr_text": "Shoulder Emperor Lillipan",
 		"jp_explain": "使用すると、新しいアクセサリーの\n肩乗せお内裏様リリーパが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Shoulder Emperor Lillipan\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803268",
 		"jp_text": "サイドシールドＢ",
 		"tr_text": "Side Shields B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nサイドシールドＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Side Shields B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803269",
 		"jp_text": "リボンカチューシャ　橙",
 		"tr_text": "Orange Ribbon Headband",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリボンカチューシャ　橙が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Orange Ribbon Headband\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803270",
 		"jp_text": "ゴシックメイドブリムＢ",
 		"tr_text": "Gothic Maid Brim B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nゴシックメイドブリムＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Gothic Maid Brim B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803271",
 		"jp_text": "ゴシックメイドリボンＢ",
 		"tr_text": "Gothic Maid Ribbon B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nゴシックメイドリボンＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Gothic Maid Ribbon B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803272",
 		"jp_text": "スケアードグラスＢ",
 		"tr_text": "Scared Glasses B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスケアードグラスＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Scared Glasses B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803273",
 		"jp_text": "トゲトゲレザーマスクＢ",
 		"tr_text": "Spiked Leather Mask B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nトゲトゲレザーマスクＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Spiked Leather Mask B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803274",
 		"jp_text": "アームクローＢ　Ｌ",
-		"tr_text": "",
+		"tr_text": "Arm Claw B L",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアームクローＢ　Ｌが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Arm Claw B L\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803275",
 		"jp_text": "アームクローＢ　Ｒ",
-		"tr_text": "",
+		"tr_text": "Arm Claw B R",
 		"jp_explain": "使用すると、新しいアクセサリーの\nアームクローＢ　Ｒが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Arm Claw B R\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803276",
 		"jp_text": "リコリスコサージュ",
 		"tr_text": "Lycoris Corsage",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリコリスコサージュが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Lycoris Corsage\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803277",
 		"jp_text": "リコリスコサージュ　赤",
 		"tr_text": "Red Lycoris Corsage",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリコリスコサージュ　赤が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Red Lycoris Corsage\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803278",
 		"jp_text": "リコリスコサージュ　白",
 		"tr_text": "White Lycoris Corsage",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリコリスコサージュ　白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"White Lycoris Corsage\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803279",
 		"jp_text": "リコリスコサージュ　黒",
 		"tr_text": "Black Lycoris Corsage",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリコリスコサージュ　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Lycoris Corsage\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803280",
 		"jp_text": "ミトンガントレット",
 		"tr_text": "Mitten Gauntlets",
 		"jp_explain": "使用すると、新しいアクセサリーの\nミトンガントレットが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Mitten Gauntlets\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803281",
 		"jp_text": "ミトンガントレット　黒",
 		"tr_text": "Black Mitten Gauntlets",
 		"jp_explain": "使用すると、新しいアクセサリーの\nミトンガントレット　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Mitten Gauntlets\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803282",
 		"jp_text": "ミトンガントレット　銀",
 		"tr_text": "Silver Mitten Gauntlets",
 		"jp_explain": "使用すると、新しいアクセサリーの\nミトンガントレット　銀が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Silver Mitten Gauntlets\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803283",
 		"jp_text": "ミトンガントレット　金",
 		"tr_text": "Gold Mitten Gauntlets",
 		"jp_explain": "使用すると、新しいアクセサリーの\nミトンガントレット　金が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Gold Mitten Gauntlets\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803284",
 		"jp_text": "トレッキングブーツ　茶",
 		"tr_text": "Brown Trekking Boots",
 		"jp_explain": "使用すると、新しいアクセサリーの\nトレッキングブーツ　茶が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Brown Trekking Boots\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803285",
 		"jp_text": "トレッキングブーツ　黒",
 		"tr_text": "Black Trekking Boots",
 		"jp_explain": "使用すると、新しいアクセサリーの\nトレッキングブーツ　黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Black Trekking Boots\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803286",
 		"jp_text": "トレッキングブーツ　灰",
 		"tr_text": "Gray Trekking Boots",
 		"jp_explain": "使用すると、新しいアクセサリーの\nトレッキングブーツ　灰が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Gray Trekking Boots\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803287",
 		"jp_text": "クローバークラウン　白",
 		"tr_text": "White Clover Crown",
 		"jp_explain": "使用すると、新しいアクセサリーの\nクローバークラウン　白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"White Clover Crown\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803288",
 		"jp_text": "クローバークラウン　桃",
 		"tr_text": "Peach Clover Crown",
 		"jp_explain": "使用すると、新しいアクセサリーの\nクローバークラウン　桃が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Peach Clover Crown\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803289",
 		"jp_text": "リアブースター",
 		"tr_text": "Rear Booster",
 		"jp_explain": "使用すると、新しいアクセサリーの\nリアブースターが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Rear Booster\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803290",
 		"jp_text": "スミスヘッドバンド",
 		"tr_text": "Smith Headband",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスミスヘッドバンドが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Smith Headband\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803291",
 		"jp_text": "スミスゴーグル",
 		"tr_text": "Smith Goggles",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスミスゴーグルが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Smith Goggles\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803292",
 		"jp_text": "スミシーマスクＡ",
 		"tr_text": "Smithy Mask A",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスミシーマスクＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Smithy Mask A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803293",
 		"jp_text": "スミシーマスクＢ",
 		"tr_text": "Smithy Mask B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスミシーマスクＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Smithy Mask B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803294",
 		"jp_text": "腰下げバンダナ",
 		"tr_text": "Waist Hung Bandana",
 		"jp_explain": "使用すると、新しいアクセサリーの\n腰下げバンダナが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Waist Hung Bandana\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803295",
 		"jp_text": "ジオメトリウィング",
 		"tr_text": "Geometric Wings",
 		"jp_explain": "使用すると、新しいアクセサリーの\nジオメトリウィングが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Geometric Wings\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803296",
 		"jp_text": "頭乗りラッピーちゃん",
-		"tr_text": "",
+		"tr_text": "Head Riding Rappy",
 		"jp_explain": "使用すると、新しいアクセサリーの\n頭乗りラッピーちゃんが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Head Riding Rappy\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803297",
 		"jp_text": "頭乗りラッピーくん",
-		"tr_text": "",
+		"tr_text": "Head Riding Kid Rappy",
 		"jp_explain": "使用すると、新しいアクセサリーの\n頭乗りラッピーくんが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Head Riding Kid Rappy\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803298",
 		"jp_text": "ステラヘッドギア２",
 		"tr_text": "Stella Headgear 2",
 		"jp_explain": "使用すると、新しいアクセサリーの\nステラヘッドギア２が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Stella Headgear 2\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803299",
 		"jp_text": "ステラアームギア",
 		"tr_text": "Stella Arm Gear",
 		"jp_explain": "使用すると、新しいアクセサリーの\nステラアームギアが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Stella Arm Gear\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803300",
 		"jp_text": "ステラリストギア",
 		"tr_text": "Stella Wrist Gear",
 		"jp_explain": "使用すると、新しいアクセサリーの\nステラリストギアが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Stella Wrist Gear\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3803307",
 		"jp_text": "スターダスト",
-		"tr_text": "",
+		"tr_text": "Stardust",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスターダストが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the accessory\n\"Stardust\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_BodyPaint.txt
+++ b/json/Item_Stack_BodyPaint.txt
@@ -2839,14 +2839,14 @@
 		"jp_text": "ダスクサイハイソックス",
 		"tr_text": "Dusk Thigh High Socks",
 		"jp_explain": "チケットを使用すると、ボディペイント\nダスクサイハイソックスが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the body paint\n\"Dusk Thigh High Socks\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3290440",
 		"jp_text": "チャームサイハイソックス",
 		"tr_text": "Charm Thigh High Socks",
 		"jp_explain": "チケットを使用すると、ボディペイント\nチャームサイハイソックスが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the body paint\n\"Charm Thigh High Socks\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3290441",
@@ -2867,13 +2867,13 @@
 		"jp_text": "ステラアームウェア",
 		"tr_text": "Stella Arm Wear",
 		"jp_explain": "チケットを使用すると、ボディペイント\nステラアームウェアが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the body paint\n\"Stella Arm Wear\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3290444",
 		"jp_text": "スミシータトゥー",
 		"tr_text": "Smithy Tattoo",
 		"jp_explain": "チケットを使用すると、ボディペイント\nスミシータトゥーが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the body paint\n\"Smithy Tattoo\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Eye.txt
+++ b/json/Item_Stack_Eye.txt
@@ -1166,13 +1166,13 @@
 		"jp_text": "マンガ風瞳Ｈ　大",
 		"tr_text": "Manga Style Eyes H L",
 		"jp_explain": "チケットを使用すると、新しい瞳の\nマンガ風瞳Ｈ　大が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the eyes\n\"Manga Style Eyes H L\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3260169",
 		"jp_text": "マンガ風瞳Ｈ　小",
 		"tr_text": "Manga Style Eyes H S",
 		"jp_explain": "チケットを使用すると、新しい瞳の\nマンガ風瞳Ｈ　小が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the eyes\n\"Manga Style Eyes H S\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_FacePaint.txt
+++ b/json/Item_Stack_FacePaint.txt
@@ -1038,9 +1038,9 @@
 	{
 		"assign": "3250155",
 		"jp_text": "ブルーノのヒゲ",
-		"tr_text": "Bruno’s Beard",
+		"tr_text": "Bruno's Beard",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nブルーノのヒゲが選択可能。\n男性のみ使用可能。",
-		"tr_explain": "By using this ticket, the makeup\n\"Bruno’s Beard\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the makeup\n\"Bruno's Beard\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3250156",
@@ -1292,6 +1292,6 @@
 		"jp_text": "スミスメイク",
 		"tr_text": "Smith Makeup",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nスミスメイクが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the makeup\n\"Smith Makeup\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -1180,14 +1180,14 @@
 		"jp_text": "セイルヘアー",
 		"tr_text": "Sail Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nセイルヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Sail Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Sail Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150196",
 		"jp_text": "ルティナヘアー",
 		"tr_text": "Lutina Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nルティナヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Lutina Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Lutina Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150197",
@@ -3903,69 +3903,69 @@
 		"jp_text": "ダスクヘアー",
 		"tr_text": "Dusk Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nダスクヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Dusk Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Dusk Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150662",
 		"jp_text": "チャームヘアー",
 		"tr_text": "Charm Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nチャームヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Charm Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Charm Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150663",
 		"jp_text": "イズナヘアー",
 		"tr_text": "Izuna Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nイズナヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Izuna Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Izuna Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150664",
 		"jp_text": "フィルディアヘアー",
 		"tr_text": "Fildia Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nフィルディアヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Fildia Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Fildia Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150665",
 		"jp_text": "ヴィテスシュタルクヘッド",
 		"tr_text": "Vitesse Stark Head",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nヴィテスシュタルクヘッドが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Vitesse Stark Head"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Vitesse Stark Head\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150666",
 		"jp_text": "ジェネツインテール２",
 		"tr_text": "Gene Twin Tail 2",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nジェネツインテール２が選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Gene Twin Tail 2"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Gene Twin Tail 2\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150667",
 		"jp_text": "スミスヘアー",
 		"tr_text": "Smith Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミスヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Smith Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Smith Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150668",
 		"jp_text": "スミシーヘアー",
 		"tr_text": "Smithy Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミシーヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Smithy Hair"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Smithy Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150669",
 		"jp_text": "コープスフード",
 		"tr_text": "Corpse Hood",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nコープスフードが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Corpse Hood"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Corpse Hood\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150670",
 		"jp_text": "内巻きロング",
 		"tr_text": "Inwardly Curled Long",
 		"jp_explain": "チケットを使用すると、新しい髪型の\n内巻きロングが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Inwardly Curled Long"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n"Inwardly Curled Long\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -1180,14 +1180,14 @@
 		"jp_text": "セイルヘアー",
 		"tr_text": "Sail Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nセイルヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Sail Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150196",
 		"jp_text": "ルティナヘアー",
 		"tr_text": "Lutina Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nルティナヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Lutina Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150197",
@@ -3903,69 +3903,69 @@
 		"jp_text": "ダスクヘアー",
 		"tr_text": "Dusk Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nダスクヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Dusk Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150662",
 		"jp_text": "チャームヘアー",
 		"tr_text": "Charm Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nチャームヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Charm Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150663",
 		"jp_text": "イズナヘアー",
 		"tr_text": "Izuna Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nイズナヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Izuna Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150664",
 		"jp_text": "フィルディアヘアー",
 		"tr_text": "Fildia Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nフィルディアヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Fildia Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150665",
 		"jp_text": "ヴィテスシュタルクヘッド",
 		"tr_text": "Vitesse Stark Head",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nヴィテスシュタルクヘッドが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Vitesse Stark Head"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150666",
 		"jp_text": "ジェネツインテール２",
 		"tr_text": "Gene Twin Tail 2",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nジェネツインテール２が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Gene Twin Tail 2"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150667",
 		"jp_text": "スミスヘアー",
 		"tr_text": "Smith Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミスヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Smith Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150668",
 		"jp_text": "スミシーヘアー",
 		"tr_text": "Smithy Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミシーヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Smithy Hair"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150669",
 		"jp_text": "コープスフード",
 		"tr_text": "Corpse Hood",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nコープスフードが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Corpse Hood"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150670",
 		"jp_text": "内巻きロング",
 		"tr_text": "Inwardly Curled Long",
 		"jp_explain": "チケットを使用すると、新しい髪型の\n内巻きロングが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the hairstyle\n"Inwardly Curled Long"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -380,9 +380,9 @@
 	{
 		"assign": "315057",
 		"jp_text": "クラテルヴェール影",
-		"tr_text": "Creater Veil Shadow",
+		"tr_text": "Crater Veil Shadow",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nクラテルヴェール影が選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Creater Veil Shadow\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Crater Veil Shadow\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "315058",

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -1180,14 +1180,14 @@
 		"jp_text": "セイルヘアー",
 		"tr_text": "Sail Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nセイルヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Sail Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Sail Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150196",
 		"jp_text": "ルティナヘアー",
 		"tr_text": "Lutina Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nルティナヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Lutina Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Lutina Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150197",
@@ -3903,69 +3903,69 @@
 		"jp_text": "ダスクヘアー",
 		"tr_text": "Dusk Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nダスクヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Dusk Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Dusk Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150662",
 		"jp_text": "チャームヘアー",
 		"tr_text": "Charm Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nチャームヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Charm Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Charm Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150663",
 		"jp_text": "イズナヘアー",
 		"tr_text": "Izuna Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nイズナヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Izuna Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Izuna Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150664",
 		"jp_text": "フィルディアヘアー",
 		"tr_text": "Fildia Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nフィルディアヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Fildia Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Fildia Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150665",
 		"jp_text": "ヴィテスシュタルクヘッド",
 		"tr_text": "Vitesse Stark Head",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nヴィテスシュタルクヘッドが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Vitesse Stark Head\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Vitesse Stark Head\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150666",
 		"jp_text": "ジェネツインテール２",
 		"tr_text": "Gene Twin Tail 2",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nジェネツインテール２が選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Gene Twin Tail 2\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Gene Twin Tail 2\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150667",
 		"jp_text": "スミスヘアー",
 		"tr_text": "Smith Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミスヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Smith Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Smith Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150668",
 		"jp_text": "スミシーヘアー",
 		"tr_text": "Smithy Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスミシーヘアーが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Smithy Hair\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Smithy Hair\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150669",
 		"jp_text": "コープスフード",
 		"tr_text": "Corpse Hood",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nコープスフードが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Corpse Hood\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Corpse Hood\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3150670",
 		"jp_text": "内巻きロング",
 		"tr_text": "Inwardly Curled Long",
 		"jp_explain": "チケットを使用すると、新しい髪型の\n内巻きロングが選択可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n"Inwardly Curled Long\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the hairstyle\n\"Inwardly Curled Long\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Headparts.txt
+++ b/json/Item_Stack_Headparts.txt
@@ -1677,13 +1677,13 @@
 		"jp_text": "クリスト・ヘッド",
 		"tr_text": "Crysto Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nクリスト・ヘッドが選択可能。\nキャスト男性のみ使用可能。",
-		"tr_explain": "By using this ticket, the head\n"Crysto Head\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Crysto Head\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160262",
 		"jp_text": "マーヴ・ヘッド",
 		"tr_text": "Marv Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nマーヴ・ヘッドが選択可能。\nキャスト女性のみ使用可能。",
-		"tr_explain": "By using this ticket, the head\n"Marv Head\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Marv Head\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Headparts.txt
+++ b/json/Item_Stack_Headparts.txt
@@ -1677,13 +1677,13 @@
 		"jp_text": "クリスト・ヘッド",
 		"tr_text": "Crysto Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nクリスト・ヘッドが選択可能。\nキャスト男性のみ使用可能。",
-		"tr_explain": "By using this ticket, the head\n"Crysto Head"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n"Crysto Head\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160262",
 		"jp_text": "マーヴ・ヘッド",
 		"tr_text": "Marv Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nマーヴ・ヘッドが選択可能。\nキャスト女性のみ使用可能。",
-		"tr_explain": "By using this ticket, the head\n"Marv Head"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n"Marv Head\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Headparts.txt
+++ b/json/Item_Stack_Headparts.txt
@@ -1649,41 +1649,41 @@
 		"jp_text": "ヒュリオン・ヘッドＧＶ",
 		"tr_text": "Hurion Head GV",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nヒュリオン・ヘッドＧＶが選択可能。\nキャスト男性のみ使用可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Hurion Head GV\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Hurion Head GV\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160256",
 		"jp_text": "アコーディ・ヘッドＧＶ",
 		"tr_text": "Accordi Head GV",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nアコーディ・ヘッドＧＶが選択可能。\nキャスト男性のみ使用可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Accordi Head GV\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Accordi Head GV\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160257",
 		"jp_text": "ケルビナ・ヘッドＧＶ",
 		"tr_text": "Cherubina Head GV",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nケルビナ・ヘッドＧＶが選択可能。\nキャスト女性のみ使用可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Cherubina Head GV\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Cherubina Head GV\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160258",
 		"jp_text": "デルマーチ・ヘッドＧＶ",
 		"tr_text": "Delmarch Head GV",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nデルマーチ・ヘッドＧＶが選択可能。\nキャスト女性のみ使用可能。",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Delmarch Head GV\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the head\n\"Delmarch Head GV\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160259",
 		"jp_text": "クリスト・ヘッド",
 		"tr_text": "Crysto Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nクリスト・ヘッドが選択可能。\nキャスト男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the head\n"Crysto Head"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3160262",
 		"jp_text": "マーヴ・ヘッド",
 		"tr_text": "Marv Head",
 		"jp_explain": "チケットを使用すると、新しい頭部の\nマーヴ・ヘッドが選択可能。\nキャスト女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the head\n"Marv Head"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -33966,44 +33966,44 @@
 	{
 		"assign": "33005065",
 		"jp_text": "☆ビハインドザダスク箱１",
-		"tr_text": "☆Behind the Dusk Box 1",
+		"tr_text": "☆Behind The Dusk Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク[Ba]」\n「ビハインドザダスク[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk [Ba]]\n[Behind the Dusk [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk [Ba]]\n[Behind The Dusk [In]]"
 	},
 	{
 		"assign": "33005066",
 		"jp_text": "☆ビハインドザダスク箱２",
-		"tr_text": "☆Behind the Dusk Box 2",
+		"tr_text": "☆Behind The Dusk Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク雪[Ba]」\n「ビハインドザダスク雅[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Snow [Ba]]\n[Behind the Dusk Elegance [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk Snow [Ba]]\n[Behind The Dusk Elegance [In]]"
 	},
 	{
 		"assign": "33005067",
 		"jp_text": "☆ビハインドザダスク箱３",
-		"tr_text": "☆Behind the Dusk Box 3",
+		"tr_text": "☆Behind The Dusk Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク夜[Ba]」\n「ビハインドザダスク夜[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Night [Ba]]\n[Behind the Dusk Night [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk Night [Ba]]\n[Behind The Dusk Night [In]]"
 	},
 	{
 		"assign": "33005068",
 		"jp_text": "☆ビハインドザダスク箱４",
-		"tr_text": "☆Behind the Dusk Box 4",
+		"tr_text": "☆Behind The Dusk Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク影[Ba]」\n「ビハインドザダスク月[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Shadow [Ba]]\n[Behind the Dusk Moon [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk Shadow [Ba]]\n[Behind The Dusk Moon [In]]"
 	},
 	{
 		"assign": "33005069",
 		"jp_text": "☆ビハインドザダスク箱５",
-		"tr_text": "☆Behind the Dusk Box 5",
+		"tr_text": "☆Behind The Dusk Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク海[Ba]」\n「ビハインドザダスク海[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Sea [Ba]]\n[Behind the Dusk Sea [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk Sea [Ba]]\n[Behind The Dusk Sea [In]]"
 	},
 	{
 		"assign": "33005070",
 		"jp_text": "☆ビハインドザダスク箱６",
-		"tr_text": "☆Behind the Dusk Box 6",
+		"tr_text": "☆Behind The Dusk Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク紅[Ba]」\n「ビハインドザダスク影[In]」",
-		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Crimson [Ba]]\n[Behind the Dusk Shadow [In]]"
+		"tr_explain": "Use to receive the following items:\n[Behind The Dusk [Ou]]\n[Behind The Dusk Crimson [Ba]]\n[Behind The Dusk Shadow [In]]"
 	},
 	{
 		"assign": "33005071",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -1971,7 +1971,7 @@
 		"jp_text": "ラストアルゴン雅セット",
 		"tr_text": "Last Argon Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ラストアルゴン雅」\n「アルゴンクラウン雅」",
-		"tr_explain": "Use to receive the following items:\n[Last Argon Elegance]\n[Argon Crown Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Last Argon Elegance]\n[Argon Crown Elegance]"
 	},
 	{
 		"assign": "3300282",
@@ -2111,7 +2111,7 @@
 		"jp_text": "セラスアリシア雅セット",
 		"tr_text": "Seras Alicia Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「セラスアリシア雅」\n「アリシアサークレット雅」",
-		"tr_explain": "Use to receive the following items:\n[Seras Alicia Elegance]\n[Alicia Circlet Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Seras Alicia Elegance]\n[Alicia Circlet Elegance]"
 	},
 	{
 		"assign": "3300302",
@@ -2272,7 +2272,7 @@
 		"jp_text": "カムイフウビ雅セット",
 		"tr_text": "Kamui Fuubi Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「カムイフウビ雅」\n「カムイズキン雅」",
-		"tr_explain": "Use to receive the following items:\n[Kamui Fubi Elegance]\n[Kamui Hood Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Kamui Fubi Elegance]\n[Kamui Hood Elegance]"
 	},
 	{
 		"assign": "3300325",
@@ -2419,7 +2419,7 @@
 		"jp_text": "カグヤヒラリ雅セット",
 		"tr_text": "Kaguya Hirari Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「カグヤヒラリ雅」\n「カグヤカンザシ雅」",
-		"tr_explain": "Use to receive the following items:\n[Kaguya Hirari Elegance]\n[Kaguya Hairpin Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Kaguya Hirari Elegance]\n[Kaguya Hairpin Elegance]"
 	},
 	{
 		"assign": "3300346",
@@ -4113,7 +4113,7 @@
 		"jp_text": "ティンクルロビン雅セット",
 		"tr_text": "Twinkle Robin Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ティンクルロビン雅」\n「ロビンキャップ雅」",
-		"tr_explain": "Use to receive the following items:\n[Twinkle Robin Elegance]\n[Robin Cap Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Twinkle Robin Elegance]\n[Robin Cap Elegance]"
 	},
 	{
 		"assign": "3300785",
@@ -4302,7 +4302,7 @@
 		"jp_text": "キャナリィピース雅セット",
 		"tr_text": "Canary Piece Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「キャナリィピース雅」\n「キャナリィリボン雅」",
-		"tr_explain": "Use to receive the following items:\n[Canary Piece Elegance]\n[Canary Ribbon Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Canary Piece Elegance]\n[Canary Ribbon Elegance]"
 	},
 	{
 		"assign": "3300812",
@@ -7732,7 +7732,7 @@
 		"jp_text": "ストアコレット雅セット",
 		"tr_text": "Stoa Colette Elegance Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ストアコレット雅」\n「コレットキャップ雅」",
-		"tr_explain": "Use to receive the following items:\n[Stoa Colette Elegance]\n[Colette Cap Elegant]"
+		"tr_explain": "Use to receive the following items:\n[Stoa Colette Elegance]\n[Colette Cap Elegance]"
 	},
 	{
 		"assign": "33001302",
@@ -23636,7 +23636,7 @@
 		"jp_text": "☆ヴァルザライズセット３",
 		"tr_text": "☆Varza Rise Set 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ヴァルザライズ[Ou]」\n「ヴァルザライズ雅[Ba]」\n「ヴァルザライズ雅[In]」",
-		"tr_explain": "Use to receive the following items:\n[Varza Rise [Ou]]\n[Varza Rise Elegance [Ba]]\n[Varza Rise Elegant [In]]"
+		"tr_explain": "Use to receive the following items:\n[Varza Rise [Ou]]\n[Varza Rise Elegance [Ba]]\n[Varza Rise Elegance [In]]"
 	},
 	{
 		"assign": "33003584",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -34164,42 +34164,42 @@
 		"jp_text": "☆コープスパーカーＭ箱１",
 		"tr_text": "☆Corpse Parka M Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ[Ba]」\n「ペイントタンク[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo [Ba]]\n[Painted Tank Top [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo [Ba]]\n[Painted Tank Top [In]] +1 other"
 	},
 	{
 		"assign": "33005094",
 		"jp_text": "☆コープスパーカーＭ箱２",
 		"tr_text": "☆Corpse Parka M Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ葉[Ba]」\n「ペイントタンク夜[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Leaf [Ba]]\n[Painted Tank Top Night [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Leaf [Ba]]\n[Painted Tank Top Night [In]] +1 other"
 	},
 	{
 		"assign": "33005095",
 		"jp_text": "☆コープスパーカーＭ箱３",
 		"tr_text": "☆Corpse Parka M Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ海[Ba]」\n「ペイントタンク雪[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sea [Ba]]\n[Painted Tank Top Snow [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sea [Ba]]\n[Painted Tank Top Snow [In]] +1 other"
 	},
 	{
 		"assign": "33005096",
 		"jp_text": "☆コープスパーカーＭ箱４",
 		"tr_text": "☆Corpse Parka M Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ陽[Ba]」\n「ペイントタンク月[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sun [Ba]]\n[Painted Tank Top Moon [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sun [Ba]]\n[Painted Tank Top Moon [In]] +1 other"
 	},
 	{
 		"assign": "33005097",
 		"jp_text": "☆コープスパーカーＭ箱５",
 		"tr_text": "☆Corpse Parka M Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ雪[Ba]」\n「ペイントタンク影[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Snow [Ba]]\n[Painted Tank Top Shadow [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Snow [Ba]]\n[Painted Tank Top Shadow [In]] +1 other"
 	},
 	{
 		"assign": "33005098",
 		"jp_text": "☆コープスパーカーＭ箱６",
 		"tr_text": "☆Corpse Parka M Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ影[Ba]」\n「ペイントタンク桜[In]」他一種",
-		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Shadow [Ba]]\n[Painted Tank Top Sakura [In]]\n +1 other"
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Shadow [Ba]]\n[Painted Tank Top Sakura [In]] +1 other"
 	},
 	{
 		"assign": "33005099",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -4349,7 +4349,7 @@
 	{
 		"assign": "3300818",
 		"jp_text": "ドロケイセット",
-		"tr_text": "",
+		"tr_text": "Cops and Robbers Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ＳＰベルト」\n「ガスマスクＣ」\n「ガスマスクＤ」",
 		"tr_explain": "Use to receive the following items:\n[SP Belt]\n[Gas Mask C]\n[Gas Mask D]"
 	},
@@ -33847,86 +33847,86 @@
 	{
 		"assign": "33005048",
 		"jp_text": "☆ノーブルロングコート箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005049",
 		"jp_text": "☆ノーブルロングコート雪箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Snow Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート雪」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat Snow]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005050",
 		"jp_text": "☆ノーブルロングコート紅箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Crimson Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート紅」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat Crimson]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005051",
 		"jp_text": "☆ノーブルロングコート夜箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Night Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート夜」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat Night]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005052",
 		"jp_text": "☆ノーブルロングコート栗箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Chestnut Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート栗」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat Chestnut]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005053",
 		"jp_text": "☆ノーブルロングコート葉箱",
-		"tr_text": "",
+		"tr_text": "☆Noble Long Coat Leaf Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ノーブルロングコート葉」\n「レーススカーフＢ　黒」\n「ロングノーズマスク　金」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Noble Long Coat Leaf]\n[Black Lace Scarf B]\n[Gold Long Nose Mask]"
 	},
 	{
 		"assign": "33005054",
 		"jp_text": "☆ミニダウンベストＭ箱１",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005055",
 		"jp_text": "☆ミニダウンベストＭ箱２",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005056",
 		"jp_text": "☆ミニダウンベストＭ箱３",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005057",
 		"jp_text": "☆ミニダウンベストＭ箱４",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005058",
 		"jp_text": "☆ミニダウンベストＭ箱５",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005059",
 		"jp_text": "☆ミニダウンベストＭ箱６",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest M Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＭ[Ou]」\n「細ベルト　黒」\n「首領マフラー　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest M [Ou]]\n[Black Small Belt]\n[Black Boss Scarf]"
 	},
 	{
 		"assign": "33005060",
@@ -33966,128 +33966,128 @@
 	{
 		"assign": "33005065",
 		"jp_text": "☆ビハインドザダスク箱１",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク[Ba]」\n「ビハインドザダスク[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk [Ba]]\n[Behind the Dusk [In]]"
 	},
 	{
 		"assign": "33005066",
 		"jp_text": "☆ビハインドザダスク箱２",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク雪[Ba]」\n「ビハインドザダスク雅[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Snow [Ba]]\n[Behind the Dusk Elegance [In]]"
 	},
 	{
 		"assign": "33005067",
 		"jp_text": "☆ビハインドザダスク箱３",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク夜[Ba]」\n「ビハインドザダスク夜[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Night [Ba]]\n[Behind the Dusk Night [In]]"
 	},
 	{
 		"assign": "33005068",
 		"jp_text": "☆ビハインドザダスク箱４",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク影[Ba]」\n「ビハインドザダスク月[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Shadow [Ba]]\n[Behind the Dusk Moon [In]]"
 	},
 	{
 		"assign": "33005069",
 		"jp_text": "☆ビハインドザダスク箱５",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク海[Ba]」\n「ビハインドザダスク海[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Sea [Ba]]\n[Behind the Dusk Sea [In]]"
 	},
 	{
 		"assign": "33005070",
 		"jp_text": "☆ビハインドザダスク箱６",
-		"tr_text": "",
+		"tr_text": "☆Behind the Dusk Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「ビハインドザダスク[Ou]」\n「ビハインドザダスク紅[Ba]」\n「ビハインドザダスク影[In]」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Behind the Dusk [Ou]]\n[Behind the Dusk Crimson [Ba]]\n[Behind the Dusk Shadow [In]]"
 	},
 	{
 		"assign": "33005071",
 		"jp_text": "☆ミニダウンベストＦ箱１",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005072",
 		"jp_text": "☆ミニダウンベストＦ箱２",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム雪[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim Snow [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005073",
 		"jp_text": "☆ミニダウンベストＦ箱３",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム夜[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim Night [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005074",
 		"jp_text": "☆ミニダウンベストＦ箱４",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム影[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim Shadow [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005075",
 		"jp_text": "☆ミニダウンベストＦ箱５",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム紅[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim Crimson [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005076",
 		"jp_text": "☆ミニダウンベストＦ箱６",
-		"tr_text": "",
+		"tr_text": "☆Mini Down Vest F Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンベストＦ[Ou]」\n「スエットミニデニム空[Ba]」\n「首領マフラー　赤」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Vest F [Ou]]\n[Sweat Mini Denim Sky [Ba]]\n[Red Boss Scarf]"
 	},
 	{
 		"assign": "33005077",
 		"jp_text": "アークマチャームセット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005078",
 		"jp_text": "アークマチャーム雪セット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム雪[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm Snow [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005079",
 		"jp_text": "アークマチャーム海セット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Sea Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム海[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm Sea [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005080",
 		"jp_text": "アークマチャーム桜セット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Sakura Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム桜[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm Sakura [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005081",
 		"jp_text": "アークマチャーム空セット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Sky Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム空[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm Sky [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005082",
 		"jp_text": "アークマチャーム紅セット",
-		"tr_text": "",
+		"tr_text": "Arkuma Charm Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマチャーム紅[Ba]」\n「アークマシュシュ」\n「チャームサイハイソックス」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Charm Crimson [Ba]]\n[Arkuma Scrunchie]\n[Charm Thigh High Socks]"
 	},
 	{
 		"assign": "33005083",
@@ -34115,7 +34115,7 @@
 		"jp_text": "☆ウールコートセットＢ",
 		"tr_text": "☆Wool Coat Set B",
 		"jp_explain": "以下のアイテムを獲得する。\n「ウールコート[Ou]」\n「ショートパンツ鋼[Ba]」\n「細ベルト　白」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Wool Coat [Ou]]\n[Shorts Steel [Ba]]\n[White Small Belt]"
 	},
 	{
 		"assign": "33005087",
@@ -34134,400 +34134,400 @@
 	{
 		"assign": "33005089",
 		"jp_text": "ダスクスタイルセット",
-		"tr_text": "",
+		"tr_text": "Dusk Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダスクヘアー」\n「ダスクマフラー」\n「ダスクスカート」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Dusk Hair]\n[Dusk Scarf]\n[Dusk Skirt] +1 other"
 	},
 	{
 		"assign": "33005090",
 		"jp_text": "チャームスタイルセット",
-		"tr_text": "",
+		"tr_text": "Charm Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「チャームヘアー」\n「アークマカチューシャ」\n「三連星ピアスＢ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Charm Hair]\n[Arkuma Headband]\n[Three Star Earrings B]"
 	},
 	{
 		"assign": "33005091",
 		"jp_text": "ミニダウンステッカー箱",
-		"tr_text": "",
+		"tr_text": "Mini Down Sticker Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ミニダウンステッカーＡ」\n「ミニダウンステッカーＢ」\n「ミニダウンステッカーＣ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Mini Down Sticker A]\n[Mini Down Sticker B]\n[Mini Down Sticker C]"
 	},
 	{
 		"assign": "33005092",
 		"jp_text": "アークマステッカーセット",
-		"tr_text": "",
+		"tr_text": "Arkuma Sticker Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「アークマステッカーＡ」\n「アークマステッカーＢ」\n「アークマステッカーＣ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Arkuma Sticker A]\n[Arkuma Sticker B]\n[Arkuma Sticker C]"
 	},
 	{
 		"assign": "33005093",
 		"jp_text": "☆コープスパーカーＭ箱１",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ[Ba]」\n「ペイントタンク[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo [Ba]]\n[Painted Tank Top [In]]\n +1 other"
 	},
 	{
 		"assign": "33005094",
 		"jp_text": "☆コープスパーカーＭ箱２",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ葉[Ba]」\n「ペイントタンク夜[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Leaf [Ba]]\n[Painted Tank Top Night [In]]\n +1 other"
 	},
 	{
 		"assign": "33005095",
 		"jp_text": "☆コープスパーカーＭ箱３",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ海[Ba]」\n「ペイントタンク雪[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sea [Ba]]\n[Painted Tank Top Snow [In]]\n +1 other"
 	},
 	{
 		"assign": "33005096",
 		"jp_text": "☆コープスパーカーＭ箱４",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ陽[Ba]」\n「ペイントタンク月[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Sun [Ba]]\n[Painted Tank Top Moon [In]]\n +1 other"
 	},
 	{
 		"assign": "33005097",
 		"jp_text": "☆コープスパーカーＭ箱５",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ雪[Ba]」\n「ペイントタンク影[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Snow [Ba]]\n[Painted Tank Top Shadow [In]]\n +1 other"
 	},
 	{
 		"assign": "33005098",
 		"jp_text": "☆コープスパーカーＭ箱６",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka M Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＭ[Ou]」\n「上なしカーゴパンツ影[Ba]」\n「ペイントタンク桜[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka M [Ou]]\n[Topless Cargo Shadow [Ba]]\n[Painted Tank Top Sakura [In]]\n +1 other"
 	},
 	{
 		"assign": "33005099",
 		"jp_text": "スミシークロースセット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース[Ba]」\n「スミシークロース[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes [Ba]]\n[Smithy Clothes [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005100",
 		"jp_text": "スミシークロース雪セット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース雪[Ba]」\n「スミシークロース雪[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes Snow [Ba]]\n[Smithy Clothes Snow [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005101",
 		"jp_text": "スミシークロース影セット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース影[Ba]」\n「スミシークロース影[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes Shadow [Ba]]\n[Smithy Clothes Shadow [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005102",
 		"jp_text": "スミシークロース海セット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Sea Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース海[Ba]」\n「スミシークロース海[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes Sea [Ba]]\n[Smithy Clothes Sea [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005103",
 		"jp_text": "スミシークロース紅セット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース紅[Ba]」\n「スミシークロース紅[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes Crimson [Ba]]\n[Smithy Clothes Crimson [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005104",
 		"jp_text": "スミシークロース葉セット",
-		"tr_text": "",
+		"tr_text": "Smithy Clothes Leaf Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシークロース葉[Ba]」\n「スミシークロース葉[In]」\n「スミシーマスクＡ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Clothes Leaf [Ba]]\n[Smithy Clothes Leaf [In]]\n[Smithy Mask A]"
 	},
 	{
 		"assign": "33005105",
 		"jp_text": "☆ＳジャンパーＭ影セット１",
-		"tr_text": "",
+		"tr_text": "☆S Jumper M Shadow Set 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ＳジャンパーＭ影[Ou]」\n「トゲトゲレザーマスクＢ」\n「トレッキングブーツ　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[S Jumper M Shadow [Ou]]\n[Spiked Leather Mask B]\n[Black Trekking Boots]"
 	},
 	{
 		"assign": "33005106",
 		"jp_text": "☆ＳジャンパーＭ影セット２",
-		"tr_text": "",
+		"tr_text": "☆S Jumper M Shadow Set 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ＳジャンパーＭ影[Ou]」\n「トゲトゲレザーマスクＢ」\n「トレッキングブーツ　黒」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[S Jumper M Shadow [Ou]]\n[Spiked Leather Mask B]\n[Black Trekking Boots]"
 	},
 	{
 		"assign": "33005107",
 		"jp_text": "☆スケアードフィッシュ茜箱",
-		"tr_text": "",
+		"tr_text": "☆Scared Fish Madder Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「スケアードフィッシュ茜」\n「スケアードグラスＢ」\n「ブルーノのヒゲ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Scared Fish Madder]\n[Scared Glasses B]\n[Bruno's Beard]"
 	},
 	{
 		"assign": "33005108",
 		"jp_text": "☆スケアードフィッシュ玄箱",
-		"tr_text": "",
+		"tr_text": "☆Scared Fish Mysterious Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「スケアードフィッシュ玄」\n「スケアードグラスＢ」\n「ブルーノのヒゲ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Scared Fish Mysterious]\n[Scared Glasses B]\n[Bruno's Beard]"
 	},
 	{
 		"assign": "33005109",
 		"jp_text": "☆ステラメモリーズセット１",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ[Ba]」\n「ステラメモリーズ[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories [Ba]]\n[Stella Memories [In]] +1 other"
 	},
 	{
 		"assign": "33005110",
 		"jp_text": "☆ステラメモリーズセット２",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ影[Ba]」\n「ステラメモリーズ影[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories Shadow [Ba]]\n[Stella Memories Shadow [In]] +1 other"
 	},
 	{
 		"assign": "33005111",
 		"jp_text": "☆ステラメモリーズセット３",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ紅[Ba]」\n「ステラメモリーズ紅[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories Crimson [Ba]]\n[Stella Memories Crimson [In]] +1 other"
 	},
 	{
 		"assign": "33005112",
 		"jp_text": "☆ステラメモリーズセット４",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ海[Ba]」\n「ステラメモリーズ海[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories Sea [Ba]]\n[Stella Memories Sea [In]] +1 other"
 	},
 	{
 		"assign": "33005113",
 		"jp_text": "☆ステラメモリーズセット５",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ桜[Ba]」\n「ステラメモリーズ桜[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories Sakura [Ba]]\n[Stella Memories Sakura [In]] +1 other"
 	},
 	{
 		"assign": "33005114",
 		"jp_text": "☆ステラメモリーズセット６",
-		"tr_text": "",
+		"tr_text": "☆Stella Memories Set 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラメモリーズ[Ou]」\n「ステラメモリーズ栗[Ba]」\n「ステラメモリーズ月[In]」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Memories [Ou]]\n[Stella Memories Chestnut [Ba]]\n[Stella Memories Moon [In]] +1 other"
 	},
 	{
 		"assign": "33005115",
 		"jp_text": "ダメージジーンズセット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ[Ba]」\n「ダンサーズビキニ[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans [Ba]]\n[Dancer Bikini [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005116",
 		"jp_text": "ダメージジーンズ夜セット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Night Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ夜[Ba]」\n「ダンサーズビキニ夜[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans Night [Ba]]\n[Dancer Bikini Night [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005117",
 		"jp_text": "ダメージジーンズ影セット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ影[Ba]」\n「ダンサーズビキニ影[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans Shadow [Ba]]\n[Dancer Bikini Shadow [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005118",
 		"jp_text": "ダメージジーンズ雪セット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ雪[Ba]」\n「ダンサーズビキニ雪[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans Snow [Ba]]\n[Dancer Bikini Snow [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005119",
 		"jp_text": "ダメージジーンズ陽セット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Sun Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ陽[Ba]」\n「ダンサーズビキニ陽[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans Sun [Ba]]\n[Dancer Bikini Sun [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005120",
 		"jp_text": "ダメージジーンズ紅セット",
-		"tr_text": "",
+		"tr_text": "Ripped Jeans Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ダメージジーンズ紅[Ba]」\n「ダンサーズビキニ紅[In]」\n「内巻きロング」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Ripped Jeans Crimson [Ba]]\n[Dancer Bikini Crimson [In]]\n[Inwardly Curled Long] +1 other"
 	},
 	{
 		"assign": "33005121",
 		"jp_text": "☆コープスパーカーＦ箱１",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005122",
 		"jp_text": "☆コープスパーカーＦ箱２",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005123",
 		"jp_text": "☆コープスパーカーＦ箱３",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 3",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005124",
 		"jp_text": "☆コープスパーカーＦ箱４",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 4",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005125",
 		"jp_text": "☆コープスパーカーＦ箱５",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 5",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005126",
 		"jp_text": "☆コープスパーカーＦ箱６",
-		"tr_text": "",
+		"tr_text": "☆Corpse Parka F Box 6",
 		"jp_explain": "以下のアイテムを獲得する。\n「コープスパーカーＦ[Ou]」\n「リコリスコサージュ　赤」\n「トレッキングブーツ　灰」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Corpse Parka F [Ou]]\n[Red Lycoris Corsage]\n[Gray Trekking Boots]"
 	},
 	{
 		"assign": "33005127",
 		"jp_text": "スミスサロペットセット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット[Ba]」\n「スミスサロペット[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette [Ba]]\n[Smith Salopette [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005128",
 		"jp_text": "スミスサロペット雪セット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット雪[Ba]」\n「スミスサロペット雪[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette Snow [Ba]]\n[Smith Salopette Snow [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005129",
 		"jp_text": "スミスサロペット影セット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット影[Ba]」\n「スミスサロペット影[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette Shadow [Ba]]\n[Smith Salopette Shadow [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005130",
 		"jp_text": "スミスサロペット夜セット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Night Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット夜[Ba]」\n「スミスサロペット夜[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette Night [Ba]]\n[Smith Salopette Night [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005131",
 		"jp_text": "スミスサロペット紅セット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット紅[Ba]」\n「スミスサロペット紅[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette Crimson [Ba]]\n[Smith Salopette Crimson [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005132",
 		"jp_text": "スミスサロペット月セット",
-		"tr_text": "",
+		"tr_text": "Smith Salopette Moon Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスサロペット月[Ba]」\n「スミスサロペット月[In]」\n「スミスヘッドバンド」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Salopette Moon [Ba]]\n[Smith Salopette Moon [In]]\n[Smith Headband]"
 	},
 	{
 		"assign": "33005133",
 		"jp_text": "☆ＳジャンパーＦ影セット１",
-		"tr_text": "",
+		"tr_text": "☆S Jumper F Shadow Set 1",
 		"jp_explain": "以下のアイテムを獲得する。\n「ＳジャンパーＦ影[Ou]」\n「タンクトップデニム玄[Ba]」\n「リボンカチューシャ　橙」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[S Jumper F Shadow [Ou]]\n[Tank Top Denim Mysterious [Ba]]\n[Orange Ribbon Headband]"
 	},
 	{
 		"assign": "33005134",
 		"jp_text": "☆ＳジャンパーＦ影セット２",
-		"tr_text": "",
+		"tr_text": "☆S Jumper F Shadow Set 2",
 		"jp_explain": "以下のアイテムを獲得する。\n「ＳジャンパーＦ影[Ou]」\n「タンクトップデニム冬[Ba]」\n「リボンカチューシャ　橙」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[S Jumper F Shadow [Ou]]\n[Tank Top Denim Winter [Ba]]\n[Orange Ribbon Headband]"
 	},
 	{
 		"assign": "33005135",
 		"jp_text": "☆ステライノセント雪セット",
-		"tr_text": "",
+		"tr_text": "☆Stella Innocent Snow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステライノセント雪」\n「ジェネツインテール」\n「ステラヘッドギア」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Innocent Snow]\n[Gene Twin Tails]\n[Stella Headgear]"
 	},
 	{
 		"assign": "33005136",
 		"jp_text": "☆ステライノセント玄セット",
-		"tr_text": "",
+		"tr_text": "☆Stella Innocent Mysterious Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステライノセント玄」\n「ジェネツインテール」\n「ステラヘッドギア」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Innocent Mysterious]\n[Gene Twin Tails]\n[Stella Headgear]"
 	},
 	{
 		"assign": "33005137",
 		"jp_text": "☆ゴシックメイドドレス冬箱",
-		"tr_text": "",
+		"tr_text": "☆Gothic Maid Dress Winter Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ゴシックメイドドレス冬」\n「ゴシックメイドブリムＢ」\n「ゴシックメイドリボンＢ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Gothic Maid Dress Winter]\n[Gothic Maid Brim B]\n[Gothic Maid Ribbon B]"
 	},
 	{
 		"assign": "33005138",
 		"jp_text": "☆ゴシックメイドドレス影箱",
-		"tr_text": "",
+		"tr_text": "☆Gothic Maid Dress Shadow Box",
 		"jp_explain": "以下のアイテムを獲得する。\n「ゴシックメイドドレス影」\n「ゴシックメイドブリムＢ」\n「ゴシックメイドリボンＢ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Gothic Maid Dress Shadow]\n[Gothic Maid Brim B]\n[Gothic Maid Ribbon B]"
 	},
 	{
 		"assign": "33005139",
 		"jp_text": "ジェネスタイルセット",
-		"tr_text": "",
+		"tr_text": "Gene Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ジェネツインテール２」\n「ステラヘッドギア２」\n「ステラアームギア」他一種",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Gene Twin Tail 2]\n[Stella Headgear 2]\n[Stella Arm Gear] +1 other"
 	},
 	{
 		"assign": "33005140",
 		"jp_text": "スミシースタイルセット",
-		"tr_text": "",
+		"tr_text": "Smithy Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミシーヘアー」\n「スミシーマスクＢ」\n「スミシータトゥー」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smithy Hair]\n[Smithy Mask B]\n[Smithy Tattoo]"
 	},
 	{
 		"assign": "33005141",
 		"jp_text": "スミススタイルセット",
-		"tr_text": "",
+		"tr_text": "Smith Style Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスヘアー」\n「スミスゴーグル」\n「スミスメイク」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Hair]\n[Smith Goggles]\n[Smith Makeup]"
 	},
 	{
 		"assign": "33005142",
 		"jp_text": "ステラステッカーセット",
-		"tr_text": "",
+		"tr_text": "Stella Sticker Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「ステラステッカーＡ」\n「ステラステッカーＢ」\n「ステラステッカーＣ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Stella Sticker A]\n[Stella Sticker B]\n[Stella Sticker C]"
 	},
 	{
 		"assign": "33005143",
 		"jp_text": "スミスステッカーセット",
-		"tr_text": "",
+		"tr_text": "Smith Sticker Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「スミスステッカーＡ」\n「スミスステッカーＢ」\n「スミスステッカーＣ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Smith Sticker A]\n[Smith Sticker B]\n[Smith Sticker C]"
 	},
 	{
 		"assign": "33005267",
 		"jp_text": "ステラウォールセット",
-		"tr_text": "",
+		"tr_text": "Stellar Wall Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「サブ／ステラウォール」\n「サブ／ステラウォール」\n「サブ／ステラウォール」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Sub/Stellar Wall]\n[Sub/Stellar Wall]\n[Sub/Stellar Wall]"
 	},
 	{
 		"assign": "33005268",
 		"jp_text": "英傑の服セット",
-		"tr_text": "",
+		"tr_text": "Champion's Tunic Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「英傑の服Ｍ」\n「英傑の服Ｆ」",
-		"tr_explain": ""
+		"tr_explain": "Use to receive the following items:\n[Champion's Tunic M]\n[Champion's Tunic F]"
 	}
 ]

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -1593,83 +1593,83 @@
 		"jp_text": "ミニダウンステッカーＡ",
 		"tr_text": "Mini Down Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker A"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170257",
 		"jp_text": "ミニダウンステッカーＢ",
 		"tr_text": "Mini Down Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker B"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170258",
 		"jp_text": "ミニダウンステッカーＣ",
 		"tr_text": "Mini Down Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker C"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170259",
 		"jp_text": "アークマステッカーＡ",
 		"tr_text": "Arkuma Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker A"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170260",
 		"jp_text": "アークマステッカーＢ",
 		"tr_text": "Arkuma Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker B"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170261",
 		"jp_text": "アークマステッカーＣ",
 		"tr_text": "Arkuma Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker C"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170262",
 		"jp_text": "ステラステッカーＡ",
 		"tr_text": "Stella Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker A"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170263",
 		"jp_text": "ステラステッカーＢ",
 		"tr_text": "Stella Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker B"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170264",
 		"jp_text": "ステラステッカーＣ",
 		"tr_text": "Stella Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker C"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170265",
 		"jp_text": "スミスステッカーＡ",
 		"tr_text": "Smith Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker A"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170266",
 		"jp_text": "スミスステッカーＢ",
 		"tr_text": "Smith Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker B"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170267",
 		"jp_text": "スミスステッカーＣ",
 		"tr_text": "Smith Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker C"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker C\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -1593,83 +1593,83 @@
 		"jp_text": "ミニダウンステッカーＡ",
 		"tr_text": "Mini Down Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker A\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Mini Down Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170257",
 		"jp_text": "ミニダウンステッカーＢ",
 		"tr_text": "Mini Down Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker B\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Mini Down Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170258",
 		"jp_text": "ミニダウンステッカーＣ",
 		"tr_text": "Mini Down Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker C\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Mini Down Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170259",
 		"jp_text": "アークマステッカーＡ",
 		"tr_text": "Arkuma Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker A\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Arkuma Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170260",
 		"jp_text": "アークマステッカーＢ",
 		"tr_text": "Arkuma Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker B\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Arkuma Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170261",
 		"jp_text": "アークマステッカーＣ",
 		"tr_text": "Arkuma Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker C\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Arkuma Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170262",
 		"jp_text": "ステラステッカーＡ",
 		"tr_text": "Stella Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker A\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Stella Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170263",
 		"jp_text": "ステラステッカーＢ",
 		"tr_text": "Stella Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker B\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Stella Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170264",
 		"jp_text": "ステラステッカーＣ",
 		"tr_text": "Stella Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker C\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Stella Sticker C\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170265",
 		"jp_text": "スミスステッカーＡ",
 		"tr_text": "Smith Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＡが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker A\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Smith Sticker A\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170266",
 		"jp_text": "スミスステッカーＢ",
 		"tr_text": "Smith Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＢが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker B\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Smith Sticker B\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170267",
 		"jp_text": "スミスステッカーＣ",
 		"tr_text": "Smith Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＣが選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker C\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"Smith Sticker C\"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -1593,83 +1593,83 @@
 		"jp_text": "ミニダウンステッカーＡ",
 		"tr_text": "Mini Down Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker A"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170257",
 		"jp_text": "ミニダウンステッカーＢ",
 		"tr_text": "Mini Down Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker B"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170258",
 		"jp_text": "ミニダウンステッカーＣ",
 		"tr_text": "Mini Down Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nミニダウンＣが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Mini Down Sticker C"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170259",
 		"jp_text": "アークマステッカーＡ",
 		"tr_text": "Arkuma Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker A"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170260",
 		"jp_text": "アークマステッカーＢ",
 		"tr_text": "Arkuma Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker B"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170261",
 		"jp_text": "アークマステッカーＣ",
 		"tr_text": "Arkuma Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nアークマＣが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Arkuma Sticker C"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170262",
 		"jp_text": "ステラステッカーＡ",
 		"tr_text": "Stella Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker A"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170263",
 		"jp_text": "ステラステッカーＢ",
 		"tr_text": "Stella Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker B"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170264",
 		"jp_text": "ステラステッカーＣ",
 		"tr_text": "Stella Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nステラＣが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Stella Sticker C"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170265",
 		"jp_text": "スミスステッカーＡ",
 		"tr_text": "Smith Sticker A",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＡが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker A"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170266",
 		"jp_text": "スミスステッカーＢ",
 		"tr_text": "Smith Sticker B",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker B"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170267",
 		"jp_text": "スミスステッカーＣ",
 		"tr_text": "Smith Sticker C",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nスミスＣが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "By using this ticket, the sticker\n"Smith Sticker C"\ncan be used in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Tool.txt
+++ b/json/Item_Stack_Tool.txt
@@ -387,7 +387,7 @@
 	{
 		"assign": "37067",
 		"jp_text": "ＴＣＧメモリ",
-		"tr_text": "",
+		"tr_text": "TCG Memory",
 		"jp_explain": "表面に特徴的な絵が描かれている\n何らかの記録媒体。内部データの\n復元ができれば有用なものとなる。",
 		"tr_explain": ""
 	},

--- a/json/Item_Stack_Voice.txt
+++ b/json/Item_Stack_Voice.txt
@@ -4323,21 +4323,21 @@
 		"jp_text": "男性追加ボイス１３１",
 		"tr_text": "Male Extra Voice 131",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n人間男性のみ使用可能。\nＣＶ緑川 光",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 131\"\ncan be used in the Beauty Salon."
+		"tr_explain": "Allows a new voice to be selected.\nNon-Cast male characters only.\nCV: Hikaru Midorikawa"
 	},
 	{
 		"assign": "3180831",
 		"jp_text": "男性共通セイルボイス",
-		"tr_text": "",
+		"tr_text": "Male Sail Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n男性のみ使用可能。\nＣＶ松岡 禎丞",
-		"tr_explain": ""
+		"tr_explain": "Allows a new voice to be selected.\nMale characters only (all races).\nCV: Yoshitsugu Matsuoka"
 	},
 	{
 		"assign": "3180832",
 		"jp_text": "男性［ＥＸ］ボイスＡ１７",
-		"tr_text": "",
+		"tr_text": "Male [EX] Voice A17",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n人間男性のみ使用可能。\nＣＶ光吉 猛修",
-		"tr_explain": ""
+		"tr_explain": "Allows a new voice to be selected.\nNon-Cast male characters only.\nCV: Takenobu Mitsuyoshi"
 	},
 	{
 		"assign": "3180842",
@@ -4713,23 +4713,23 @@
 	{
 		"assign": "3180924",
 		"jp_text": "女性共通ルティナボイス",
-		"tr_text": "",
+		"tr_text": "Female Lutina Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n女性のみ使用可能。\nＣＶ内田 真礼",
-		"tr_explain": ""
+		"tr_explain": "Allows a new voice to be selected.\nFemale characters only (all races).\nCV: Maaya Uchida"
 	},
 	{
 		"assign": "3180925",
 		"jp_text": "女性共通フィルディアボイス",
-		"tr_text": "",
+		"tr_text": "Female Fildia Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n女性のみ使用可能。\nＣＶ沢城 みゆき",
-		"tr_explain": ""
+		"tr_explain": "Allows a new voice to be selected.\nFemale characters only (all races).\nCV: Miyuki Sawashiro"
 	},
 	{
 		"assign": "3180926",
 		"jp_text": "女性共通イズナボイス",
-		"tr_text": "",
+		"tr_text": "Female Izuna Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n女性のみ使用可能。\nＣＶ茅野 愛衣",
-		"tr_explain": ""
+		"tr_explain": "Allows a new voice to be selected.\nFemale characters only (all races).\nCV: Ai Kayano"
 	},
 	{
 		"assign": "3180943",
@@ -5028,9 +5028,9 @@
 	{
 		"assign": "31801010",
 		"jp_text": "男性Ｃ［ＥＸ］ボイスＡ１７",
-		"tr_text": "",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\nキャスト男性のみ使用可能。\nＣＶ光吉 猛修",
-		"tr_explain": ""
+		"tr_text": "Male C [EX] Voice A17",
+		"tr_explain": "Allows a new voice to be selected.\nMale Casts only.\nCV: Takenobu Mitsuyoshi"
 	},
 	{
 		"assign": "31801020",

--- a/json/Item_Stack_Voice.txt
+++ b/json/Item_Stack_Voice.txt
@@ -5028,7 +5028,7 @@
 	{
 		"assign": "31801010",
 		"jp_text": "男性Ｃ［ＥＸ］ボイスＡ１７",
-        "tr_text": "Male C [EX] Voice A17",
+		"tr_text": "Male C [EX] Voice A17",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\nキャスト男性のみ使用可能。\nＣＶ光吉 猛修",
 		"tr_explain": "Allows a new voice to be selected.\nMale Casts only.\nCV: Takenobu Mitsuyoshi"
 	},

--- a/json/Item_Stack_Voice.txt
+++ b/json/Item_Stack_Voice.txt
@@ -5028,8 +5028,8 @@
 	{
 		"assign": "31801010",
 		"jp_text": "男性Ｃ［ＥＸ］ボイスＡ１７",
+        "tr_text": "Male C [EX] Voice A17",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\nキャスト男性のみ使用可能。\nＣＶ光吉 猛修",
-		"tr_text": "Male C [EX] Voice A17",
 		"tr_explain": "Allows a new voice to be selected.\nMale Casts only.\nCV: Takenobu Mitsuyoshi"
 	},
 	{

--- a/json/Name_Chip_DarkerName.txt
+++ b/json/Name_Chip_DarkerName.txt
@@ -352,21 +352,21 @@
 	{
 		"assign": "6071",
 		"jp_text": "ドリュアーダ",
-		"tr_text": ""
+		"tr_text": "Doluahda"
 	},
 	{
 		"assign": "6072",
 		"jp_text": "闇羽鳥 ドリュアーダ",
-		"tr_text": ""
+		"tr_text": "Dark-Winged Bird Doluahda "
 	},
 	{
 		"assign": "6073",
 		"jp_text": "ソルダ・カピタ",
-		"tr_text": ""
+		"tr_text": "Solda Kapita"
 	},
 	{
 		"assign": "6074",
 		"jp_text": "群帥翼人 ソルダ・カピタ",
-		"tr_text": ""
+		"tr_text": "Birdman Commander Solda Kapita"
 	}
 ]

--- a/json/Name_Chip_DimensionName.txt
+++ b/json/Name_Chip_DimensionName.txt
@@ -42,11 +42,11 @@
 	{
 		"assign": "6609",
 		"jp_text": "ブルトルボン",
-		"tr_text": ""
+		"tr_text": "Blutorbon"
 	},
 	{
 		"assign": "6610",
 		"jp_text": "穿棘貝 ブルトルボン",
-		"tr_text": ""
+		"tr_text": "Thorned Shellfish Blutorbon"
 	}
 ]

--- a/json/Name_Chip_LegendName.txt
+++ b/json/Name_Chip_LegendName.txt
@@ -7,11 +7,11 @@
 	{
 		"assign": "6422",
 		"jp_text": "Mr.アンブラ",
-		"tr_text": ""
+		"tr_text": "Mr. Umblla"
 	},
 	{
 		"assign": "6423",
 		"jp_text": "異次元の来訪者 Mr.アンブラ",
-		"tr_text": ""
+		"tr_text": "Interdimensional Visitor Mr. Umblla"
 	}
 ]

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -4107,12 +4107,12 @@
 	{
 		"assign": "40235",
 		"jp_text": "ウェポンエンハンス・光大剣",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Light Sword"
 	},
 	{
 		"assign": "40236",
 		"jp_text": "ウェポンエンハンス・光大剣＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Light Sword+"
 	},
 	{
 		"assign": "40237",
@@ -4177,12 +4177,12 @@
 	{
 		"assign": "40249",
 		"jp_text": "ウェポンエンハンス・闇自在槍",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Partizan"
 	},
 	{
 		"assign": "40250",
 		"jp_text": "ウェポンエンハンス・闇自在槍＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Partizan+"
 	},
 	{
 		"assign": "40251",
@@ -4297,12 +4297,12 @@
 	{
 		"assign": "40273",
 		"jp_text": "ウェポンエンハンス・闇双小剣",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Twin Daggers"
 	},
 	{
 		"assign": "40274",
 		"jp_text": "ウェポンエンハンス・闇双小剣＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Twin Daggers"
 	},
 	{
 		"assign": "40275",
@@ -4387,12 +4387,12 @@
 	{
 		"assign": "40291",
 		"jp_text": "ウェポンエンハンス・雷鋼拳",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Lightning Knuckles"
 	},
 	{
 		"assign": "40292",
 		"jp_text": "ウェポンエンハンス・雷鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Lightning Knuckles＋"
 	},
 	{
 		"assign": "40293",
@@ -4427,12 +4427,12 @@
 	{
 		"assign": "40299",
 		"jp_text": "ウェポンエンハンス・炎銃剣",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Fire 銃剣"
 	},
 	{
 		"assign": "40300",
 		"jp_text": "ウェポンエンハンス・炎銃剣＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Fire 銃剣＋"
 	},
 	{
 		"assign": "40301",
@@ -4507,12 +4507,12 @@
 	{
 		"assign": "40315",
 		"jp_text": "ウェポンエンハンス・雷抜剣",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Lightning Katana"
 	},
 	{
 		"assign": "40316",
 		"jp_text": "ウェポンエンハンス・雷抜剣＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Lightning Katana+"
 	},
 	{
 		"assign": "40317",
@@ -4577,12 +4577,12 @@
 	{
 		"assign": "40329",
 		"jp_text": "ウェポンエンハンス・風飛翔剣",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Dual Blades"
 	},
 	{
 		"assign": "40330",
 		"jp_text": "ウェポンエンハンス・風飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Dual Blades+"
 	},
 	{
 		"assign": "40331",
@@ -4637,12 +4637,12 @@
 	{
 		"assign": "40341",
 		"jp_text": "ウェポンエンハンス・風長銃",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Assault Rifle"
 	},
 	{
 		"assign": "40342",
 		"jp_text": "ウェポンエンハンス・風長銃＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Assault Rifle+"
 	},
 	{
 		"assign": "40343",
@@ -4677,12 +4677,12 @@
 	{
 		"assign": "40349",
 		"jp_text": "ウェポンエンハンス・氷大砲",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Ice Launcher"
 	},
 	{
 		"assign": "40350",
 		"jp_text": "ウェポンエンハンス・氷大砲＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Ice Launcher＋"
 	},
 	{
 		"assign": "40351",
@@ -4837,12 +4837,12 @@
 	{
 		"assign": "40381",
 		"jp_text": "ウェポンエンハンス・闇強弓",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Bow"
 	},
 	{
 		"assign": "40382",
 		"jp_text": "ウェポンエンハンス・闇強弓＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Dark Bow＋"
 	},
 	{
 		"assign": "40383",
@@ -4887,12 +4887,12 @@
 	{
 		"assign": "40391",
 		"jp_text": "ウェポンエンハンス・光魔装脚",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Light Jet Boots"
 	},
 	{
 		"assign": "40392",
 		"jp_text": "ウェポンエンハンス・光魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Light Jet Boots＋"
 	},
 	{
 		"assign": "40393",
@@ -4907,12 +4907,12 @@
 	{
 		"assign": "40395",
 		"jp_text": "ウェポンエンハンス・炎長杖",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Fire Rod"
 	},
 	{
 		"assign": "40396",
 		"jp_text": "ウェポンエンハンス・炎長杖＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Fire Rod＋"
 	},
 	{
 		"assign": "40397",
@@ -4977,12 +4977,12 @@
 	{
 		"assign": "40409",
 		"jp_text": "ウェポンエンハンス・氷導具",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Ice Talis"
 	},
 	{
 		"assign": "40410",
 		"jp_text": "ウェポンエンハンス・氷導具＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Ice Talis＋"
 	},
 	{
 		"assign": "40411",
@@ -5057,12 +5057,12 @@
 	{
 		"assign": "40425",
 		"jp_text": "ウェポンエンハンス・風短杖",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Wand"
 	},
 	{
 		"assign": "40426",
 		"jp_text": "ウェポンエンハンス・風短杖＋",
-		"tr_text": ""
+		"tr_text": "Weapon Enhance - Wind Wand＋"
 	},
 	{
 		"assign": "40427",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -2937,342 +2937,342 @@
 	{
 		"assign": "40001",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40002",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40003",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40004",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40005",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40006",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40007",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40008",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40009",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40010",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40011",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40012",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40013",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40014",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40015",
 		"jp_text": "アビリティバースト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle"
 	},
 	{
 		"assign": "40016",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle＋"
 	},
 	{
 		"assign": "40017",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40018",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40019",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40020",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40021",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40022",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana＋"
 	},
 	{
 		"assign": "40023",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40024",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow＋"
 	},
 	{
 		"assign": "40025",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40026",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40027",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40028",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40029",
 		"jp_text": "アビリティバースト・炎法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 炎法術"
 	},
 	{
 		"assign": "40030",
 		"jp_text": "アビリティバースト・炎法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 炎法術＋"
 	},
 	{
 		"assign": "40031",
 		"jp_text": "アビリティバースト・氷法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 氷法術"
 	},
 	{
 		"assign": "40032",
 		"jp_text": "アビリティバースト・氷法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 氷法術＋"
 	},
 	{
 		"assign": "40033",
 		"jp_text": "アビリティバースト・風法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 風法術"
 	},
 	{
 		"assign": "40034",
 		"jp_text": "アビリティバースト・風法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 風法術＋"
 	},
 	{
 		"assign": "40035",
 		"jp_text": "アビリティバースト・雷法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 雷法術"
 	},
 	{
 		"assign": "40036",
 		"jp_text": "アビリティバースト・雷法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 雷法術＋"
 	},
 	{
 		"assign": "40037",
 		"jp_text": "アビリティバースト・光法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 光法術"
 	},
 	{
 		"assign": "40038",
 		"jp_text": "アビリティバースト・光法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 光法術＋"
 	},
 	{
 		"assign": "40039",
 		"jp_text": "アビリティバースト・闇法術",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 闇法術"
 	},
 	{
 		"assign": "40040",
 		"jp_text": "アビリティバースト・闇法術＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - 闇法術＋"
 	},
 	{
 		"assign": "40041",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40042",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40043",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40044",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40045",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40046",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40047",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40048",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40049",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40050",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40051",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40052",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40053",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40054",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40055",
 		"jp_text": "アビリティバースト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle"
 	},
 	{
 		"assign": "40056",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle＋"
 	},
 	{
 		"assign": "40057",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40058",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40059",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40060",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40061",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40062",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana＋"
 	},
 	{
 		"assign": "40063",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40064",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow＋"
 	},
 	{
 		"assign": "40065",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40066",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40067",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40068",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40069",
@@ -3337,662 +3337,662 @@
 	{
 		"assign": "40081",
 		"jp_text": "アビリティブラスト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Sword"
 	},
 	{
 		"assign": "40082",
 		"jp_text": "アビリティブラスト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Sword＋"
 	},
 	{
 		"assign": "40083",
 		"jp_text": "アビリティブラスト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Wired Lance"
 	},
 	{
 		"assign": "40084",
 		"jp_text": "アビリティブラスト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Wired Lance＋"
 	},
 	{
 		"assign": "40085",
 		"jp_text": "アビリティブラスト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Partizan"
 	},
 	{
 		"assign": "40086",
 		"jp_text": "アビリティブラスト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Partizan＋"
 	},
 	{
 		"assign": "40087",
 		"jp_text": "アビリティブラスト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Twin Daggers"
 	},
 	{
 		"assign": "40088",
 		"jp_text": "アビリティブラスト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Twin Daggers＋"
 	},
 	{
 		"assign": "40089",
 		"jp_text": "アビリティブラスト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Double Saber"
 	},
 	{
 		"assign": "40090",
 		"jp_text": "アビリティブラスト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Double Saber＋"
 	},
 	{
 		"assign": "40091",
 		"jp_text": "アビリティブラスト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Knuckles"
 	},
 	{
 		"assign": "40092",
 		"jp_text": "アビリティブラスト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Knuckles＋"
 	},
 	{
 		"assign": "40093",
 		"jp_text": "アビリティブラスト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Gunslash"
 	},
 	{
 		"assign": "40094",
 		"jp_text": "アビリティブラスト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Gunslash＋"
 	},
 	{
 		"assign": "40095",
 		"jp_text": "アビリティブラスト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Assault Rifle"
 	},
 	{
 		"assign": "40096",
 		"jp_text": "アビリティブラスト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Assault Rifle＋"
 	},
 	{
 		"assign": "40097",
 		"jp_text": "アビリティブラスト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Launcher"
 	},
 	{
 		"assign": "40098",
 		"jp_text": "アビリティブラスト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Launcher＋"
 	},
 	{
 		"assign": "40099",
 		"jp_text": "アビリティブラスト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Twin Machineguns"
 	},
 	{
 		"assign": "40100",
 		"jp_text": "アビリティブラスト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Twin Machineguns＋"
 	},
 	{
 		"assign": "40101",
 		"jp_text": "アビリティブラスト・長杖",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Rod"
 	},
 	{
 		"assign": "40102",
 		"jp_text": "アビリティブラスト・長杖＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Rod＋"
 	},
 	{
 		"assign": "40103",
 		"jp_text": "アビリティブラスト・導具",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Talis"
 	},
 	{
 		"assign": "40104",
 		"jp_text": "アビリティブラスト・導具＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Talis＋"
 	},
 	{
 		"assign": "40105",
 		"jp_text": "アビリティブラスト・短杖",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Wand"
 	},
 	{
 		"assign": "40106",
 		"jp_text": "アビリティブラスト・短杖＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Wand＋"
 	},
 	{
 		"assign": "40107",
 		"jp_text": "アビリティブラスト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Katana"
 	},
 	{
 		"assign": "40108",
 		"jp_text": "アビリティブラスト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Katana＋"
 	},
 	{
 		"assign": "40109",
 		"jp_text": "アビリティブラスト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Bow"
 	},
 	{
 		"assign": "40110",
 		"jp_text": "アビリティブラスト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Bow＋"
 	},
 	{
 		"assign": "40111",
 		"jp_text": "アビリティブラスト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Jet Boots"
 	},
 	{
 		"assign": "40112",
 		"jp_text": "アビリティブラスト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Jet Boots＋"
 	},
 	{
 		"assign": "40113",
 		"jp_text": "アビリティブラスト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Dual Blades"
 	},
 	{
 		"assign": "40114",
 		"jp_text": "アビリティブラスト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Blast - Dual Blades＋"
 	},
 	{
 		"assign": "40115",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40116",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40117",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40118",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40119",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40120",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40121",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40122",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40123",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40124",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40125",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40126",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40127",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40128",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40129",
 		"jp_text": "アビリティバースト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle"
 	},
 	{
 		"assign": "40130",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle＋"
 	},
 	{
 		"assign": "40131",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40132",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40133",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40134",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40135",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40136",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40137",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40138",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": Ability Burst - Bow+""
 	},
 	{
 		"assign": "40139",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40140",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40141",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40142",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40143",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40144",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40145",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40146",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40147",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40148",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40149",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40150",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40151",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40152",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40153",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40154",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40155",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40156",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40157",
 		"jp_text": "アビリティバースト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle"
 	},
 	{
 		"assign": "40158",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle＋"
 	},
 	{
 		"assign": "40159",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40160",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40161",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40162",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40163",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40164",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana＋"
 	},
 	{
 		"assign": "40165",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40166",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow＋"
 	},
 	{
 		"assign": "40167",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40168",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40169",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40170",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40171",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40172",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40173",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40174",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40175",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40176",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40177",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40178",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40179",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40180",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40181",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40182",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40183",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40184",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40185",
 		"jp_text": "アビリティバースト・長銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle"
 	},
 	{
 		"assign": "40186",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Assault Rifle＋"
 	},
 	{
 		"assign": "40187",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40188",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40189",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40190",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40191",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40192",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana＋"
 	},
 	{
 		"assign": "40193",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40194",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow＋"
 	},
 	{
 		"assign": "40195",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40196",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40197",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40198",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40199",
 		"jp_text": "アビリティバースト・大剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword"
 	},
 	{
 		"assign": "40200",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Sword＋"
 	},
 	{
 		"assign": "40201",
 		"jp_text": "アビリティバースト・自在槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance"
 	},
 	{
 		"assign": "40202",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Wired Lance＋"
 	},
 	{
 		"assign": "40203",
 		"jp_text": "アビリティバースト・長槍",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan"
 	},
 	{
 		"assign": "40204",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Partizan＋"
 	},
 	{
 		"assign": "40205",
 		"jp_text": "アビリティバースト・双小剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers"
 	},
 	{
 		"assign": "40206",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Daggers＋"
 	},
 	{
 		"assign": "40207",
 		"jp_text": "アビリティバースト・両剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber"
 	},
 	{
 		"assign": "40208",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Double Saber＋"
 	},
 	{
 		"assign": "40209",
 		"jp_text": "アビリティバースト・鋼拳",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles"
 	},
 	{
 		"assign": "40210",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Knuckles＋"
 	},
 	{
 		"assign": "40211",
 		"jp_text": "アビリティバースト・銃剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash"
 	},
 	{
 		"assign": "40212",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Gunslash＋"
 	},
 	{
 		"assign": "40213",
@@ -4007,62 +4007,62 @@
 	{
 		"assign": "40215",
 		"jp_text": "アビリティバースト・大砲",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher"
 	},
 	{
 		"assign": "40216",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Launcher＋"
 	},
 	{
 		"assign": "40217",
 		"jp_text": "アビリティバースト・双機銃",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns"
 	},
 	{
 		"assign": "40218",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Twin Machineguns＋"
 	},
 	{
 		"assign": "40219",
 		"jp_text": "アビリティバースト・抜剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana"
 	},
 	{
 		"assign": "40220",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Katana＋"
 	},
 	{
 		"assign": "40221",
 		"jp_text": "アビリティバースト・強弓",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow"
 	},
 	{
 		"assign": "40222",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Bow＋"
 	},
 	{
 		"assign": "40223",
 		"jp_text": "アビリティバースト・魔装脚",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots"
 	},
 	{
 		"assign": "40224",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Jet Boots＋"
 	},
 	{
 		"assign": "40225",
 		"jp_text": "アビリティバースト・飛翔剣",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades"
 	},
 	{
 		"assign": "40226",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": ""
+		"tr_text": "Ability Burst - Dual Blades＋"
 	},
 	{
 		"assign": "40227",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -3077,62 +3077,62 @@
 	{
 		"assign": "40029",
 		"jp_text": "アビリティバースト・炎法術",
-		"tr_text": "Ability Burst - 炎法術"
+		"tr_text": "Ability Burst - Fire Techniques"
 	},
 	{
 		"assign": "40030",
 		"jp_text": "アビリティバースト・炎法術＋",
-		"tr_text": "Ability Burst - 炎法術＋"
+		"tr_text": "Ability Burst - Fire Techniques＋"
 	},
 	{
 		"assign": "40031",
 		"jp_text": "アビリティバースト・氷法術",
-		"tr_text": "Ability Burst - 氷法術"
+		"tr_text": "Ability Burst - Ice Techniques"
 	},
 	{
 		"assign": "40032",
 		"jp_text": "アビリティバースト・氷法術＋",
-		"tr_text": "Ability Burst - 氷法術＋"
+		"tr_text": "Ability Burst - Ice Techniques＋"
 	},
 	{
 		"assign": "40033",
 		"jp_text": "アビリティバースト・風法術",
-		"tr_text": "Ability Burst - 風法術"
+		"tr_text": "Ability Burst - Wind Techniques"
 	},
 	{
 		"assign": "40034",
 		"jp_text": "アビリティバースト・風法術＋",
-		"tr_text": "Ability Burst - 風法術＋"
+		"tr_text": "Ability Burst - Wind Techniques＋"
 	},
 	{
 		"assign": "40035",
 		"jp_text": "アビリティバースト・雷法術",
-		"tr_text": "Ability Burst - 雷法術"
+		"tr_text": "Ability Burst - Lightning Techniques"
 	},
 	{
 		"assign": "40036",
 		"jp_text": "アビリティバースト・雷法術＋",
-		"tr_text": "Ability Burst - 雷法術＋"
+		"tr_text": "Ability Burst - Lightning Techniques＋"
 	},
 	{
 		"assign": "40037",
 		"jp_text": "アビリティバースト・光法術",
-		"tr_text": "Ability Burst - 光法術"
+		"tr_text": "Ability Burst - Light Techniques"
 	},
 	{
 		"assign": "40038",
 		"jp_text": "アビリティバースト・光法術＋",
-		"tr_text": "Ability Burst - 光法術＋"
+		"tr_text": "Ability Burst - Light Techniques＋"
 	},
 	{
 		"assign": "40039",
 		"jp_text": "アビリティバースト・闇法術",
-		"tr_text": "Ability Burst - 闇法術"
+		"tr_text": "Ability Burst - Dark Techniques"
 	},
 	{
 		"assign": "40040",
 		"jp_text": "アビリティバースト・闇法術＋",
-		"tr_text": "Ability Burst - 闇法術＋"
+		"tr_text": "Ability Burst - Dark Techniques＋"
 	},
 	{
 		"assign": "40041",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -22,12 +22,12 @@
 	{
 		"assign": "1010",
 		"jp_text": "ペインヒット",
-		"tr_text": ""
+		"tr_text": "Pain Hit"
 	},
 	{
 		"assign": "1020",
 		"jp_text": "ペインヒット＋",
-		"tr_text": ""
+		"tr_text": "Pain Hit+"
 	},
 	{
 		"assign": "1210",
@@ -342,12 +342,12 @@
 	{
 		"assign": "30091",
 		"jp_text": "灰の一扇",
-		"tr_text": "The Ash Fan"
+		"tr_text": "Ashen Fan"
 	},
 	{
 		"assign": "30092",
 		"jp_text": "灰の一扇＋",
-		"tr_text": "The Ash Fan+"
+		"tr_text": "Ashen Fan+"
 	},
 	{
 		"assign": "30093",
@@ -752,12 +752,12 @@
 	{
 		"assign": "31107",
 		"jp_text": "紅炎の歌術",
-		"tr_text": ""
+		"tr_text": "Song Magic of Crimson Flame"
 	},
 	{
 		"assign": "31108",
 		"jp_text": "紅炎の歌術＋",
-		"tr_text": ""
+		"tr_text": "Song Magic of Crimson Flame"
 	},
 	{
 		"assign": "31109",
@@ -5237,12 +5237,12 @@
 	{
 		"assign": "5910",
 		"jp_text": "遁走",
-		"tr_text": ""
+		"tr_text": "Escape"
 	},
 	{
 		"assign": "5920",
 		"jp_text": "大遁走",
-		"tr_text": ""
+		"tr_text": "Great Escape"
 	},
 	{
 		"assign": "6210",
@@ -5297,32 +5297,32 @@
 	{
 		"assign": "7710",
 		"jp_text": "龍の知識「防」",
-		"tr_text": "Dragon's Knowledge \"Defend\""
+		"tr_text": "Dragon's Knowledge [Defense]"
 	},
 	{
 		"assign": "7720",
 		"jp_text": "龍の叡智「防」",
-		"tr_text": "Dragon's Wisdom \"Defend\""
+		"tr_text": "Dragon's Wisdom [Defense]"
 	},
 	{
 		"assign": "7810",
 		"jp_text": "龍の知識「攻」",
-		"tr_text": "Dragon's Knowledge \"Attack\""
+		"tr_text": "Dragon's Knowledge [Attack]"
 	},
 	{
 		"assign": "7820",
 		"jp_text": "龍の叡智「攻」",
-		"tr_text": "Dragon's Wisdom \"Attack\""
+		"tr_text": "Dragon's Wisdom [Attack]"
 	},
 	{
 		"assign": "7910",
 		"jp_text": "龍の知識「術」",
-		"tr_text": "Dragon's Knowledge \"Art\""
+		"tr_text": "Dragon's Knowledge [Art]"
 	},
 	{
 		"assign": "7920",
 		"jp_text": "龍の叡智「術」",
-		"tr_text": "Dragon's Wisdom \"Art\""
+		"tr_text": "Dragon's Wisdom [Art]"
 	},
 	{
 		"assign": "8010",
@@ -5347,32 +5347,32 @@
 	{
 		"assign": "8210",
 		"jp_text": "龍の光の知識「防」",
-		"tr_text": "Light Dragon's Knowledge \"Defend\""
+		"tr_text": "Light Dragon's Knowledge [Defense]"
 	},
 	{
 		"assign": "8220",
 		"jp_text": "龍の光の叡智「防」",
-		"tr_text": "Light Dragon's Wisdom \"Defend\""
+		"tr_text": "Light Dragon's Wisdom [Defense]"
 	},
 	{
 		"assign": "8310",
 		"jp_text": "龍の光の知識「攻」",
-		"tr_text": "Light Dragon's Knowledge \"Attack\""
+		"tr_text": "Light Dragon's Knowledge [Attack]"
 	},
 	{
 		"assign": "8320",
 		"jp_text": "龍の光の叡智「攻」",
-		"tr_text": "Light Dragon's Wisdom \"Attack\""
+		"tr_text": "Light Dragon's Wisdom [Attack]"
 	},
 	{
 		"assign": "8410",
 		"jp_text": "龍の光の知識「術」",
-		"tr_text": "Light Dragon's Knowledge \"Art\""
+		"tr_text": "Light Dragon's Knowledge [Art]"
 	},
 	{
 		"assign": "8420",
 		"jp_text": "龍の光の叡智「術」",
-		"tr_text": "Light Dragon's Wisdom \"Art\""
+		"tr_text": "Light Dragon's Wisdom [Art]"
 	},
 	{
 		"assign": "8510",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -3622,7 +3622,7 @@
 	{
 		"assign": "40138",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": Ability Burst - Bow+""
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40139",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -2942,7 +2942,7 @@
 	{
 		"assign": "40002",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40003",
@@ -2952,7 +2952,7 @@
 	{
 		"assign": "40004",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40005",
@@ -2962,7 +2962,7 @@
 	{
 		"assign": "40006",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40007",
@@ -2972,7 +2972,7 @@
 	{
 		"assign": "40008",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40009",
@@ -2982,7 +2982,7 @@
 	{
 		"assign": "40010",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40011",
@@ -2992,7 +2992,7 @@
 	{
 		"assign": "40012",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40013",
@@ -3002,7 +3002,7 @@
 	{
 		"assign": "40014",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40015",
@@ -3012,7 +3012,7 @@
 	{
 		"assign": "40016",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": "Ability Burst - Assault Rifle＋"
+		"tr_text": "Ability Burst - Assault Rifle+"
 	},
 	{
 		"assign": "40017",
@@ -3022,7 +3022,7 @@
 	{
 		"assign": "40018",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40019",
@@ -3032,7 +3032,7 @@
 	{
 		"assign": "40020",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40021",
@@ -3042,7 +3042,7 @@
 	{
 		"assign": "40022",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": "Ability Burst - Katana＋"
+		"tr_text": "Ability Burst - Katana+"
 	},
 	{
 		"assign": "40023",
@@ -3052,7 +3052,7 @@
 	{
 		"assign": "40024",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": "Ability Burst - Bow＋"
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40025",
@@ -3062,7 +3062,7 @@
 	{
 		"assign": "40026",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40027",
@@ -3072,7 +3072,7 @@
 	{
 		"assign": "40028",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40029",
@@ -3082,7 +3082,7 @@
 	{
 		"assign": "40030",
 		"jp_text": "アビリティバースト・炎法術＋",
-		"tr_text": "Ability Burst - Fire Techniques＋"
+		"tr_text": "Ability Burst - Fire Techniques+"
 	},
 	{
 		"assign": "40031",
@@ -3092,7 +3092,7 @@
 	{
 		"assign": "40032",
 		"jp_text": "アビリティバースト・氷法術＋",
-		"tr_text": "Ability Burst - Ice Techniques＋"
+		"tr_text": "Ability Burst - Ice Techniques+"
 	},
 	{
 		"assign": "40033",
@@ -3102,7 +3102,7 @@
 	{
 		"assign": "40034",
 		"jp_text": "アビリティバースト・風法術＋",
-		"tr_text": "Ability Burst - Wind Techniques＋"
+		"tr_text": "Ability Burst - Wind Techniques+"
 	},
 	{
 		"assign": "40035",
@@ -3112,7 +3112,7 @@
 	{
 		"assign": "40036",
 		"jp_text": "アビリティバースト・雷法術＋",
-		"tr_text": "Ability Burst - Lightning Techniques＋"
+		"tr_text": "Ability Burst - Lightning Techniques+"
 	},
 	{
 		"assign": "40037",
@@ -3122,7 +3122,7 @@
 	{
 		"assign": "40038",
 		"jp_text": "アビリティバースト・光法術＋",
-		"tr_text": "Ability Burst - Light Techniques＋"
+		"tr_text": "Ability Burst - Light Techniques+"
 	},
 	{
 		"assign": "40039",
@@ -3132,7 +3132,7 @@
 	{
 		"assign": "40040",
 		"jp_text": "アビリティバースト・闇法術＋",
-		"tr_text": "Ability Burst - Dark Techniques＋"
+		"tr_text": "Ability Burst - Dark Techniques+"
 	},
 	{
 		"assign": "40041",
@@ -3142,7 +3142,7 @@
 	{
 		"assign": "40042",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40043",
@@ -3152,7 +3152,7 @@
 	{
 		"assign": "40044",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40045",
@@ -3162,7 +3162,7 @@
 	{
 		"assign": "40046",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40047",
@@ -3172,7 +3172,7 @@
 	{
 		"assign": "40048",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40049",
@@ -3182,7 +3182,7 @@
 	{
 		"assign": "40050",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40051",
@@ -3192,7 +3192,7 @@
 	{
 		"assign": "40052",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40053",
@@ -3202,7 +3202,7 @@
 	{
 		"assign": "40054",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40055",
@@ -3212,7 +3212,7 @@
 	{
 		"assign": "40056",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": "Ability Burst - Assault Rifle＋"
+		"tr_text": "Ability Burst - Assault Rifle+"
 	},
 	{
 		"assign": "40057",
@@ -3222,7 +3222,7 @@
 	{
 		"assign": "40058",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40059",
@@ -3232,7 +3232,7 @@
 	{
 		"assign": "40060",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40061",
@@ -3242,7 +3242,7 @@
 	{
 		"assign": "40062",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": "Ability Burst - Katana＋"
+		"tr_text": "Ability Burst - Katana+"
 	},
 	{
 		"assign": "40063",
@@ -3252,7 +3252,7 @@
 	{
 		"assign": "40064",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": "Ability Burst - Bow＋"
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40065",
@@ -3262,7 +3262,7 @@
 	{
 		"assign": "40066",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40067",
@@ -3272,7 +3272,7 @@
 	{
 		"assign": "40068",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40069",
@@ -3342,7 +3342,7 @@
 	{
 		"assign": "40082",
 		"jp_text": "アビリティブラスト・大剣＋",
-		"tr_text": "Ability Blast - Sword＋"
+		"tr_text": "Ability Blast - Sword+"
 	},
 	{
 		"assign": "40083",
@@ -3352,7 +3352,7 @@
 	{
 		"assign": "40084",
 		"jp_text": "アビリティブラスト・自在槍＋",
-		"tr_text": "Ability Blast - Wired Lance＋"
+		"tr_text": "Ability Blast - Wired Lance+"
 	},
 	{
 		"assign": "40085",
@@ -3362,7 +3362,7 @@
 	{
 		"assign": "40086",
 		"jp_text": "アビリティブラスト・長槍＋",
-		"tr_text": "Ability Blast - Partizan＋"
+		"tr_text": "Ability Blast - Partizan+"
 	},
 	{
 		"assign": "40087",
@@ -3372,7 +3372,7 @@
 	{
 		"assign": "40088",
 		"jp_text": "アビリティブラスト・双小剣＋",
-		"tr_text": "Ability Blast - Twin Daggers＋"
+		"tr_text": "Ability Blast - Twin Daggers+"
 	},
 	{
 		"assign": "40089",
@@ -3382,7 +3382,7 @@
 	{
 		"assign": "40090",
 		"jp_text": "アビリティブラスト・両剣＋",
-		"tr_text": "Ability Blast - Double Saber＋"
+		"tr_text": "Ability Blast - Double Saber+"
 	},
 	{
 		"assign": "40091",
@@ -3392,7 +3392,7 @@
 	{
 		"assign": "40092",
 		"jp_text": "アビリティブラスト・鋼拳＋",
-		"tr_text": "Ability Blast - Knuckles＋"
+		"tr_text": "Ability Blast - Knuckles+"
 	},
 	{
 		"assign": "40093",
@@ -3402,7 +3402,7 @@
 	{
 		"assign": "40094",
 		"jp_text": "アビリティブラスト・銃剣＋",
-		"tr_text": "Ability Blast - Gunslash＋"
+		"tr_text": "Ability Blast - Gunslash+"
 	},
 	{
 		"assign": "40095",
@@ -3412,7 +3412,7 @@
 	{
 		"assign": "40096",
 		"jp_text": "アビリティブラスト・長銃＋",
-		"tr_text": "Ability Blast - Assault Rifle＋"
+		"tr_text": "Ability Blast - Assault Rifle+"
 	},
 	{
 		"assign": "40097",
@@ -3422,7 +3422,7 @@
 	{
 		"assign": "40098",
 		"jp_text": "アビリティブラスト・大砲＋",
-		"tr_text": "Ability Blast - Launcher＋"
+		"tr_text": "Ability Blast - Launcher+"
 	},
 	{
 		"assign": "40099",
@@ -3432,7 +3432,7 @@
 	{
 		"assign": "40100",
 		"jp_text": "アビリティブラスト・双機銃＋",
-		"tr_text": "Ability Blast - Twin Machineguns＋"
+		"tr_text": "Ability Blast - Twin Machineguns+"
 	},
 	{
 		"assign": "40101",
@@ -3442,7 +3442,7 @@
 	{
 		"assign": "40102",
 		"jp_text": "アビリティブラスト・長杖＋",
-		"tr_text": "Ability Blast - Rod＋"
+		"tr_text": "Ability Blast - Rod+"
 	},
 	{
 		"assign": "40103",
@@ -3452,7 +3452,7 @@
 	{
 		"assign": "40104",
 		"jp_text": "アビリティブラスト・導具＋",
-		"tr_text": "Ability Blast - Talis＋"
+		"tr_text": "Ability Blast - Talis+"
 	},
 	{
 		"assign": "40105",
@@ -3462,7 +3462,7 @@
 	{
 		"assign": "40106",
 		"jp_text": "アビリティブラスト・短杖＋",
-		"tr_text": "Ability Blast - Wand＋"
+		"tr_text": "Ability Blast - Wand+"
 	},
 	{
 		"assign": "40107",
@@ -3472,7 +3472,7 @@
 	{
 		"assign": "40108",
 		"jp_text": "アビリティブラスト・抜剣＋",
-		"tr_text": "Ability Blast - Katana＋"
+		"tr_text": "Ability Blast - Katana+"
 	},
 	{
 		"assign": "40109",
@@ -3482,7 +3482,7 @@
 	{
 		"assign": "40110",
 		"jp_text": "アビリティブラスト・強弓＋",
-		"tr_text": "Ability Blast - Bow＋"
+		"tr_text": "Ability Blast - Bow+"
 	},
 	{
 		"assign": "40111",
@@ -3492,7 +3492,7 @@
 	{
 		"assign": "40112",
 		"jp_text": "アビリティブラスト・魔装脚＋",
-		"tr_text": "Ability Blast - Jet Boots＋"
+		"tr_text": "Ability Blast - Jet Boots+"
 	},
 	{
 		"assign": "40113",
@@ -3502,7 +3502,7 @@
 	{
 		"assign": "40114",
 		"jp_text": "アビリティブラスト・飛翔剣＋",
-		"tr_text": "Ability Blast - Dual Blades＋"
+		"tr_text": "Ability Blast - Dual Blades+"
 	},
 	{
 		"assign": "40115",
@@ -3512,7 +3512,7 @@
 	{
 		"assign": "40116",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40117",
@@ -3522,7 +3522,7 @@
 	{
 		"assign": "40118",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40119",
@@ -3532,7 +3532,7 @@
 	{
 		"assign": "40120",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40121",
@@ -3542,7 +3542,7 @@
 	{
 		"assign": "40122",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40123",
@@ -3552,7 +3552,7 @@
 	{
 		"assign": "40124",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40125",
@@ -3562,7 +3562,7 @@
 	{
 		"assign": "40126",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40127",
@@ -3572,7 +3572,7 @@
 	{
 		"assign": "40128",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40129",
@@ -3582,7 +3582,7 @@
 	{
 		"assign": "40130",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": "Ability Burst - Assault Rifle＋"
+		"tr_text": "Ability Burst - Assault Rifle+"
 	},
 	{
 		"assign": "40131",
@@ -3592,7 +3592,7 @@
 	{
 		"assign": "40132",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40133",
@@ -3602,7 +3602,7 @@
 	{
 		"assign": "40134",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40135",
@@ -3632,7 +3632,7 @@
 	{
 		"assign": "40140",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40141",
@@ -3642,7 +3642,7 @@
 	{
 		"assign": "40142",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40143",
@@ -3652,7 +3652,7 @@
 	{
 		"assign": "40144",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40145",
@@ -3662,7 +3662,7 @@
 	{
 		"assign": "40146",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40147",
@@ -3672,7 +3672,7 @@
 	{
 		"assign": "40148",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40149",
@@ -3682,7 +3682,7 @@
 	{
 		"assign": "40150",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40151",
@@ -3692,7 +3692,7 @@
 	{
 		"assign": "40152",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40153",
@@ -3702,7 +3702,7 @@
 	{
 		"assign": "40154",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40155",
@@ -3712,7 +3712,7 @@
 	{
 		"assign": "40156",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40157",
@@ -3722,7 +3722,7 @@
 	{
 		"assign": "40158",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": "Ability Burst - Assault Rifle＋"
+		"tr_text": "Ability Burst - Assault Rifle+"
 	},
 	{
 		"assign": "40159",
@@ -3732,7 +3732,7 @@
 	{
 		"assign": "40160",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40161",
@@ -3742,7 +3742,7 @@
 	{
 		"assign": "40162",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40163",
@@ -3752,7 +3752,7 @@
 	{
 		"assign": "40164",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": "Ability Burst - Katana＋"
+		"tr_text": "Ability Burst - Katana+"
 	},
 	{
 		"assign": "40165",
@@ -3762,7 +3762,7 @@
 	{
 		"assign": "40166",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": "Ability Burst - Bow＋"
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40167",
@@ -3772,7 +3772,7 @@
 	{
 		"assign": "40168",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40169",
@@ -3782,7 +3782,7 @@
 	{
 		"assign": "40170",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40171",
@@ -3792,7 +3792,7 @@
 	{
 		"assign": "40172",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40173",
@@ -3802,7 +3802,7 @@
 	{
 		"assign": "40174",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40175",
@@ -3812,7 +3812,7 @@
 	{
 		"assign": "40176",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40177",
@@ -3822,7 +3822,7 @@
 	{
 		"assign": "40178",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40179",
@@ -3832,7 +3832,7 @@
 	{
 		"assign": "40180",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40181",
@@ -3842,7 +3842,7 @@
 	{
 		"assign": "40182",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40183",
@@ -3852,7 +3852,7 @@
 	{
 		"assign": "40184",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40185",
@@ -3862,7 +3862,7 @@
 	{
 		"assign": "40186",
 		"jp_text": "アビリティバースト・長銃＋",
-		"tr_text": "Ability Burst - Assault Rifle＋"
+		"tr_text": "Ability Burst - Assault Rifle+"
 	},
 	{
 		"assign": "40187",
@@ -3872,7 +3872,7 @@
 	{
 		"assign": "40188",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40189",
@@ -3882,7 +3882,7 @@
 	{
 		"assign": "40190",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40191",
@@ -3892,7 +3892,7 @@
 	{
 		"assign": "40192",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": "Ability Burst - Katana＋"
+		"tr_text": "Ability Burst - Katana+"
 	},
 	{
 		"assign": "40193",
@@ -3902,7 +3902,7 @@
 	{
 		"assign": "40194",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": "Ability Burst - Bow＋"
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40195",
@@ -3912,7 +3912,7 @@
 	{
 		"assign": "40196",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40197",
@@ -3922,7 +3922,7 @@
 	{
 		"assign": "40198",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40199",
@@ -3932,7 +3932,7 @@
 	{
 		"assign": "40200",
 		"jp_text": "アビリティバースト・大剣＋",
-		"tr_text": "Ability Burst - Sword＋"
+		"tr_text": "Ability Burst - Sword+"
 	},
 	{
 		"assign": "40201",
@@ -3942,7 +3942,7 @@
 	{
 		"assign": "40202",
 		"jp_text": "アビリティバースト・自在槍＋",
-		"tr_text": "Ability Burst - Wired Lance＋"
+		"tr_text": "Ability Burst - Wired Lance+"
 	},
 	{
 		"assign": "40203",
@@ -3952,7 +3952,7 @@
 	{
 		"assign": "40204",
 		"jp_text": "アビリティバースト・長槍＋",
-		"tr_text": "Ability Burst - Partizan＋"
+		"tr_text": "Ability Burst - Partizan+"
 	},
 	{
 		"assign": "40205",
@@ -3962,7 +3962,7 @@
 	{
 		"assign": "40206",
 		"jp_text": "アビリティバースト・双小剣＋",
-		"tr_text": "Ability Burst - Twin Daggers＋"
+		"tr_text": "Ability Burst - Twin Daggers+"
 	},
 	{
 		"assign": "40207",
@@ -3972,7 +3972,7 @@
 	{
 		"assign": "40208",
 		"jp_text": "アビリティバースト・両剣＋",
-		"tr_text": "Ability Burst - Double Saber＋"
+		"tr_text": "Ability Burst - Double Saber+"
 	},
 	{
 		"assign": "40209",
@@ -3982,7 +3982,7 @@
 	{
 		"assign": "40210",
 		"jp_text": "アビリティバースト・鋼拳＋",
-		"tr_text": "Ability Burst - Knuckles＋"
+		"tr_text": "Ability Burst - Knuckles+"
 	},
 	{
 		"assign": "40211",
@@ -3992,7 +3992,7 @@
 	{
 		"assign": "40212",
 		"jp_text": "アビリティバースト・銃剣＋",
-		"tr_text": "Ability Burst - Gunslash＋"
+		"tr_text": "Ability Burst - Gunslash+"
 	},
 	{
 		"assign": "40213",
@@ -4012,7 +4012,7 @@
 	{
 		"assign": "40216",
 		"jp_text": "アビリティバースト・大砲＋",
-		"tr_text": "Ability Burst - Launcher＋"
+		"tr_text": "Ability Burst - Launcher+"
 	},
 	{
 		"assign": "40217",
@@ -4022,7 +4022,7 @@
 	{
 		"assign": "40218",
 		"jp_text": "アビリティバースト・双機銃＋",
-		"tr_text": "Ability Burst - Twin Machineguns＋"
+		"tr_text": "Ability Burst - Twin Machineguns+"
 	},
 	{
 		"assign": "40219",
@@ -4032,7 +4032,7 @@
 	{
 		"assign": "40220",
 		"jp_text": "アビリティバースト・抜剣＋",
-		"tr_text": "Ability Burst - Katana＋"
+		"tr_text": "Ability Burst - Katana+"
 	},
 	{
 		"assign": "40221",
@@ -4042,7 +4042,7 @@
 	{
 		"assign": "40222",
 		"jp_text": "アビリティバースト・強弓＋",
-		"tr_text": "Ability Burst - Bow＋"
+		"tr_text": "Ability Burst - Bow+"
 	},
 	{
 		"assign": "40223",
@@ -4052,7 +4052,7 @@
 	{
 		"assign": "40224",
 		"jp_text": "アビリティバースト・魔装脚＋",
-		"tr_text": "Ability Burst - Jet Boots＋"
+		"tr_text": "Ability Burst - Jet Boots+"
 	},
 	{
 		"assign": "40225",
@@ -4062,7 +4062,7 @@
 	{
 		"assign": "40226",
 		"jp_text": "アビリティバースト・飛翔剣＋",
-		"tr_text": "Ability Burst - Dual Blades＋"
+		"tr_text": "Ability Burst - Dual Blades+"
 	},
 	{
 		"assign": "40227",
@@ -4392,7 +4392,7 @@
 	{
 		"assign": "40292",
 		"jp_text": "ウェポンエンハンス・雷鋼拳＋",
-		"tr_text": "Weapon Enhance - Lightning Knuckles＋"
+		"tr_text": "Weapon Enhance - Lightning Knuckles+"
 	},
 	{
 		"assign": "40293",
@@ -4432,7 +4432,7 @@
 	{
 		"assign": "40300",
 		"jp_text": "ウェポンエンハンス・炎銃剣＋",
-		"tr_text": "Weapon Enhance - Fire 銃剣＋"
+		"tr_text": "Weapon Enhance - Fire 銃剣+"
 	},
 	{
 		"assign": "40301",
@@ -4682,7 +4682,7 @@
 	{
 		"assign": "40350",
 		"jp_text": "ウェポンエンハンス・氷大砲＋",
-		"tr_text": "Weapon Enhance - Ice Launcher＋"
+		"tr_text": "Weapon Enhance - Ice Launcher+"
 	},
 	{
 		"assign": "40351",
@@ -4842,7 +4842,7 @@
 	{
 		"assign": "40382",
 		"jp_text": "ウェポンエンハンス・闇強弓＋",
-		"tr_text": "Weapon Enhance - Dark Bow＋"
+		"tr_text": "Weapon Enhance - Dark Bow+"
 	},
 	{
 		"assign": "40383",
@@ -4892,7 +4892,7 @@
 	{
 		"assign": "40392",
 		"jp_text": "ウェポンエンハンス・光魔装脚＋",
-		"tr_text": "Weapon Enhance - Light Jet Boots＋"
+		"tr_text": "Weapon Enhance - Light Jet Boots+"
 	},
 	{
 		"assign": "40393",
@@ -4912,7 +4912,7 @@
 	{
 		"assign": "40396",
 		"jp_text": "ウェポンエンハンス・炎長杖＋",
-		"tr_text": "Weapon Enhance - Fire Rod＋"
+		"tr_text": "Weapon Enhance - Fire Rod+"
 	},
 	{
 		"assign": "40397",
@@ -4982,7 +4982,7 @@
 	{
 		"assign": "40410",
 		"jp_text": "ウェポンエンハンス・氷導具＋",
-		"tr_text": "Weapon Enhance - Ice Talis＋"
+		"tr_text": "Weapon Enhance - Ice Talis+"
 	},
 	{
 		"assign": "40411",
@@ -5062,7 +5062,7 @@
 	{
 		"assign": "40426",
 		"jp_text": "ウェポンエンハンス・風短杖＋",
-		"tr_text": "Weapon Enhance - Wind Wand＋"
+		"tr_text": "Weapon Enhance - Wind Wand+"
 	},
 	{
 		"assign": "40427",

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -4,7 +4,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "E.M.A.研究所の爆破事件……<%br>唯一の生存者　ザッカードの保護が<%br>わたしのアークスとしての<%br>初めての任務でした。",
-		"tr_text": "E.M.A. Lab Bombing Incident...\nMy first duty of ARKS was the\nprotection of sole survivor, Zackard.",
+		"tr_text": "The E.M.A. Lab Bombing Incident...\nMy first duty as an ARKS was the\nprotection of the sole survivor, Zackard.",
 		"fileID": 1
 	},
 	{
@@ -20,7 +20,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "「イノセントブルー」によって<%br>生まれたウェポノイド<%br>そして……敵として現れた<%br>ロード達との闘い……",
-		"tr_text": "By \"Innocent Blue\",\nI was born as a Weaponoid,\nAnd also, Lord, who fought\nas our adversary.",
+		"tr_text": "Because of \"Innocent Blue\",\nI was born as a Weaponoid...\nAs was Lord, who fought\nas our adversary.",
 		"fileID": 1
 	},
 	{
@@ -28,7 +28,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "すべては、終わったんだって<%br>そう……思っていました。",
-		"tr_text": "Everything was over... So I thought.",
+		"tr_text": "Everything was over...\nOr so I thought.",
 		"fileID": 1
 	},
 	{
@@ -44,7 +44,7 @@
 		"jp_name": "泣いてる女性",
 		"tr_name": "Crying Woman",
 		"jp_text": "…ヘイ……ド……<%br>ヘイド……",
-		"tr_text": "..Ha..de...<%br>Hade...",
+		"tr_text": "Ha...de...<%br>Hade...",
 		"fileID": 1
 	},
 	{
@@ -52,7 +52,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "……約束だ。<%br>……必ず俺が、ここからお前を出してやる。",
-		"tr_text": "...It's a promise.<%br>I will get you out here.",
+		"tr_text": "I promise you.<%br>I will get you out of here.",
 		"fileID": 1
 	},
 	{
@@ -60,7 +60,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "全員殺して、俺が……<%br>ここからお前を……出してやる。",
-		"tr_text": "I will kill them all...<%br>And get you ... from here.",
+		"tr_text": "I will kill them all...<%br>And take you... away from this place.",
 		"fileID": 1
 	},
 	{
@@ -68,7 +68,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "人間こそが、宇宙を蝕む存在だ……<%br>俺たちは……自由だ、そうだろう？",
-		"tr_text": "",
+		"tr_text": "The humans are a blight on this universe...\nWe... We are free, are we not?",
 		"fileID": 1
 	},
 	{
@@ -84,7 +84,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "誰も知らない悪意は<%br>深い深いその場所で<%br>すでに始まっていました。",
-		"tr_text": "",
+		"tr_text": "Nobody could have known,\nbut in that deep, dark place,\nevil had begun to return to the world.",
 		"fileID": 1
 	},
 	{
@@ -92,7 +92,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "誰かが思いついたことは<%br>すでにどこかで<%br>それは実現している。",
-		"tr_text": "",
+		"tr_text": "By the time anyone realised.\nit was too late.\nIt was already taking shape.",
 		"fileID": 1
 	},
 	{
@@ -100,7 +100,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "わたし達が防いだと思った悪意は<%br>別の場所で、別の誰かが<%br>すでに実現していました……",
-		"tr_text": "",
+		"tr_text": "The evil that we thought we had stopped\nwas manifesting in another place,\nthrough another person.",
 		"fileID": 1
 	},
 	{
@@ -108,7 +108,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "『その……小さな手と<%br>　その　小さな瞳で』",
-		"tr_text": "",
+		"tr_text": "\"With eyes so tiny,\n　and hands so tiny...\"",
 		"fileID": 1
 	},
 	{
@@ -116,7 +116,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "腹が減った……<%br>この子に栄養を与えねば……",
-		"tr_text": "",
+		"tr_text": "I am hungry...\nIf this child goes without sustenance...",
 		"fileID": 1
 	},
 	{
@@ -124,7 +124,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "腹の子が育たぬ。<%br>ヘイド……頼む。",
-		"tr_text": "",
+		"tr_text": "The child within me is not growing.\nHade... please.",
 		"fileID": 1
 	},
 	{
@@ -132,7 +132,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "そうだな。食事の準備をしてこよう……",
-		"tr_text": "",
+		"tr_text": "That's right. Let us get ready to eat...",
 		"fileID": 1
 	},
 	{
@@ -140,7 +140,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "<%name>さん……<%br>今日は来てくれてありがとうございます。",
-		"tr_text": "",
+		"tr_text": "<%name>...\nThank you for coming today.",
 		"fileID": 1
 	},
 	{
@@ -148,7 +148,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "実は今回の任務は<%br>ブルーノさんからの協力要請です。",
-		"tr_text": "",
+		"tr_text": "Actually, this mission is\na request from Bruno.",
 		"fileID": 1
 	},
 	{
@@ -156,7 +156,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "よ！　久しぶりだな<%br><%name>！",
-		"tr_text": "",
+		"tr_text": "Yo! Long time no see,\n<%name>!",
 		"fileID": 1
 	},
 	{
@@ -164,7 +164,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "あれからの、アンタの活躍は噂で聞いてるぜ。",
-		"tr_text": "",
+		"tr_text": "I hear you've been working hard.",
 		"fileID": 1
 	},
 	{
@@ -172,7 +172,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "<%name>さん、まずは……<%br>ブルーノさんの現在の調査任務……いえ。",
-		"tr_text": "",
+		"tr_text": "Firstly, <%name>...\nBruno's current mision is... No.",
 		"fileID": 1
 	},
 	{
@@ -180,7 +180,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "……おふたりが解決した事件の経緯から<%br>一度整理させてください。",
-		"tr_text": "",
+		"tr_text": "Let me explain what has been happening\nsince the incident that we resolved.",
 		"fileID": 1
 	},
 	{
@@ -188,7 +188,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "事の発端は、E.M.A.研究所の<%br>内部告発から始まりました……",
-		"tr_text": "",
+		"tr_text": "It all began with a whistleblower in the E.M.A. Lab...",
 		"fileID": 1
 	},
 	{
@@ -196,7 +196,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "E.M.A.研究所が極秘に開発した<%br>「イノセントブルー」。",
-		"tr_text": "",
+		"tr_text": "The E.M.A. Lab had been secretly\nworking on \"Innocent Blue\".",
 		"fileID": 1
 	},
 	{
@@ -204,7 +204,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "それによって生み出されたのが、武器を<%br>元にして作られたウェポノイドたち……",
-		"tr_text": "",
+		"tr_text": "From that research, Weaponoids\nwere created, based on weapons.",
 		"fileID": 1
 	},
 	{
@@ -212,7 +212,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "その有用性を認めたアークスはウェポノイドを<%br>共に戦う仲間として迎え入れた。",
-		"tr_text": "",
+		"tr_text": "ARKS recognized the Weaponoids' value on the\nbattlefield, welcoming them as comrades in arms.",
 		"fileID": 1
 	},
 	{
@@ -220,7 +220,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "そしてアンタ……、リーダーもウェポノイドを<%br>加えたチームを率いて任務に出た。",
-		"tr_text": "",
+		"tr_text": "And you... The leader of a team who\nundertook missions alongside Weaponoids.",
 		"fileID": 1
 	},
 	{
@@ -228,7 +228,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "その任務を進めるうちに、ウェポノイドと同じ<%br>原理で、エネミーを元に作られた「ダンテ」達……",
-		"tr_text": "",
+		"tr_text": "As that mission progressed, \"Dante\" was created,\nsimilar to a Weaponoid, but based on an enemy.",
 		"fileID": 1
 	},
 	{
@@ -236,7 +236,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "っと、「ダンテ達」のことを、ここからは<%br>「トランスエネミー」と呼ばせてもらう。",
-		"tr_text": "",
+		"tr_text": "We're calling Dante and his people \"Trans Enemies\".",
 		"fileID": 1
 	},
 	{
@@ -244,7 +244,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "そして、奴ら「トランスエネミー」は<%br>俺たちアークスの敵となった。",
-		"tr_text": "",
+		"tr_text": "And those \"Trans Enemies\"\nbecame the enemies of us in ARKS.",
 		"fileID": 1
 	},
 	{
@@ -252,7 +252,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "それによって、「ウェポノイド」まで<%br>危険なんじゃねーかって話が持ち上がった。",
-		"tr_text": "",
+		"tr_text": "Because of that, word got around that\nWeaponoids were somehow dangerous.",
 		"fileID": 1
 	},
 	{
@@ -260,7 +260,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "ですが、トランスエネミーを指揮する<%br>ロードを倒したことで、事件は解決しました。",
-		"tr_text": "",
+		"tr_text": "However, when we defeated Lord, commander\nof the Trans Enemies, that issue was settled.",
 		"fileID": 1
 	},
 	{
@@ -268,7 +268,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "リーダーのお陰で、今ではウェポノイドを<%br>危険視する声はなくなりました。",
-		"tr_text": "",
+		"tr_text": "Thanks to you, Leader, nobody thinks\nWeaponoids are dangerous any more.",
 		"fileID": 1
 	},
 	{
@@ -276,7 +276,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ははは！<%br>俺も結構頑張ったんだけどねぇ？",
-		"tr_text": "",
+		"tr_text": "Hahaha!\nDidn't I have something to do with it, too?",
 		"fileID": 1
 	},
 	{
@@ -284,7 +284,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "す、すみません……<%br>つい……",
-		"tr_text": "",
+		"tr_text": "I-I'm sorry...\nI didn't mean...",
 		"fileID": 1
 	},
 	{
@@ -292,7 +292,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ま！　そんな感じで事件を解決してあのチーム<%br>……ダーカーバスターズは解散した。",
-		"tr_text": "",
+		"tr_text": "But! With that situation defused, our team,\nthe Darker Busters, was dissolved.",
 		"fileID": 1
 	},
 	{
@@ -300,7 +300,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "俺はチームが解散してから半年……ダンテたち<%br>「トランスエネミー」の追跡調査をしていた。",
-		"tr_text": "",
+		"tr_text": "Ever since the team split up six months ago,\nI've been tracking Dante and the Trans Enemies.",
 		"fileID": 1
 	},
 	{
@@ -308,7 +308,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ようやく、ダンテたちの尻尾が掴めた<%br>ってことで、アンタに協力して欲しいんだ。",
-		"tr_text": "",
+		"tr_text": "And now I finally think I have a lead on\nDante, so I want your help to catch him.",
 		"fileID": 1
 	},
 	{
@@ -316,7 +316,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "……ダンテたちを追うなら<%br>ジェネちゃんたちを呼ばなくていいんですか？",
-		"tr_text": "",
+		"tr_text": "If you're pursuing Dante,\ndon't you want to call Gene?",
 		"fileID": 1
 	},
 	{
@@ -324,7 +324,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ジェネちゃんとアネットは……<%br>ダンテたちに情みたいなもんがあるからね……",
-		"tr_text": "",
+		"tr_text": "The thing is, Gene and Annette...\nDante and his people are emotionally unstable.",
 		"fileID": 1
 	},
 	{
@@ -332,7 +332,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ハッピーエンドになる保証がないわけだし……<%br>呼ばない方が俺は、いいと思ってるよ。",
-		"tr_text": "",
+		"tr_text": "I can't say for sure that this will end well.\nBest to keep them out of it.",
 		"fileID": 1
 	},
 	{
@@ -340,7 +340,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "俺も、この任務はできるだけ早く片を付けたい。<%br>それにはアンタ……リーダーの力が必要なんだ。",
-		"tr_text": "",
+		"tr_text": "I want to get this wrapped up as soon as possible.\nTo do that... I need the power of the Leader.",
 		"fileID": 1
 	},
 	{
@@ -348,7 +348,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "頼むよ、リーダー。",
-		"tr_text": "",
+		"tr_text": "What do you say, Leader?",
 		"fileID": 1
 	},
 	{
@@ -356,14 +356,14 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "頼むよ、リーダー。",
-		"tr_text": "",
+		"tr_text": "What do you say, Leader?",
 		"jp_buttons": [
 			"もちろんだ。",
 			"仕方ないな……"
 		],
 		"tr_buttons": [
-			"",
-			""
+			"Of course.",
+			"I have no choice..."
 		],
 		"fileID": 1
 	},
@@ -372,7 +372,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "さっすが、リーダー！<%br>そう言ってくれると、思ってたぜ……",
-		"tr_text": "",
+		"tr_text": "That's the spirit, Leader!\nI had a feeling you'd say that...",
 		"fileID": 1
 	},
 	{
@@ -380,7 +380,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "…………なに、俺とふたりはごめんってか？<%br>つれないこと言うなよなぁー。",
-		"tr_text": "",
+		"tr_text": "What's wrong, aren't we friends?\nThere's no need to be so cold.",
 		"fileID": 1
 	},
 	{
@@ -388,7 +388,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ってことでセラフィさん。<%br>サポート頼むぜ？",
-		"tr_text": "",
+		"tr_text": "How about you, Seraphy?\nWill you be our support?",
 		"fileID": 1
 	},
 	{
@@ -396,7 +396,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "はい。それでは早速ですが<%br>惑星ナベリウスへ向かってください。",
-		"tr_text": "",
+		"tr_text": "Okay. Well then, head to\nplanet Naberius right away.",
 		"fileID": 1
 	},
 	{

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -20,7 +20,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "「イノセントブルー」によって<%br>生まれたウェポノイド<%br>そして……敵として現れた<%br>ロード達との闘い……",
-		"tr_text": "Because of \"Innocent Blue\",\nI was born as a Weaponoid...\nAs was Lord, who fought\nas our adversary.",
+		"tr_text": "From \"Innocent Blue\",\nI was born as a Weaponoid...\nAs was Lord, who fought\nas our adversary.",
 		"fileID": 1
 	},
 	{

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -106,7 +106,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アナティス",
-		"tr_name": "Anatits",
+		"tr_name": "Anatis",
 		"jp_text": "『その……小さな手と<%br>　その　小さな瞳で』",
 		"tr_text": "",
 		"fileID": 1
@@ -1898,7 +1898,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "ふゅ……ふぅ……ふぅ……？",
 		"tr_text": "",
 		"fileID": 1
@@ -1914,7 +1914,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "じぇ……じぇーね？<%br>じぇね……じぇね……",
 		"tr_text": "",
 		"fileID": 1
@@ -1930,7 +1930,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "でゅな、でゅな……",
 		"tr_text": "",
 		"fileID": 1
@@ -2946,7 +2946,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "若い研究員",
-		"tr_name": "",
+		"tr_name": "Older Researcher",
 		"jp_text": "イノセントブルー？　こんなものを<%br>生み出したのか……まさに化け物ですね。",
 		"tr_text": "",
 		"fileID": 1
@@ -2954,7 +2954,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "老年の研究員",
-		"tr_name": "",
+		"tr_name": "Younger researcher",
 		"jp_text": "第二研究所が挙げた最大の成果だ。<%br>それをあのバカは……",
 		"tr_text": "",
 		"fileID": 1
@@ -2962,7 +2962,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "老年の研究員",
-		"tr_name": "",
+		"tr_name": "Older Researcher",
 		"jp_text": "しかし、これを上手く活用すれば、ここの<%br>化け物どもも扱いやすくなるかもしれない。",
 		"tr_text": "",
 		"fileID": 1
@@ -3242,7 +3242,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "……うるさい。<%br>アークス……",
 		"tr_text": "",
 		"fileID": 1
@@ -4202,7 +4202,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "若い研究員",
-		"tr_name": "",
+		"tr_name": "Younger researcher",
 		"jp_text": "わ、分からないのか……言葉を理解しても<%br>貴様らは……うわあぁぁぁぁぁぁっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4210,7 +4210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "老年の研究員",
-		"tr_name": "",
+		"tr_name": "Younger researcher",
 		"jp_text": "……ま、まずい、まずいぞ……なんでだ……<%br>いや、これだけでも……どうにかっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -4218,7 +4218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Older Researcher",
 		"jp_text": "アナティス……ここから出られる。<%br>俺たちはもう、自由だ……",
 		"tr_text": "",
 		"fileID": 2
@@ -4226,7 +4226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4234,7 +4234,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "アナティス……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4242,7 +4242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -4266,7 +4266,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……あぁ、どうした？",
 		"tr_text": "",
 		"fileID": 2
@@ -4274,7 +4274,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "私も、外へ出たほうがいいだろうか？<%br>お前ひとりに……させるわけには……",
 		"tr_text": "",
 		"fileID": 2
@@ -4282,7 +4282,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……いや、アナティス。<%br>ここにいろ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4290,7 +4290,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ここから、出るな。",
 		"tr_text": "",
 		"fileID": 2
@@ -4298,7 +4298,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "塞がれた世界",
 		"tr_text": "",
 		"fileID": 2
@@ -4338,7 +4338,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……アネットさん。<%br>あの……シュトラさんの体は……大丈夫です？",
 		"tr_text": "",
 		"fileID": 2
@@ -4346,7 +4346,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ええ、体調は回復しているわ。ここから先は<%br>チップ研究所に任せることになる。",
 		"tr_text": "",
 		"fileID": 2
@@ -4354,7 +4354,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "私たちを襲ってきた時、確かにシュトラは<%br>ヘイドの命令に従っていた……けど。",
 		"tr_text": "",
 		"fileID": 2
@@ -4362,7 +4362,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あの時の状態は……今のシュトラと比べると<%br>正常な状態だとは思えないわね。",
 		"tr_text": "",
 		"fileID": 2
@@ -4370,7 +4370,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……はい、命令されたことだけを<%br>ただただ、しようとしているようでした。",
 		"tr_text": "",
 		"fileID": 2
@@ -4378,7 +4378,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まるで……本人の……<%br>シュトラさんの、意思を無視したような……",
 		"tr_text": "",
 		"fileID": 2
@@ -4386,7 +4386,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なるほどねぇ……ウェポノイドを悪用する術を<%br>E.M.A.研究所は作ろうとしてた。",
 		"tr_text": "",
 		"fileID": 2
@@ -4394,7 +4394,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "でもそれは、ザッカードが研究を拒み<%br>研究所を爆破したことによって阻止された。",
 		"tr_text": "",
 		"fileID": 2
@@ -4402,7 +4402,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "はい。そのはず……でした。<%br>なのに……なのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -4410,7 +4410,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたし達は、ウェポノイドを……<%br>守ったはずだったのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -4418,7 +4418,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4426,7 +4426,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……寝ちゃったみたいです。",
 		"tr_text": "",
 		"fileID": 2
@@ -4434,7 +4434,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……まだ、幼いものね。子どもはよく寝るものよ。<%br>トランスエネミーの子も、一緒だわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4442,7 +4442,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "にしても……ダンテたちを追ってたはずが<%br>「捕食事件」にデュナちゃん……だもんなぁ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4450,7 +4450,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "どうしたんだよ、ブルーノ？<%br>なんか落ち込んでるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -4458,7 +4458,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いやぁー、最初に「捕食事件」のことを聞いた時は<%br>ここまで大ごとになるって思ってなかったわけよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4466,7 +4466,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それが、ヘイド……新たなトランスエネミーの<%br>存在に繋がるとはなぁ……",
 		"tr_text": "",
 		"fileID": 2
@@ -4474,7 +4474,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ちょ……ちょっとまってください！<%br>まだチームへの正式な紹介が……",
 		"tr_text": "",
 		"fileID": 2
@@ -4482,7 +4482,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……ん？<%br>なんだか、部屋の外が騒がしいな。",
 		"tr_text": "",
 		"fileID": 2
@@ -4490,7 +4490,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "アークスはほんとに馬鹿ばっかり！<%br>「捕食事件」にしてもそうだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -4498,7 +4498,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "だ、誰だ、お前ってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -4506,7 +4506,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "か、カラミティさん……せめて私の<%br>紹介を待ってください。",
 		"tr_text": "",
 		"fileID": 2
@@ -4514,7 +4514,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "んんっ！　それは失礼した。<%br>しっかりボクの紹介をしてくれ、頼んだよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4522,7 +4522,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "以前お伝えした、惑星ウォパルで起きていた<%br>「捕食事件」。その報告者が彼なんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -4530,7 +4530,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "そうっ！　ボクだっ！<%br>君たちアークスはボクの報告を聞かなかった。",
 		"tr_text": "",
 		"fileID": 2
@@ -4538,7 +4538,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "なぜなら馬鹿だからだ。馬鹿だから<%br>報告件数でのみ重要性を判断する、なぜか？",
 		"tr_text": "",
 		"fileID": 2
@@ -4546,7 +4546,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "そう……馬鹿だからだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -4554,7 +4554,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……おい、やめろってば！<%br>今ちょっとだけ、ブルーノ落ち込んでるんだぞ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4562,7 +4562,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……で？<%br>セラフィさん、まさか彼……",
 		"tr_text": "",
 		"fileID": 2
@@ -4570,7 +4570,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "はい。えっと……今回の任務、カラミティさんにも<%br>参加していただきたいと思っています。",
 		"tr_text": "",
 		"fileID": 2
@@ -4578,7 +4578,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "うえぇぇぇー！",
 		"tr_text": "",
 		"fileID": 2
@@ -4586,7 +4586,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "カラミティさん、よろしくお願いします。<%br>わたし、ジェネっていいます！",
 		"tr_text": "",
 		"fileID": 2
@@ -4594,7 +4594,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4602,7 +4602,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "その、君が抱いている子供……<%br>トランスエネミー……だね？",
 		"tr_text": "",
 		"fileID": 2
@@ -4610,7 +4610,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4618,7 +4618,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ボクはトランスエネミーの存在も<%br>独自の調査で気づいた。優秀だから当然だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4626,7 +4626,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "君たちは、ボクがこの任務に参加することを<%br>受け入れるんだ。なぜならボクは優秀だから。",
 		"tr_text": "",
 		"fileID": 2
@@ -4634,7 +4634,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……なんかさ。<%br>アイツ……変なヤツだってば。",
 		"tr_text": "",
 		"fileID": 2
@@ -4642,7 +4642,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いいじゃない。本当に単独でトランスエネミーの<%br>存在までたどり着いたなら、賢いことは確か。",
 		"tr_text": "",
 		"fileID": 2
@@ -4650,7 +4650,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "「賢さ」に自信があるなら、変に一人で行動<%br>されるより……私たちと一緒にいる方がいいわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4658,7 +4658,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……よろしく、カラミティ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4666,7 +4666,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "んんっ！　改めて。<%br>ボクの名前はカラミティ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4674,7 +4674,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "「カラミティソウル」をベースにして生まれた<%br>ウェポノイドだ。よろしく。",
 		"tr_text": "",
 		"fileID": 2
@@ -4682,7 +4682,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "でゅー！<%br>でゅな！",
 		"tr_text": "",
 		"fileID": 2
@@ -4690,7 +4690,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ひいっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4698,7 +4698,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "な、なんだ……子供か……<%br>……あまりボクに近づかないように。",
 		"tr_text": "",
 		"fileID": 2
@@ -4706,7 +4706,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ふぇ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4714,7 +4714,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "それでは、カラミティさんの挨拶も済んだので<%br>次の任務について説明させていただきます。",
 		"tr_text": "",
 		"fileID": 2
@@ -4722,7 +4722,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "現在、複数のアークスから「捕食事件」の<%br>追加報告が入っています。",
 		"tr_text": "",
 		"fileID": 2
@@ -4730,7 +4730,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "それって、ヘイド……彼かもしれない<%br>ってことですよね？",
 		"tr_text": "",
 		"fileID": 2
@@ -4738,7 +4738,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ、ですが……前回確認できた、ヘイドの<%br>生体反応と同一のものとは断定できていません。",
 		"tr_text": "",
 		"fileID": 2
@@ -4746,7 +4746,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……うーん、なるほどっ！　興味があります。<%br>さっそく目撃情報が挙がった場所へ……",
 		"tr_text": "",
 		"fileID": 2
@@ -4754,7 +4754,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "いや。カラミティと……アネット。ふたりは俺と<%br>一緒に、ロードたちのアジトに行くぞ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4762,7 +4762,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……アジト？",
 		"tr_text": "",
 		"fileID": 2
@@ -4770,7 +4770,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ウェポノイドを生み出す仕組みを作った科学者<%br>ザッカードが作ったアジトだ。……興味ない？",
 		"tr_text": "",
 		"fileID": 2
@@ -4778,7 +4778,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "んんっー！！　<%br>それはもう、ぜひとも行きたい……！",
 		"tr_text": "",
 		"fileID": 2
@@ -4786,7 +4786,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ちょっと待って。捕食者は追わないの？<%br>今更あのアジトに、何をしに行くっていうの？",
 		"tr_text": "",
 		"fileID": 2
@@ -4794,7 +4794,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "まぁ……！　ここはリーダーにも相談なんだけど<%br>俺としては、二手に分かれて任務を続けたい。",
 		"tr_text": "",
 		"fileID": 2
@@ -4802,7 +4802,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "捕食者の追跡をやめるわけにもいかないし<%br>そっちは、リーダーたちに任せようかなっと……",
 		"tr_text": "",
 		"fileID": 2
@@ -4810,7 +4810,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "俺たちは、デュナちゃんとヘイドのことを上手く<%br>隠す方法について……ある人に相談しに行く。",
 		"tr_text": "",
 		"fileID": 2
@@ -4818,7 +4818,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……いつまでも、セラフィさんに報告を<%br>誤魔化してもらうのも、限界があるしねぇー。",
 		"tr_text": "",
 		"fileID": 2
@@ -4826,7 +4826,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それって……ブルーノさんが言っていた<%br>「当て」……の人のところに相談に行くんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -4834,7 +4834,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そう、正解！<%br>奴らのアジトはアークスの通信が使えない。",
 		"tr_text": "",
 		"fileID": 2
@@ -4842,7 +4842,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "いっけん面倒な場所だけど……<%br>内緒話をするには、もってこいなんだよね。",
 		"tr_text": "",
 		"fileID": 2
@@ -4850,7 +4850,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4858,7 +4858,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（でも……事件の全容もつかめていないのに<%br>　ジェネやモアと別行動をするのは……危険すぎる）",
 		"tr_text": "",
 		"fileID": 2
@@ -4866,7 +4866,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……どうしたんだよ？<%br>アネット……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4874,7 +4874,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……ブルーノの、言いたいことはわかった。<%br>でも……私は………",
 		"tr_text": "",
 		"fileID": 2
@@ -4882,7 +4882,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ブルーノの、言いたいことはわかった。<%br>でも……私は………",
 		"tr_text": "",
 		"jp_buttons": [
@@ -4898,7 +4898,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……べつに。<%br>リーダーがいれば……",
 		"tr_text": "",
 		"fileID": 2
@@ -4906,7 +4906,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "それに、わかってるわ……<%br>もう十分ふたりは強くなった。",
 		"tr_text": "",
 		"fileID": 2
@@ -4914,7 +4914,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……大丈夫です。<%br>リーダーも、モアも……デュナもいます。",
 		"tr_text": "",
 		"fileID": 2
@@ -4922,7 +4922,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……知ってるわよ。<%br>心配なんか……していないわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4930,7 +4930,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ふゅ？？？",
 		"tr_text": "",
 		"fileID": 2
@@ -4938,7 +4938,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "よーし、こっちも終わったらすぐに<%br>合流するからさ。命大事に、無茶しないようにね。",
 		"tr_text": "",
 		"fileID": 2
@@ -4946,7 +4946,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "はい！　リーダー、モア……デュナ<%br>わたし達も捕食者を追いましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -4954,7 +4954,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おうっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -4962,7 +4962,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -4970,7 +4970,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "それでは、「捕食跡」の報告が入った<%br>惑星リリーパへ向かってください！",
 		"tr_text": "",
 		"fileID": 2
@@ -4978,7 +4978,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "よっしゃあ！<%br>このぐらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -4986,7 +4986,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "セラフィさん、捕食されたって報告のあった場所は<%br>この近くなんだよな？",
 		"tr_text": "",
 		"fileID": 2
@@ -4994,7 +4994,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい、ヘイドの生体反応は捕捉できていませんが<%br>目撃情報を元に追跡を開始しましょう。",
 		"tr_text": "",
 		"fileID": 2
@@ -5002,7 +5002,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……惑星リリーパでの捕食……もしかして<%br>リリーパ族さんも……",
 		"tr_text": "",
 		"fileID": 2
@@ -5010,7 +5010,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "じぇね？<%br>いたいの？　けがー？",
 		"tr_text": "",
 		"fileID": 2
@@ -5018,7 +5018,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。いいえ、大丈夫です。<%br>ただ、少しだけね、悲しいなって思って。",
 		"tr_text": "",
 		"fileID": 2
@@ -5026,7 +5026,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "かなしー？",
 		"tr_text": "",
 		"fileID": 2
@@ -5034,7 +5034,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい。<%br>悲しいは、心がしゅんってなるんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -5042,7 +5042,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "しゅーん……？<%br>かなしい、かなしい？",
 		"tr_text": "",
 		"fileID": 2
@@ -5050,7 +5050,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ジェネ、落ち込んでる場合じゃないってば！<%br>まだ、助けられるかもしれないんだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5058,7 +5058,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……モア。<%br>そうですね。悲しんでる場合じゃないですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5066,7 +5066,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……でもさ、デュナを連れてきて大丈夫なのか？<%br>ヘイドのヤツと、戦うかもしれないのにさ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5074,7 +5074,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ふゅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5082,7 +5082,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そうですね。ただ……アークスシップ内で<%br>デュナちゃんの存在を誤魔化し続けるのも難しく……",
 		"tr_text": "",
 		"fileID": 2
@@ -5090,7 +5090,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "それに、デュナちゃん……ジェネちゃんには<%br>すっかり心を許してくれていますしね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5098,7 +5098,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "あぁ、そっか。たしかに、ジェネが離れようとしたら<%br>デュナ、すごい泣き出しちゃったもんな……",
 		"tr_text": "",
 		"fileID": 2
@@ -5106,7 +5106,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……デュナを、ちゃんと……守らないと。",
 		"tr_text": "",
 		"fileID": 2
@@ -5114,7 +5114,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……デュナを、ちゃんと……守らないと。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -5130,7 +5130,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -5138,7 +5138,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー……",
 		"tr_text": "",
 		"fileID": 2
@@ -5146,7 +5146,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうだってば！<%br>ジェネにはオレとリーダーがついてんだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5154,7 +5154,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "そうですね。<%br>うふふ……ありがとうございます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5162,7 +5162,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みんなで、デュナを守るから……<%br>だから、心配しないでくださいね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5170,7 +5170,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ふゅ？<%br>まーもる？",
 		"tr_text": "",
 		"fileID": 2
@@ -5178,7 +5178,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "おうっ！<%br>任せとけってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5186,7 +5186,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……リーダー、あのっ！<%br>えっと……さっきは、ありがとうございます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5194,7 +5194,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "弱気になると、いつもリーダーが<%br>励ましてくれて……それで……",
 		"tr_text": "",
 		"fileID": 2
@@ -5202,7 +5202,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたし、だからどんな時も……<%br>リーダーと一緒なら頑張れるって思えるんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -5210,7 +5210,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ……ジェネ！　リーダーだけじゃないってば。<%br>オレたちもいるぞ。な、セラフィさん？",
 		"tr_text": "",
 		"fileID": 2
@@ -5218,7 +5218,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あ、えっと！　ごめんなさい……<%br>そういう意味じゃなくって……",
 		"tr_text": "",
 		"fileID": 2
@@ -5226,7 +5226,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もちろんです。私も全力で、みなさんの任務を<%br>サポートさせていただきますね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5234,7 +5234,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はい！　きっとこの捕食の跡の先に……<%br>ヘイドがいるはずです、行きましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5242,7 +5242,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……！<%br>ここにも、ひどい跡が……ありますね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5250,7 +5250,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "じぇね、だーじょぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5258,7 +5258,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……はい、大丈夫です。<%br>わたし、少しだけ疲れやすくって。",
 		"tr_text": "",
 		"fileID": 2
@@ -5266,7 +5266,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ちゅかれる？",
 		"tr_text": "",
 		"fileID": 2
@@ -5274,7 +5274,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……うふふ。つ、か、れ、る。です！<%br>デュナはすぐ言葉を覚える、いい子ですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5282,7 +5282,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あら、学習能力が高いのね。<%br>いいことじゃない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5290,7 +5290,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん！",
 		"tr_text": "",
 		"fileID": 2
@@ -5298,7 +5298,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "私たちは、これからロードがいた……<%br>あのアジト内部に入るわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5306,7 +5306,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "通信ができなくなるから……<%br>その前に連絡しておこうと思って。",
 		"tr_text": "",
 		"fileID": 2
@@ -5314,7 +5314,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット、気をつけてなっ！　ブルーノ……<%br>アネットがケガしないようにしろよ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5322,7 +5322,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はーい、分かってるって……",
 		"tr_text": "",
 		"fileID": 2
@@ -5330,7 +5330,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "アークスの通信が使えないなんて、一体どんな<%br>仕組みで……あぁー、いい、すごくいい！",
 		"tr_text": "",
 		"fileID": 2
@@ -5338,7 +5338,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……カラミティとも仲良くしてるんで<%br>ご心配なく。ははは……",
 		"tr_text": "",
 		"fileID": 2
@@ -5346,7 +5346,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そっちも、気を付けるのよ。彼……<%br>ヘイドはまた、ウェポノイドを使うかもしれない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5354,7 +5354,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ウェポノイド……。シュトラさんのように<%br>ウェポノイドを悪用するかもしれないんですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5362,7 +5362,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……詳しくはシュトラのチップ解析結果を<%br>待つしかないけれど……ヘイドには……",
 		"tr_text": "",
 		"fileID": 2
@@ -5370,7 +5370,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ウェポノイドを使役する方法……<%br>あるいは能力がある……",
 		"tr_text": "",
 		"fileID": 2
@@ -5378,7 +5378,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そう考えて、ほぼ間違いないと思うわ。<%br>だから、警戒することね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5386,7 +5386,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……はい。<%br>アネットさん達も気を付けてくださいね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5394,7 +5394,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……さ！<%br>話も済んだことだし、行くとするかねぇ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5402,7 +5402,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そういえばセラフィさん、デュナとかさ……<%br>その、ヘイドのことって今、どうなってるんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5410,7 +5410,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "オレがあんな風に言っちゃったせいで……<%br>本当は報告しなきゃいけないんだろ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5418,7 +5418,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -5434,7 +5434,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "同じトランスエネミーだからって理由で<%br>デュナのこと……処分したりしないよな？",
 		"tr_text": "",
 		"fileID": 2
@@ -5442,7 +5442,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……モア。",
 		"tr_text": "",
 		"fileID": 2
@@ -5450,7 +5450,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "モアくん……気にしないでください。私が<%br>協力したいと思って自分で判断したことですから。",
 		"tr_text": "",
 		"fileID": 2
@@ -5458,7 +5458,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "今はブルーノさんの「当て」を信じましょう。<%br>……ね、モアくん？",
 		"tr_text": "",
 		"fileID": 2
@@ -5466,7 +5466,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "セラフィさん……<%br>ありがとってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5474,7 +5474,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイドについては、トランスエネミーではなく<%br>ヘイズ・ドラールの異常種として報告してます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5482,7 +5482,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "デュナちゃんについては、全ての報告を<%br>私で止めている状態です。",
 		"tr_text": "",
 		"fileID": 2
@@ -5490,7 +5490,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "シュトラさんは、どうなったんです？<%br>今、チップ研究所なんですよね……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5498,7 +5498,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "「捕食者」追跡任務で巻き込まれた<%br>ウェポノイドとして報告しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -5506,7 +5506,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ただ、シュトラさんのチップが登録されていないと<%br>だいぶ怪しまれていますが……",
 		"tr_text": "",
 		"fileID": 2
@@ -5514,7 +5514,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ってことは、やっぱりあんまり<%br>隠せることじゃないってことなんだな……",
 		"tr_text": "",
 		"fileID": 2
@@ -5522,7 +5522,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "えぇ、なのでブルーノさんの「当て」が<%br>当てにならなかった場合、困りますね……",
 		"tr_text": "",
 		"fileID": 2
@@ -5530,7 +5530,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "うー！　頼りになんかしたくないけど<%br>ブルーノがどうにかするってば！　きっと！",
 		"tr_text": "",
 		"fileID": 2
@@ -5538,7 +5538,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい……！　今は、ブルーノさんを信じて<%br>わたし達は、わたし達の任務を頑張りましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5546,7 +5546,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おうっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5554,7 +5554,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5562,7 +5562,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ふふ……！<%br>デュナも、一緒に頑張ろうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5570,7 +5570,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、前方にグワナーダの反応が<%br>確認できました。気を付けてください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5578,7 +5578,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はい！<%br>行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5586,7 +5586,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、グワナーダ撃破おめでとうございます！",
 		"tr_text": "",
 		"fileID": 2
@@ -5594,7 +5594,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ふゅぅ……うゅ……",
 		"tr_text": "",
 		"fileID": 2
@@ -5602,7 +5602,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はぁ……はぁ……<%br>デュナ、大丈夫ですよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5610,7 +5610,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もう怖いのはいなくなったからな？",
 		"tr_text": "",
 		"fileID": 2
@@ -5618,7 +5618,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ひゅう？<%br>いない、ない？",
 		"tr_text": "",
 		"fileID": 2
@@ -5626,7 +5626,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい……よく我慢しましたね。<%br>いい子です。",
 		"tr_text": "",
 		"fileID": 2
@@ -5634,7 +5634,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ひゃぁー！<%br>いいこ、いいこ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5642,7 +5642,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん、「地下坑道」エリアで<%br>ヘイドと思われる反応が確認できました！",
 		"tr_text": "",
 		"fileID": 2
@@ -5650,7 +5650,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "よっしゃ！<%br>リーダー、ジェネ急ぐってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5658,7 +5658,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "よっしゃ！<%br>リーダー、ジェネ急ぐってば！",
 		"tr_text": "",
 		"jp_buttons": [
@@ -5674,7 +5674,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい！",
 		"tr_text": "",
 		"fileID": 2
@@ -5682,7 +5682,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "一点、報告させてください。<%br>以前のヘイドの反応と異なる点があります。",
 		"tr_text": "",
 		"fileID": 2
@@ -5690,7 +5690,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "実は、少々反応が前回と異なる点があり……<%br>ヘイドとは断定できかねます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5698,7 +5698,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "そ、それってヘイドの仲間かもしれないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -5706,7 +5706,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "その可能性は、ゼロではありません。<%br>警戒してください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5714,7 +5714,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ふぁ……？<%br>むぅ？　むぅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5722,7 +5722,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ、気になるのか？<%br>ここ、迷路みたいだからはぐれちゃダメだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5730,7 +5730,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "迷子になったら、大変なんだからな！<%br>機甲種ってのがいるから、危ないんだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5738,7 +5738,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はぁい。<%br>まいご、ならない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5746,7 +5746,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "でゅな、じぇねのそばにいる。",
 		"tr_text": "",
 		"fileID": 2
@@ -5754,7 +5754,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……！<%br>はい、デュナはわたしの側にいてください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5762,7 +5762,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、反応が近づいています。<%br>ここからはより慎重に進んでください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5770,7 +5770,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "おう！<%br>反応が、ヘイドのものかわからないもんな！",
 		"tr_text": "",
 		"fileID": 2
@@ -5778,7 +5778,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "そうですね、行きましょう。<%br>リーダー、モア……デュナも、ね！",
 		"tr_text": "",
 		"fileID": 2
@@ -5786,7 +5786,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5794,7 +5794,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ここでも……ヘイドに、「捕食」……<%br>されたんでしょうか？",
 		"tr_text": "",
 		"fileID": 2
@@ -5802,7 +5802,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ふゅぅ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -5810,7 +5810,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……大丈夫です。怖くないですよ。<%br>デュナ……",
 		"tr_text": "",
 		"fileID": 2
@@ -5818,7 +5818,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ここ近辺の生体反応が、数時間前に<%br>消失していることが確認できます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5826,7 +5826,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ジェネちゃんが言うように、「捕食」されたとみて<%br>間違いはないと思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -5834,7 +5834,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "な、なぁ……セラフィさん。最初に「捕食」の<%br>報告があったのってどこだっけ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5842,7 +5842,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "みなさんが、惑星ナベリウスで発見するまで<%br>惑星ウォパルでしか報告はありませんでした。",
 		"tr_text": "",
 		"fileID": 2
@@ -5850,7 +5850,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……ヘイズ・ドラールってさ、龍族だろ？<%br>なんで惑星ウォパルなんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5858,7 +5858,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "確かに、そうですよね。<%br>……どうして、ウォパルにいたんでしょうか。",
 		"tr_text": "",
 		"fileID": 2
@@ -5866,7 +5866,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "現在、惑星ウォパルで報告された<%br>「捕食」については調査を開始しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -5874,7 +5874,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "惑星ウォパルの報告以前から<%br>ヘイドが活動していたのか……",
 		"tr_text": "",
 		"fileID": 2
@@ -5882,7 +5882,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "それとも惑星ウォパルから彼が行動範囲を<%br>広げたのが、惑星ナベリウスなのか……",
 		"tr_text": "",
 		"fileID": 2
@@ -5890,7 +5890,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "まもなく、調査を開始している別部隊から<%br>報告が入るかと思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -5898,7 +5898,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -5906,7 +5906,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"jp_buttons": [
@@ -5922,7 +5922,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー……そうですよね。<%br>今は、わたし達にできることを……",
 		"tr_text": "",
 		"fileID": 2
@@ -5930,7 +5930,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうだってば！<%br>オレたちはヘイドを捕まえるんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5938,7 +5938,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "でゅなも、つかまえる！",
 		"tr_text": "",
 		"fileID": 2
@@ -5946,7 +5946,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "不安……",
 		"tr_text": "",
 		"fileID": 2
@@ -5954,7 +5954,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫です。だって、リーダーと……<%br>みんなと一緒ですから！",
 		"tr_text": "",
 		"fileID": 2
@@ -5962,7 +5962,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうそう！　またオレたちが<%br>活躍しちゃうから、大丈夫だって！",
 		"tr_text": "",
 		"fileID": 2
@@ -5970,7 +5970,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "か、つやく、しちゃう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5978,7 +5978,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい……！<%br>そうですね、わたし達にできることを……",
 		"tr_text": "",
 		"fileID": 2
@@ -5986,7 +5986,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー、ジェネちゃん！<%br>この先に反応を確認しました。",
 		"tr_text": "",
 		"fileID": 2
@@ -5994,7 +5994,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "行きましょう！<%br>リーダー！",
 		"tr_text": "",
 		"fileID": 2
@@ -6002,7 +6002,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6010,7 +6010,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "せ、セラフィさん……<%br>反応は……近いです？",
 		"tr_text": "",
 		"fileID": 2
@@ -6018,7 +6018,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "待ってください、今、最新の情報を……",
 		"tr_text": "",
 		"fileID": 2
@@ -6026,7 +6026,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "反応、すぐ近くです！<%br>みなさん、警戒してください！！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6034,7 +6034,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "デュナ……危ない……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6042,7 +6042,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -6058,7 +6058,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "うぅ……<%br>だい、じょうぶ……です……",
 		"tr_text": "",
 		"fileID": 2
@@ -6066,7 +6066,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ふゅ……？<%br>じぇね？　どったの？",
 		"tr_text": "",
 		"fileID": 2
@@ -6074,7 +6074,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "オンナ……いい反応だ。<%br>よくかわしたな。",
 		"tr_text": "",
 		"fileID": 2
@@ -6082,7 +6082,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ジェネ！　大丈夫か！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6090,7 +6090,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "じぇね、いたいの？<%br>いたいいたい？",
 		"tr_text": "",
 		"fileID": 2
@@ -6098,7 +6098,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……大丈夫です。<%br>このくらい……なんてことないですよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6106,7 +6106,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6114,7 +6114,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ひゃっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6122,7 +6122,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あなた、デュナを今、攻撃しましたね？",
 		"tr_text": "",
 		"fileID": 2
@@ -6130,7 +6130,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうして……デュナはあなたと同じ<%br>トランスエネミーなのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -6138,7 +6138,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……「トランスエネミー」？<%br>またお前らは、「名前」をつけるのか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6146,7 +6146,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "そうやって全てを自分たちが知りうるために<%br>勝手に名を付け、管理しようとする。",
 		"tr_text": "",
 		"fileID": 2
@@ -6154,7 +6154,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 2
@@ -6162,7 +6162,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6170,7 +6170,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ひゅ？",
 		"tr_text": "",
 		"fileID": 2
@@ -6178,7 +6178,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "お前らの相手をするのは、まだ先でいい……",
 		"tr_text": "",
 		"fileID": 2
@@ -6186,7 +6186,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……な、なに言ってんだよさっきから！<%br>先とかじゃないってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6194,7 +6194,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "お前は今から、オレたちが捕まえるんだ！<%br>聞かなきゃいけないことがあるんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6202,7 +6202,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なんで……シュトラを……<%br>ウェポノイドをあんなふうに……",
 		"tr_text": "",
 		"fileID": 2
@@ -6210,7 +6210,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ウェポノイドは……アークスに使われることを<%br>選んだ。お前らは、ただの道具だろ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6218,7 +6218,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……クシャネビュラ、こいつらを殺せ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6226,7 +6226,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……！<%br>また、ウェポノイドが……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6234,7 +6234,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "またウェポノイドが、ヘイドの命令で……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6242,7 +6242,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "コロ……ス……コ……ロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6250,7 +6250,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "ひゃぁっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6258,7 +6258,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ひゃぁっ……！",
 		"tr_text": "",
 		"jp_buttons": [
@@ -6274,7 +6274,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "だじょぶ。<%br>ありあと、りだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6282,7 +6282,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "うん、いる。",
 		"tr_text": "",
 		"fileID": 2
@@ -6290,7 +6290,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "コロス、コロス……<%br>アークス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6298,7 +6298,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "彼女も……<%br>アークスに攻撃をする、ウェポノイド……",
 		"tr_text": "",
 		"fileID": 2
@@ -6306,7 +6306,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なんで……<%br>なんでだってば……",
 		"tr_text": "",
 		"fileID": 2
@@ -6314,7 +6314,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -6322,7 +6322,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……クレイモア。<%br>これが……アークスが、しようとしたことだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6330,7 +6330,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6338,7 +6338,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ぶ……ブリュー・リンガーダ……！？",
 		"tr_text": "",
 		"fileID": 2
@@ -6346,7 +6346,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "クシャネビュラ、コイツをつかえ。<%br>……あとは適当に、相手をしてやれ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6354,7 +6354,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あ！<%br>ヘイド、……ま、ま、まてってば！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6362,7 +6362,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "リーダー、ジェネ……<%br>ヘイドのやつ逃げちまうぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6370,7 +6370,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "コロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6378,7 +6378,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "クシャネ……ビュラ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6386,7 +6386,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア、来ますよ……<%br>クシャネビュラと戦わないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -6394,7 +6394,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うぅううああああ……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6402,7 +6402,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "お、おい……<%br>どうしたんだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6410,7 +6410,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイド……サマ……<%br>くっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6418,7 +6418,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "ま、まって……！<%br>うっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6426,7 +6426,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "じぇね、いたいいたいなの？<%br>いたいの……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6434,7 +6434,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……ジェネ、大丈夫か？　さっきヘイドの<%br>攻撃からデュナを庇った時にケガしたんだろ？",
 		"tr_text": "",
 		"fileID": 2
@@ -6442,7 +6442,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……大丈夫です。それより、クシャネビュラが<%br>……逃げてしまいました。",
 		"tr_text": "",
 		"fileID": 2
@@ -6450,7 +6450,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うん……。なぁ、アネットたちにも<%br>クシャネビュラのこと伝えたほうがいいよな。",
 		"tr_text": "",
 		"fileID": 2
@@ -6458,7 +6458,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "そうですね。でも、あのアジトは通信が使えない<%br>はずです。……一度、試してみましょうか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6466,7 +6466,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あねと……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6474,7 +6474,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6482,7 +6482,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あぁあぁ！　すばらしい！<%br>ここは天国だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6490,7 +6490,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……って、なーにほっつき歩いてんだ<%br>カラミティ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6498,7 +6498,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "許してあげなさいよ。抑圧された好奇心が<%br>ようやく満たされてるんだから。",
 		"tr_text": "",
 		"fileID": 2
@@ -6506,7 +6506,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ま、いいけど。",
 		"tr_text": "",
 		"fileID": 2
@@ -6514,7 +6514,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それより、ジェネたちも心配。<%br>早く「当て」とやらに、会わせてちょうだい。",
 		"tr_text": "",
 		"fileID": 2
@@ -6522,7 +6522,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6530,7 +6530,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……ここにボクを連れてきてくれた！<%br>君たちはすばらしいっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6538,7 +6538,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "惑星で既に研究しつくされたエネミーと<%br>戦うなんて退屈だったんだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6546,7 +6546,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ここでは退屈のしようがない！<%br>ははは……あーすばらしい！",
 		"tr_text": "",
 		"fileID": 2
@@ -6554,7 +6554,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……うん？<%br>どうした、ふたりして固まって。",
 		"tr_text": "",
 		"fileID": 2
@@ -6562,7 +6562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ところで、どうして私を連れてきたの？<%br>リーダーでも、ジェネでもなくて……",
 		"tr_text": "",
 		"fileID": 2
@@ -6570,7 +6570,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……なんでだと、思う？",
 		"tr_text": "",
 		"fileID": 2
@@ -6578,7 +6578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "さぁ……？<%br>単に戦力バランスを考えて、かしら。",
 		"tr_text": "",
 		"fileID": 2
@@ -6586,7 +6586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ははは。なーに、そんなにジェネちゃんや<%br>おチビと離れるのが嫌だったのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6594,7 +6594,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6602,7 +6602,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……あのー……その、あれだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6610,7 +6610,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ふたりとも、ボクを置いてけぼりに<%br>しないでくれ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6618,7 +6618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……やっぱり<%br>アネットたちに通信、つながらないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6626,7 +6626,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい。やはりあそこは、アークスの通信を<%br>妨害する仕組みが働いているようですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -6634,7 +6634,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……アネットさん達もきっと、デュナや<%br>ウェポノイドのために頑張ってくれてるんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -6642,7 +6642,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたし達も、頑張って<%br>ヘイドとクシャネビュラを追いましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -6650,7 +6650,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "よっしゃあ！<%br>このくらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6658,7 +6658,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "てばーっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6666,7 +6666,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ、もう怖くないのか？<%br>大丈夫なのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6674,7 +6674,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "でゅな、ないよ。<%br>こわない。",
 		"tr_text": "",
 		"fileID": 2
@@ -6682,7 +6682,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、まもってくれる。<%br>ね？",
 		"tr_text": "",
 		"fileID": 2
@@ -6690,7 +6690,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6698,7 +6698,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -6714,7 +6714,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……「トランスエネミー」？<%br>またお前らは、「名前」をつけるのか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6722,7 +6722,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "そうやって全てを自分たちが知りうるために<%br>勝手に名を付け、管理しようとする。",
 		"tr_text": "",
 		"fileID": 2
@@ -6730,7 +6730,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ふゅ……？<%br>じぇね？？",
 		"tr_text": "",
 		"fileID": 2
@@ -6738,7 +6738,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ……？<%br>じぇね？？",
 		"tr_text": "",
 		"jp_buttons": [
@@ -6754,7 +6754,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あ……いえ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6762,7 +6762,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ……！<%br>うふふ、ごめんね、デュナ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6770,7 +6770,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6778,7 +6778,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "フェル達と、ヘイドは……<%br>なんだか、違うように思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -6786,7 +6786,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "理由ややり方は別にしても、フェル達には<%br>「仲間」だって意識がありました。",
 		"tr_text": "",
 		"fileID": 2
@@ -6794,7 +6794,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "大事にしたい、守りたいって……<%br>そうお互いを思っていたように思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -6802,7 +6802,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "でも、ヘイドは同じトランスエネミーの<%br>デュナに攻撃をしました……",
 		"tr_text": "",
 		"fileID": 2
@@ -6810,7 +6810,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……なんか、ヘイドは怖いってば。<%br>れ、レヴィとかも、ちょっと怖かったけど……",
 		"tr_text": "",
 		"fileID": 2
@@ -6818,7 +6818,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイドの目って、なんかすごく……<%br>すごく、怖いんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6826,7 +6826,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "みゅぅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6834,7 +6834,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6842,7 +6842,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（アレを、殺せなかった。）",
 		"tr_text": "",
 		"fileID": 2
@@ -6850,7 +6850,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（あのオンナは、俺を<%br>　「トランスエネミー」と呼んだ）",
 		"tr_text": "",
 		"fileID": 2
@@ -6858,7 +6858,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（人間……アークス……<%br>　お前らはどうして、こうも傲慢なんだ……）",
 		"tr_text": "",
 		"fileID": 2
@@ -6866,7 +6866,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ぐぅぅおおおおお！！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6874,7 +6874,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "う……あぁ……これは……<%br>わた、私は……",
 		"tr_text": "",
 		"fileID": 2
@@ -6882,7 +6882,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "〔お前だけだ。アナティス。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6890,7 +6890,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……あなて……アナティス？",
 		"tr_text": "",
 		"fileID": 2
@@ -6898,7 +6898,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔お前の名前だ。ここのやつらは、お前を<%br>　そう呼んでいる。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6906,7 +6906,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "アナティス、わた……私、私の名……",
 		"tr_text": "",
 		"fileID": 2
@@ -6914,7 +6914,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔……そうだ。俺はやつらの言葉を理解している。<%br>　特殊な能力のために、ここに連れてこられた。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6922,7 +6922,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔……それから俺はずっと、ここで見てきた。<%br>　数多のエネミーが……使われる様子を。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6930,7 +6930,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "つか、われる？",
 		"tr_text": "",
 		"fileID": 2
@@ -6938,7 +6938,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔実験だ。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6946,7 +6946,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "実験……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6954,7 +6954,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔人間は実験が好きだ。未知を嫌い<%br>　全てを理解しようとする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6962,7 +6962,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔そういう生き物は、「実験」をする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6970,7 +6970,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………うぅ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6978,7 +6978,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド、サマ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6986,7 +6986,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "……なんだ。<%br>殺せなかったのか……",
 		"tr_text": "",
 		"fileID": 2
@@ -6994,7 +6994,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前も……殺せなかったのか……",
 		"tr_text": "",
 		"fileID": 2
@@ -7002,7 +7002,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "みなさん、ヘイドの生体反応が動きを<%br>止めました……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7010,7 +7010,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "この先にいます。急いでください！",
 		"tr_text": "",
 		"fileID": 2
@@ -7018,7 +7018,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はい……！<%br>急ぎましょう、リーダー、モア！",
 		"tr_text": "",
 		"fileID": 2
@@ -7026,7 +7026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おい……！<%br>あれ……クシャネビュラじゃ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7034,7 +7034,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "う……うぅ……うぅぅ……<%br>く……",
 		"tr_text": "",
 		"fileID": 2
@@ -7042,7 +7042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "……さっきの戦いで、すごく傷ついて<%br>弱っていますね……",
 		"tr_text": "",
 		"fileID": 2
@@ -7050,7 +7050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "お、オレ……クシャネビュラと……<%br>戦いたくない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7058,7 +7058,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "だって、アイツもきっと<%br>ヘイドに無理やり戦わされてるんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -7066,7 +7066,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "アイツは悪くないんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -7074,7 +7074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -7082,7 +7082,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"jp_buttons": [
@@ -7098,7 +7098,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうです、クシャネビュラを保護しましょう。<%br>シュトラさんのように助けられるかもしれない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7106,7 +7106,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫だってば。オレ……<%br>アイツを助けたいんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7114,7 +7114,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "うん。そうだね、モア……<%br>助けましょう、クシャネビュラを一緒に！",
 		"tr_text": "",
 		"fileID": 2
@@ -7122,7 +7122,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "クシャネビュラ……お前と戦いたくないんだ。<%br>ケガ……たくさんしてるだろ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7130,7 +7130,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "一緒に、アークスシップに行くってば！<%br>そしたらケガ、治せるから！",
 		"tr_text": "",
 		"fileID": 2
@@ -7138,7 +7138,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "う……アークス、コロス、アークス……",
 		"tr_text": "",
 		"fileID": 2
@@ -7146,7 +7146,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "……そうだ、クシャネビュラ。<%br>アークスは殺せ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7154,7 +7154,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7162,7 +7162,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……ふん。",
 		"tr_text": "",
 		"fileID": 2
@@ -7170,7 +7170,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "クレイモア、こうなった奴は<%br>戻らない……",
 		"tr_text": "",
 		"fileID": 2
@@ -7178,7 +7178,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "モア、危ないです！<%br>今度は空間から、ゼッシュレイダを……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7186,7 +7186,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナ、わたしから離れちゃダメですよ。<%br>行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 2
@@ -7194,7 +7194,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うあぁぁぁぁぁぁっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7202,7 +7202,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "クシャネビュラーっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7210,7 +7210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ぐぐぐ……あ、アークスころ、コロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -7218,7 +7218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "どうして……",
 		"tr_text": "",
 		"fileID": 2
@@ -7226,7 +7226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なんでまだ、アークスをオレたちを<%br>敵だって思ってるんだ……クシャネビュラ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7234,7 +7234,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なんでだよ！　シュトラは、シュトラは……<%br>戦ったあと、様子が変わったのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -7242,7 +7242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -7250,7 +7250,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー、クシャネビュラを……<%br>保護しましょう。このままじゃ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7258,7 +7258,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー、クシャネビュラを……<%br>保護しましょう。このままじゃ……",
 		"tr_text": "",
 		"jp_buttons": [
@@ -7274,7 +7274,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……「保護」か。<%br>また偽りの、聞こえのいい言葉を……",
 		"tr_text": "",
 		"fileID": 2
@@ -7282,7 +7282,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "へ、ヘイド……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7290,7 +7290,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……俺に気づいたか？",
 		"tr_text": "",
 		"fileID": 2
@@ -7298,7 +7298,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……<%br>あなた、何を……",
 		"tr_text": "",
 		"fileID": 2
@@ -7306,7 +7306,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ、あ、……アークス……コロ、ス。",
 		"tr_text": "",
 		"fileID": 2
@@ -7314,7 +7314,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "……クシャネビュラ。<%br>お前はもう無理だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7322,7 +7322,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "俺の血となれ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7330,7 +7330,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "グシャ……グシャ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7346,7 +7346,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ひゃぅぅ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7354,7 +7354,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "どうして……そんな……",
 		"tr_text": "",
 		"fileID": 2
@@ -7362,7 +7362,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "こ、このやろーっ！！<%br>ゆるさないぞー！",
 		"tr_text": "",
 		"fileID": 2
@@ -7370,7 +7370,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "まだだ……<%br>まだ、アークスと戦う力が足りない……",
 		"tr_text": "",
 		"fileID": 2
@@ -7378,7 +7378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "もあ、……だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7386,7 +7386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……お、おう！　大丈夫だってば……<%br>それより、早くヘイドを捕まえないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -7394,7 +7394,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……アイツ……アイツ……<%br>クシャネビュラのこと……食べたんだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7402,7 +7402,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "仲間なのに！　アイツ！",
 		"tr_text": "",
 		"fileID": 2
@@ -7410,7 +7410,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……モアくん。",
 		"tr_text": "",
 		"fileID": 2
@@ -7418,7 +7418,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "恐らくヘイドの捕食能力は、元のエネミーである<%br>ヘイズ・ドラールよりも強化されています。",
 		"tr_text": "",
 		"fileID": 2
@@ -7426,7 +7426,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ヘイズ・ドラールは、ダーカーを捕食し<%br>自らの能力を強化することができますが……",
 		"tr_text": "",
 		"fileID": 2
@@ -7434,7 +7434,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ヘイドは、他のエネミーやウェポノイドをも<%br>捕食の対象にできるのではないかと。",
 		"tr_text": "",
 		"fileID": 2
@@ -7442,7 +7442,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……じゃあ、ヘイドのやつはクシャネビュラを<%br>食べて、強くなったって言うのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -7450,7 +7450,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい。捕食の目的は、やはり<%br>能力の強化の為かと思われます。",
 		"tr_text": "",
 		"fileID": 2
@@ -7458,7 +7458,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "フェル達は、強くなるために<%br>自分の体に強力なフォトンを取り込みました。",
 		"tr_text": "",
 		"fileID": 2
@@ -7466,7 +7466,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それが、自分達を傷つけることになっても……<%br>でもヘイドは、捕食で強くなれる。",
 		"tr_text": "",
 		"fileID": 2
@@ -7474,7 +7474,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それって、すごい危ないってば。<%br>早く、捕まえないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -7482,7 +7482,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "また、また……クシャネビュラみたいな<%br>ウェポノイドが増えたら、オレ嫌だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7490,7 +7490,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……みなさん、確認ができました。<%br>ヘイドは採掘場跡エリアへ移動しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -7498,7 +7498,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "行きましょう、リーダー、モア！",
 		"tr_text": "",
 		"fileID": 2
@@ -7506,7 +7506,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "でゅな！",
 		"tr_text": "",
 		"fileID": 2
@@ -7514,7 +7514,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7522,7 +7522,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はい、デュナも一緒です。",
 		"tr_text": "",
 		"fileID": 2
@@ -7530,7 +7530,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7538,7 +7538,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "じぇね、だーじょぶ？<%br>だーじょうぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7546,7 +7546,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……はい。大丈夫ですよ。<%br>このくらい……",
 		"tr_text": "",
 		"fileID": 2
@@ -7554,7 +7554,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "急ごう。オレたちで、捕まえなきゃいけないんだ。<%br>アネットたちは居ないんだから。",
 		"tr_text": "",
 		"fileID": 2
@@ -7562,7 +7562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あねと、いなーない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7570,7 +7570,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "なーにその、不満でいっぱいの目は。<%br>ふぅ……それなのに付いてきてくれたの？",
 		"tr_text": "",
 		"fileID": 2
@@ -7578,7 +7578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "不満はあるけど、貴方が無意味な判断を<%br>この状況でするとは思っていない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7586,7 +7586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……驚いた。<%br>随分信頼されてんのね、俺。",
 		"tr_text": "",
 		"fileID": 2
@@ -7594,7 +7594,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……信頼なんてしてないわよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7602,7 +7602,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -7610,7 +7610,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "でも、信用ならしている。",
 		"tr_text": "",
 		"fileID": 2
@@ -7618,7 +7618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そう？　頼ってくれてもいいんだけどねー。<%br>ま、そういうのはリーダーに任せるとするよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7626,7 +7626,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "どう考えてもこれから、状況は悪くなる。<%br>ウェポノイドが悪用されちまったんだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7634,7 +7634,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "その事実が上に伝われば、一気に処分……<%br>よくてもウェポノイドは回収される可能性がある。",
 		"tr_text": "",
 		"fileID": 2
@@ -7642,7 +7642,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "おまけに、デュナちゃんだってそうだ。<%br>他のアークスは、必ずあの子の存在を危険視する。",
 		"tr_text": "",
 		"fileID": 2
@@ -7650,7 +7650,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そうね。ウェポノイドは回収……最悪、処分。<%br>デュナも研究所行きでしょうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -7658,7 +7658,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……<%br>そこまでわかってて、ずいぶん余裕そうだな？",
 		"tr_text": "",
 		"fileID": 2
@@ -7666,7 +7666,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "もう私は……「ひとりで頑張らない」って<%br>そう……ジェネと約束したから。",
 		"tr_text": "",
 		"fileID": 2
@@ -7674,7 +7674,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "言ったでしょう？　信頼はしてないけど<%br>貴方のことだって「信用」はしているわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7682,7 +7682,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……変わったねぇ……ほんとに。",
 		"tr_text": "",
 		"fileID": 2
@@ -7690,7 +7690,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "アネット、カラミティ……<%br>お前らに会わせたい人がいる。",
 		"tr_text": "",
 		"fileID": 2
@@ -7698,7 +7698,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "話は、アナタからしてくれよ……<%br>来ているんでしょう？",
 		"tr_text": "",
 		"fileID": 2
@@ -7706,7 +7706,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "次席……",
 		"tr_text": "",
 		"fileID": 2
@@ -7714,7 +7714,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -7738,7 +7738,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（彼女いつの間に……ここに居たのかしら。<%br>　私には、気づけなかった）",
 		"tr_text": "",
 		"fileID": 2
@@ -7746,7 +7746,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………<%br>ブルーノ、貴方の「当て」は……彼女ってこと？",
 		"tr_text": "",
 		"fileID": 2
@@ -7754,7 +7754,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "おっと！　この方はこう見えても、俺よりずっと<%br>上の地位にいる人だ。言葉には気を付けてな？",
 		"tr_text": "",
 		"fileID": 2
@@ -7762,7 +7762,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ど、どこから出てきたんだ！？<%br>す、すごいぞ……こんなのありえない……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7770,7 +7770,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラミティ……少し、黙ってて。",
 		"tr_text": "",
 		"fileID": 2
@@ -7778,7 +7778,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "次席と呼ばれた女性",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……初めまして。<%br>あなたがアネット、ですね？",
 		"tr_text": "",
 		"fileID": 2
@@ -7794,7 +7794,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ブルーノ、貴方が報告をせっせと上げていた<%br>相手が、この方ってことね。",
 		"tr_text": "",
 		"fileID": 2
@@ -7802,7 +7802,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "理解が早くて助かるよ。<%br>やっぱ、お前を次席に会わせたのは正解だな。",
 		"tr_text": "",
 		"fileID": 2
@@ -7810,7 +7810,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "いきなりですので、どこまで信用いただけるかは<%br>わかりませんが……",
 		"tr_text": "",
 		"fileID": 2
@@ -7818,7 +7818,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "わたしは、あなた達に協力したいと思っています。",
 		"tr_text": "",
 		"fileID": 2
@@ -7826,7 +7826,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "新たなトランスエネミー「デュナ」と<%br>「ヘイド」の報告は、ブルーノから受けました。",
 		"tr_text": "",
 		"fileID": 2
@@ -7834,7 +7834,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "エネミーを捕食し<%br>空間転移能力を持つ龍族……",
 		"tr_text": "",
 		"fileID": 2
@@ -7842,7 +7842,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "信じたくはないですが、あの組織の研究が<%br>元になっている可能性は、否定できない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7850,7 +7850,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ならば、この件はアークスにとって脅威となる。<%br>解決しなければなりません。",
 		"tr_text": "",
 		"fileID": 2
@@ -7858,7 +7858,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "あの「組織」？<%br>E.M.A.研究所のこと？",
 		"tr_text": "",
 		"fileID": 2
@@ -7866,7 +7866,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……すみません。これは単なるわたしの憶測。<%br>少し言葉がすぎました。",
 		"tr_text": "",
 		"fileID": 2
@@ -7874,7 +7874,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ですが……多くは語れませんが<%br>空間転移能力を持つ龍族については……",
 		"tr_text": "",
 		"fileID": 2
@@ -7882,7 +7882,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "わたしにとっても浅からぬ因縁があります。<%br>その為、力になりたいと考えています。",
 		"tr_text": "",
 		"fileID": 2
@@ -7890,7 +7890,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "………………",
 		"tr_text": "",
 		"fileID": 2
@@ -7898,7 +7898,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "時間が惜しいので、率直に<%br>聞かせて貰うわ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7906,7 +7906,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "上層部への、「ヘイド」「デュナ」の報告を貴方の<%br>ところで止めることができる……ということかしら？",
 		"tr_text": "",
 		"fileID": 2
@@ -7914,7 +7914,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ。それは心配しないでください。",
 		"tr_text": "",
 		"fileID": 2
@@ -7922,7 +7922,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ただ、わたしより上に気づかれる前に<%br>この事件を解決しなければなりません。",
 		"tr_text": "",
 		"fileID": 2
@@ -7930,7 +7930,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……悠長なことは、言ってられない。<%br>そういうこと……ね。",
 		"tr_text": "",
 		"fileID": 2
@@ -7938,7 +7938,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "彼が、あなたをわたしに会わせたということは<%br>信じるに足ると、判断したのでしょう。",
 		"tr_text": "",
 		"fileID": 2
@@ -7946,7 +7946,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7954,7 +7954,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ま、俺もお前を信用してるってことだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7962,7 +7962,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……アネット……それから、カラミティ<%br>ここは、アークスの通信が利かない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7970,7 +7970,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ここでこの方とお前らを会わせたのは<%br>この先何かが起きたとき……の、ためだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7978,7 +7978,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "んんっ？<%br>この先何かって、何が起きるっていうんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7986,7 +7986,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……さぁねぇ？<%br>まぁ、念のためってやつだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7994,7 +7994,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "お前らも、この人と顔を繋いでおいた方が<%br>いいんじゃねーかって思っただけだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8002,7 +8002,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -8010,7 +8010,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あぁ、そうだアネット。これからは研究報告は<%br>お前から直接してくれよ？　",
 		"tr_text": "",
 		"fileID": 2
@@ -8018,7 +8018,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……分かったわ。<%br>改めて、どうぞよろしく。",
 		"tr_text": "",
 		"fileID": 2
@@ -8026,7 +8026,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "みなさん、ヘイドはもうすぐそこです。<%br>急いでください……！",
 		"tr_text": "",
 		"fileID": 2
@@ -8034,7 +8034,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "わ、わかってるってば！<%br>行くぞ、リーダー、ジェネ……っとデュナもな！",
 		"tr_text": "",
 		"fileID": 2
@@ -8042,7 +8042,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "もな！",
 		"tr_text": "",
 		"fileID": 2
@@ -8050,7 +8050,7 @@
 	{
 		"eventNo": "39",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい、急ぎましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -8058,7 +8058,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -8066,7 +8066,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "追いついたぞ！　ヘイド！<%br>お前のこと、オレは絶対許さないってば！！",
 		"tr_text": "",
 		"fileID": 2
@@ -8074,7 +8074,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイド……どうして、どうして<%br>クシャネビュラを……仲間を……食べたのっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8082,7 +8082,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……「食べる」。<%br>それに理由がいるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8090,7 +8090,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 2
@@ -8098,7 +8098,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "お前らアークスはそうやって、なんにでも<%br>「理由」をつけようとする。",
 		"tr_text": "",
 		"fileID": 2
@@ -8106,7 +8106,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "それも真実なんてどうでもいい。<%br>自分たちが「納得」できる「説明」が欲しいだけだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8114,7 +8114,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……どういう、意味です？",
 		"tr_text": "",
 		"fileID": 2
@@ -8122,7 +8122,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "俺が食べることに理由はない。<%br>オンナ、お前は呼吸や、瞬きに理由がいるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8130,7 +8130,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "生きる上で必要だからしたことだ。<%br>ただ、それだけだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -8138,7 +8138,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……クシャネビュラを……捕食したのは<%br>生きる上で、必要だった？",
 		"tr_text": "",
 		"fileID": 2
@@ -8146,7 +8146,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あぁ、アークスという強大な力の前に<%br>今の俺では叶わない……",
 		"tr_text": "",
 		"fileID": 2
@@ -8154,7 +8154,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "食べなければ、お前らアークスを<%br>殺し尽くすことは……できない。",
 		"tr_text": "",
 		"fileID": 2
@@ -8162,7 +8162,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あなたは、どうして……<%br>アークスを殺したいと、思うんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -8170,7 +8170,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうして、同じトランスエネミーの<%br>デュナに攻撃したんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -8178,7 +8178,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……どうしてお前らアークスは<%br>俺や、そこのクレイモアを作り出した？",
 		"tr_text": "",
 		"fileID": 2
@@ -8186,7 +8186,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "この世界にないはずのものを、勝手に作り出す。<%br>そして名前をつけ管理をしたがる。",
 		"tr_text": "",
 		"fileID": 2
@@ -8194,7 +8194,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前たちアークス以上に……<%br>危険な存在はいるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8202,7 +8202,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "へ、ヘイド……<%br>あなたは、誰に作られたんです……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8210,7 +8210,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "一体……何が……",
 		"tr_text": "",
 		"fileID": 2
@@ -8218,7 +8218,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ひゅあっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8226,7 +8226,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ？　どうしました……",
 		"tr_text": "",
 		"fileID": 2
@@ -8234,7 +8234,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "手にした力を試すにはちょうどいい。<%br>コドモ、お前もここで死ぬんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -8242,7 +8242,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "デュナは下がるんだ！<%br>ジェネ、リーダー……アイツを止めるってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -8250,7 +8250,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "これは！！　みなさん、気を付けてください！<%br>ヘイドのフォトン量が異常に増加しています！",
 		"tr_text": "",
 		"fileID": 2
@@ -8258,7 +8258,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はい……っ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8266,7 +8266,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "『ウォオォォォォォォォッ！！』",
 		"tr_text": "",
 		"fileID": 2
@@ -8274,7 +8274,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……くっ……これが、アークス。<%br>アークスの、力……か……",
 		"tr_text": "",
 		"fileID": 2
@@ -8282,7 +8282,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "今はまだ、戦える相手では……ない。<%br>お前らも倒せないようでは、まだ、ダメだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8290,7 +8290,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "もっと、もっと喰らわねば。<%br>……力が必要だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8298,7 +8298,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ま、まって……！<%br>ヘイド……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -8306,7 +8306,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "逃げんなー！<%br>ヘイド、お前は、お前だけは許せないんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8314,7 +8314,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -8322,7 +8322,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……もあ？<%br>どったの……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8330,7 +8330,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……心配してくれたのか？<%br>へへ、ありがとな、大丈夫だぜ？",
 		"tr_text": "",
 		"fileID": 2
@@ -8338,7 +8338,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "…………<%br>リーダー、ジェネ……オレさ……",
 		"tr_text": "",
 		"fileID": 2
@@ -8346,7 +8346,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……たださ、クシャネビュラが……<%br>かわいそうで、悔しいってば。",
 		"tr_text": "",
 		"fileID": 2
@@ -8354,7 +8354,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "だって、もしかしたら、ウェポノイドは……<%br>オレだって同じ風になってたかもしれないんだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8362,7 +8362,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "だから、助けたかった……",
 		"tr_text": "",
 		"fileID": 2
@@ -8370,7 +8370,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -8378,7 +8378,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、無事帰還できてよかったです。<%br>モアくん、辛い思いをしましたね……",
 		"tr_text": "",
 		"fileID": 2
@@ -8386,7 +8386,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……落ち込んでなんかいられないってば<%br>だって……他のウェポノイドを守るんだかんなっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8394,7 +8394,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "うん、そうだね……モア。<%br>一緒に頑張りましょうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -8402,7 +8402,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ふぁ……。じぇね……ねぇねぇー。<%br>おーたうたって。",
 		"tr_text": "",
 		"fileID": 2
@@ -8410,7 +8410,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ？<%br>どうしたんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -8418,7 +8418,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おーた、うたって？",
 		"tr_text": "",
 		"fileID": 2
@@ -8426,7 +8426,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "なんだ？　デュナのやつ、眠そうじゃないか？<%br>あれだ、ジェネに子守歌歌ってほしいんだな？",
 		"tr_text": "",
 		"fileID": 2
@@ -8434,7 +8434,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "こ、子守歌……です？",
 		"tr_text": "",
 		"fileID": 2
@@ -8442,7 +8442,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なんだか、デュナって<%br>ジェネのことママだと思ってんじゃないか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8450,7 +8450,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "えぇ！？<%br>ママ、に見えます？",
 		"tr_text": "",
 		"fileID": 2
@@ -8458,7 +8458,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8466,7 +8466,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、まま？",
 		"tr_text": "",
 		"fileID": 2
@@ -8474,7 +8474,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "えへへ。<%br>なんだか、ちょっと嬉しいです。",
 		"tr_text": "",
 		"fileID": 2
@@ -8482,7 +8482,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あっ、そーだ！　なぁなぁ、セラフィさん<%br>アネットたちはまだ戻ってきてないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8490,7 +8490,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい……今も通信は繋がらないので<%br>恐らく、まだアジト内部にいるのだと思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -8498,7 +8498,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "そっか……大丈夫かな？",
 		"tr_text": "",
 		"fileID": 2
@@ -8506,7 +8506,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "心配ですね……",
 		"tr_text": "",
 		"fileID": 2
@@ -8514,7 +8514,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "貴方が言っていた、「あの組織」……<%br>E.M.A.じゃないなら……",
 		"tr_text": "",
 		"fileID": 2
@@ -8522,7 +8522,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "もしかして、「虚空機関（ヴォイド）」？<%br>まさか、もう閉鎖されたはず……",
 		"tr_text": "",
 		"fileID": 2
@@ -8530,7 +8530,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ブルーノ……彼女は確かに<%br>あなたの報告通り、勘がいいですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -8538,7 +8538,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……でしょう？<%br>ま、ややマイナス思考なところはありますが。",
 		"tr_text": "",
 		"fileID": 2
@@ -8546,7 +8546,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "虚空機関は様々な、人体・生物実験を<%br>していたと言われる研究機関……",
 		"tr_text": "",
 		"fileID": 2
@@ -8554,7 +8554,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そして、E.M.A.によって生み出された<%br>トランスエネミー達……もしかしてヘイドは……",
 		"tr_text": "",
 		"fileID": 2
@@ -8562,7 +8562,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……はい。その虚空機関の研究がE.M.A.に<%br>引き継がれて……生み出されたと考えています。",
 		"tr_text": "",
 		"fileID": 2
@@ -8570,7 +8570,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……アークス。<%br>お前らは、恐ろしい生き物だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8578,7 +8578,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔人間は実験が好きだ。未知を嫌い<%br>　全てを理解しようとする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8586,7 +8586,7 @@
 	{
 		"eventNo": "39",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔そういう生き物は、「実験」をする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8594,7 +8594,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔人間は実験が好きだ。未知を嫌い<%br>　全てを理解しようとする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8602,7 +8602,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔そういう生き物は、「実験」をする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8610,7 +8610,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "人間、あの……<%br>白い衣をまとった生物のことか。",
 		"tr_text": "",
 		"fileID": 2
@@ -8618,7 +8618,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔あぁ。実験はこの世界の摂理で起きない事象を<%br>　無理やり起こす。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8626,7 +8626,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔その結果、お前は人間の姿を手に入れた。<%br>　そして……〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8634,7 +8634,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔その実験で、お前以外の生き物は<%br>　すべて、死んだ。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8642,7 +8642,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔「実験」「失敗」というやつだ。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8650,7 +8650,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "なんという……<%br>なんでだ！　知るために、殺すのか！",
 		"tr_text": "",
 		"fileID": 2
@@ -8658,7 +8658,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔……憎いか？　人間が。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8666,7 +8666,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "憎い……<%br>憎まずにおれるのか！",
 		"tr_text": "",
 		"fileID": 2
@@ -8674,7 +8674,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔俺は明日、お前と同じ「実験」を受ける。<%br>　ほとんどの確率で「失敗」するだろう。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8682,7 +8682,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -8690,7 +8690,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔俺は、人の言葉が理解できる。<%br>　奴らの言葉を、ずっと聞いてきた……〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8698,7 +8698,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "〔奴らの傲慢さも、恐ろしさも全て聞いてきた。<%br>　ようやく、この恐ろしい地獄が終わる〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8706,7 +8706,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……死ぬな。",
 		"tr_text": "",
 		"fileID": 2
@@ -8714,7 +8714,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔……〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8722,7 +8722,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "死なないでくれ。<%br>名を……名を教えてくれ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8730,7 +8730,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "〔……ヘイド〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8738,7 +8738,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド、死ぬな。<%br>もし死なれたら、私はここにひとりだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8746,7 +8746,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "共に……この地獄から、出よう。<%br>ヘイド……だから、死なないでくれ……頼む。",
 		"tr_text": "",
 		"fileID": 2
@@ -8754,7 +8754,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……アークス。<%br>お前らは、恐ろしい生き物だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8762,7 +8762,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "塞がれた世界",
 		"tr_text": "",
 		"fileID": 2
@@ -8810,7 +8810,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………！",
 		"tr_text": "",
 		"fileID": 3
@@ -8818,7 +8818,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 3
@@ -8826,7 +8826,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……ヘイド？<%br>どうした……ケガを、しているのか。",
 		"tr_text": "",
 		"fileID": 3
@@ -8834,7 +8834,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……いや。<%br>それより……機嫌がいいな。",
 		"tr_text": "",
 		"fileID": 3
@@ -8842,7 +8842,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ふふ……<%br>すこし、腹の子が大きくなったと思わないか？",
 		"tr_text": "",
 		"fileID": 3
@@ -8850,7 +8850,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -8858,7 +8858,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あぁ、そうだな。<%br>よかったな、アナティス。",
 		"tr_text": "",
 		"fileID": 3
@@ -8866,7 +8866,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "それぞれの「理由」",
 		"tr_text": "",
 		"fileID": 3
@@ -8882,7 +8882,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "あははー、思いのほか時間かかっちゃってね。<%br>ごめんねー？",
 		"tr_text": "",
 		"fileID": 3
@@ -8890,7 +8890,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "でも、ま……！　これで、みんなが心配してた<%br>デュナちゃんのことは、内緒にできるはずだよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -8898,7 +8898,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ブルーノさん……アネットさん、カラミティさん<%br>ありがとうございます！　よかった……",
 		"tr_text": "",
 		"fileID": 3
@@ -8906,7 +8906,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ぶーの、あねと、からみて……<%br>ありあとー。",
 		"tr_text": "",
 		"fileID": 3
@@ -8914,7 +8914,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あら。ずいぶん喋れるようになったのね。<%br>ヒトよりずっと、成長が早いわね。",
 		"tr_text": "",
 		"fileID": 3
@@ -8922,7 +8922,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "みなさん……１点、ご報告があります。",
 		"tr_text": "",
 		"fileID": 3
@@ -8930,7 +8930,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "シュトラさんのチップ解析が終わったのですが<%br>特に異常はみられませんでした。",
 		"tr_text": "",
 		"fileID": 3
@@ -8938,7 +8938,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……そっか。うーん……？<%br>でもたしかに、あの時様子は違ったよね。",
 		"tr_text": "",
 		"fileID": 3
@@ -8946,7 +8946,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……確か、戦ったあと……この子が……<%br>デュナがシュトラを撫でた……わよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -8954,7 +8954,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ふゅ？",
 		"tr_text": "",
 		"fileID": 3
@@ -8962,7 +8962,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……アネット……さん？",
 		"tr_text": "",
 		"fileID": 3
@@ -8970,7 +8970,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "この子はどんな能力を利用されるために……<%br>トランスエネミーとして生まれたのかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -8978,7 +8978,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……あにぇっと？<%br>どーしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -8986,7 +8986,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ま！　デュナちゃんのことは、ヘイドを<%br>追っていけば、自然と分かるんじゃないかな？",
 		"tr_text": "",
 		"fileID": 3
@@ -8994,7 +8994,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "みゅ？　わかる？<%br>ふぅー？",
 		"tr_text": "",
 		"fileID": 3
@@ -9002,7 +9002,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……そうね。デュナがシュトラを撫でたことが<%br>紐づいているとは、まだ断定できないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9010,7 +9010,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうっ！<%br>その面白いウェポノイド！",
 		"tr_text": "",
 		"fileID": 3
@@ -9018,7 +9018,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "そんな面白いウェポノイド……ボクが<%br>チップを解析したかった。ボクなら何か……",
 		"tr_text": "",
 		"fileID": 3
@@ -9026,7 +9026,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "そうだ、管理官！　シュトラとやらの尋問と<%br>チップの検査をボクにさせて……",
 		"tr_text": "",
 		"fileID": 3
@@ -9034,7 +9034,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "面白いウェポノイド……？<%br>何言ってんだよお前！",
 		"tr_text": "",
 		"fileID": 3
@@ -9042,7 +9042,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ……！<%br>お前、もう……えっと、その……",
 		"tr_text": "",
 		"fileID": 3
@@ -9050,7 +9050,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……アンタたちに、攻撃なんかもうしない。<%br>その……記憶がないんだ、攻撃したときの。",
 		"tr_text": "",
 		"fileID": 3
@@ -9058,7 +9058,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "記憶がないって言っても、攻撃をしたことは<%br>事実だ。……その……だから、悪かった。",
 		"tr_text": "",
 		"fileID": 3
@@ -9066,7 +9066,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラは悪くないって思うぞ。<%br>それより、よかった……よかったってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -9074,7 +9074,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "記憶がない。……チップに異常もない。<%br>そもそも自我を持つウェポノイドに……",
 		"tr_text": "",
 		"fileID": 3
@@ -9082,7 +9082,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "アンタが、リーダーだって聞いた。<%br>オレを任務に、このチームに加えてくれないか？",
 		"tr_text": "",
 		"fileID": 3
@@ -9090,7 +9090,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アンタが、リーダーだって聞いた。<%br>オレを任務に、このチームに加えてくれないか？",
 		"tr_text": "",
 		"jp_buttons": [
@@ -9106,7 +9106,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……あ、ありがとう。<%br>オレ、少しでも戦力になれるように、がんばるよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9114,7 +9114,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "でゅなもー、いっしょ、がんばるね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9122,7 +9122,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "リーダー！<%br>オレからもお願いだってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -9130,7 +9130,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "でゅなもー。ねがい、てば。<%br>ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9138,7 +9138,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "リーダーの心配もわかるけど、私は賛成よ。<%br>いいんじゃないかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -9146,7 +9146,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（シュトラの状態を観察するには<%br>　行動を共にするのが一番手っ取り早い……）",
 		"tr_text": "",
 		"fileID": 3
@@ -9154,7 +9154,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "よーしっ！　ってことで、シュトラ。<%br>そんな気ぃ張りすぎるなよ、よろしくな。",
 		"tr_text": "",
 		"fileID": 3
@@ -9162,7 +9162,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……うん、その……よろしく。",
 		"tr_text": "",
 		"fileID": 3
@@ -9170,7 +9170,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラさん、一緒にがんばりましょうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9178,7 +9178,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "がんばりーしょーね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9186,7 +9186,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あ……あぁ、うん。",
 		"tr_text": "",
 		"fileID": 3
@@ -9194,7 +9194,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……で、君。リーダー達との戦闘中<%br>記憶がないって言っていたが……",
 		"tr_text": "",
 		"fileID": 3
@@ -9202,7 +9202,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "いや、まず質問はそこからじゃないな。<%br>一度チップの中に戻ってもらって……",
 		"tr_text": "",
 		"fileID": 3
@@ -9210,7 +9210,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "うっせぇな。お前、なんなんだよ。<%br>……オレはこのチームに入ったんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9218,7 +9218,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "リーダーの指示ならきくけど……<%br>お前にどうこう言われたくねー！",
 		"tr_text": "",
 		"fileID": 3
@@ -9226,7 +9226,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………！！",
 		"tr_text": "",
 		"fileID": 3
@@ -9234,7 +9234,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "お……怒られた？",
 		"tr_text": "",
 		"fileID": 3
@@ -9242,7 +9242,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "おーられた。<%br>……からみて、いいこいいこ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9250,7 +9250,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9258,7 +9258,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "いいこ、いいこ。<%br>いちゃいの、ないない！",
 		"tr_text": "",
 		"fileID": 3
@@ -9266,7 +9266,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9274,7 +9274,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ち、近づくな、子供！<%br>そしてボクをな、なでるなぁ……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9282,7 +9282,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……みなさん、今しがたこのチームに<%br>「特例」が適用されることになりました。",
 		"tr_text": "",
 		"fileID": 3
@@ -9290,7 +9290,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "これから先の任務については<%br>ブルーノさんがすべての報告を上げる……",
 		"tr_text": "",
 		"fileID": 3
@@ -9298,7 +9298,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "つまり、管理官として私から通常ルートでの<%br>報告は、行わないことになりました。",
 		"tr_text": "",
 		"fileID": 3
@@ -9306,7 +9306,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……なぁ、これがブルーノが<%br>「あて」とか言ってたやつのことか？",
 		"tr_text": "",
 		"fileID": 3
@@ -9314,7 +9314,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……これで私たちの、ヘイド捕獲任務は<%br>内密に行われることになるわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9322,7 +9322,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "俺の上司っていうのかな……お願いしたのよ。<%br>この任務の指示系統を、通常と分けてほしいって。",
 		"tr_text": "",
 		"fileID": 3
@@ -9330,7 +9330,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "シュトラのことも、デュナちゃんのことも<%br>これで、しょっ引かれたりはしないさ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9338,7 +9338,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "つまりは、ボクらのお陰でトランスエネミーの<%br>子供は捕獲されずにすむ、ということだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9346,7 +9346,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……「ボクら」じゃなくて、それってその<%br>おっさんの上司のお陰じゃね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9354,7 +9354,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "おっさん……おっさんかぁ……<%br>いいけどね。うん。",
 		"tr_text": "",
 		"fileID": 3
@@ -9362,7 +9362,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ぶーの？<%br>かなしー？　だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9370,7 +9370,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あはは！　にぎやかになってきましたね。<%br>リーダー、これからどうします？",
 		"tr_text": "",
 		"fileID": 3
@@ -9378,7 +9378,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あはは！　にぎやかになってきましたね。<%br>リーダー、これからどうします？",
 		"tr_text": "",
 		"jp_buttons": [
@@ -9394,7 +9394,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "んー！　んー！　行くべきだっ……！<%br>さぁ……行こう、ウォパルッ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9402,7 +9402,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "たしか、カラミティさんが捕食跡を<%br>目撃したのも、惑星ウォパルでしたね！",
 		"tr_text": "",
 		"fileID": 3
@@ -9410,7 +9410,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん……今入った報告によりますと<%br>惑星アムドゥスキアで捕食跡が見つかりました。",
 		"tr_text": "",
 		"fileID": 3
@@ -9418,7 +9418,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "まずいな……次の捕食対象は、龍族か？<%br>ウォパルは後回しにするしかないね……",
 		"tr_text": "",
 		"fileID": 3
@@ -9426,7 +9426,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……捕食の報告はあれから上がってきては……<%br>ま、待ってください……！",
 		"tr_text": "",
 		"fileID": 3
@@ -9434,7 +9434,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "今……惑星アムドゥスキアで捕食跡の<%br>報告が入りました！",
 		"tr_text": "",
 		"fileID": 3
@@ -9442,7 +9442,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ヘイズ・ドラールは造龍よ。<%br>まさか、龍族を……",
 		"tr_text": "",
 		"fileID": 3
@@ -9450,7 +9450,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "とにかく急ぎましょう、リーダー！<%br>惑星アムドゥスキアに……！",
 		"tr_text": "",
 		"fileID": 3
@@ -9458,7 +9458,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ごほんっ！　んーんーっ！<%br>ところで、子供はどうする？",
 		"tr_text": "",
 		"fileID": 3
@@ -9466,7 +9466,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "こどもー？",
 		"tr_text": "",
 		"fileID": 3
@@ -9474,7 +9474,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "君、君のことだ！　君は子供だろ？<%br>そして近寄るな！　少しボクから離れたまえ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9482,7 +9482,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "どうするって……戦いに連れて行くわけには<%br>いかねーだろ。置いていこうぜ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9490,7 +9490,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……うーん。<%br>いやぁ……でもねぇ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9498,7 +9498,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……連れて行きましょう。そうしないとまずい。<%br>そうでしょう、ブルーノ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9506,7 +9506,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ど、ど、どういうことだってば？",
 		"tr_text": "",
 		"fileID": 3
@@ -9514,7 +9514,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ん……？<%br>連れてくのは、危ないですよ……ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9522,7 +9522,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ま！　こっからはアムドゥスキアに<%br>移動してから、説明するよ。行こうか！",
 		"tr_text": "",
 		"fileID": 3
@@ -9530,7 +9530,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "よっし、こんなもんか！　……そうだねぇ。<%br>みんなにもざっくりだけど説明しとくね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9538,7 +9538,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "今回動いてくれた、俺の上司より上の権限の人に<%br>デュナちゃんの存在が気づかれれば……",
 		"tr_text": "",
 		"fileID": 3
@@ -9546,7 +9546,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "今回の事件に全面的に<%br>介入される恐れがあるわけ。そうなると……",
 		"tr_text": "",
 		"fileID": 3
@@ -9554,7 +9554,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……トランスエネミーのデュナや、アークスに<%br>危害を加えたオレは、このままではいられない？",
 		"tr_text": "",
 		"fileID": 3
@@ -9562,7 +9562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……えぇ、今はまだ貴方もアークスに害を<%br>加えたウェポノイドだとは報告していないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9570,7 +9570,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "単に負傷したウェポノイドとして<%br>チップへの影響がないか調べてもらっただけ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9578,7 +9578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "存在が偉い奴に知られると<%br>こんな子供まで、検査されたりすんのかよ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9586,7 +9586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "はははーん！　シュトラ、君は馬鹿か。<%br>いや、馬鹿だ。わかっていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -9594,7 +9594,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "トランスエネミーは過去に<%br>市街地を襲撃しているんだぞ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9602,7 +9602,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "アークスにとって危険視するレベルは<%br>ボクらウェポノイドと、この子供とでは違うっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9610,7 +9610,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "検査だなんて生ぬるいことにはならない！<%br>ボクだってしたい……！　いろんな……じ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9618,7 +9618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "黙ってカラミティ。十分よ。確かに<%br>こうして任務に連れて来るのは危険だけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -9626,7 +9626,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "デュナをひとり置いていくのも、危ない……<%br>ってことですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9634,7 +9634,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "（それに……気になることがある。<%br>　この子の能力は……もしかしたら……）",
 		"tr_text": "",
 		"fileID": 3
@@ -9642,7 +9642,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "でもさ、でもさ！<%br>チームの人数すげー増えるよな？",
 		"tr_text": "",
 		"fileID": 3
@@ -9650,7 +9650,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はい！　仲間が増えて、うれしいです。<%br>みんなでがんばりましょうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9658,7 +9658,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "がんばる！　<%br>でゅなも、がんばうよー！　まま！",
 		"tr_text": "",
 		"fileID": 3
@@ -9666,7 +9666,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット&ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……まま？",
 		"tr_text": "",
 		"fileID": 3
@@ -9674,7 +9674,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette & Bruno",
 		"jp_text": "みなさん、周囲のエネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 3
@@ -9682,7 +9682,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はぁ……はぁ……なんだか、龍族の様子が……<%br>すこし、いつもと違いますね……",
 		"tr_text": "",
 		"fileID": 3
@@ -9690,7 +9690,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……りゅーぞく？",
 		"tr_text": "",
 		"fileID": 3
@@ -9698,7 +9698,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい。この惑星アムドゥスキアに住んでいる……<%br>……えーっと。",
 		"tr_text": "",
 		"fileID": 3
@@ -9706,7 +9706,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "惑星アムドゥスキアに住む種族のこと。<%br>姿はさまざまだが、全て龍族という種だ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9714,7 +9714,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "彼らは高い知能を持ち、言葉を解する。<%br>アークスと念話で話すことができるのだっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9722,7 +9722,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "おはなしできう。……しゅごいね。<%br>しゅごいねー、まま！",
 		"tr_text": "",
 		"fileID": 3
@@ -9730,7 +9730,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……す、すごいですねぇ。<%br>えぇっと……まま、じゃ……うぅ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9738,7 +9738,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……って。<%br>いつの間にこんな短期間で、母親になったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -9746,7 +9746,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "うぅ……モアがママみたいだって<%br>言ったんですよ。それで……",
 		"tr_text": "",
 		"fileID": 3
@@ -9754,7 +9754,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だってさぁ、デュナがすっげージェネに懐いて<%br>子守歌うたってーって言うんだぜ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9762,7 +9762,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なんかそれみてたら、デュナはジェネのこと<%br>ママだと思ってるんだろうなーってさ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9770,7 +9770,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……子守歌？<%br>デュナという名前……それに……",
 		"tr_text": "",
 		"fileID": 3
@@ -9778,7 +9778,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……母親が、いるのかねぇ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9786,7 +9786,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "母親……です？",
 		"tr_text": "",
 		"fileID": 3
@@ -9794,7 +9794,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "名前なら研究者がつけた可能性がある。<%br>でも、子守歌をこの子が知っているのは……",
 		"tr_text": "",
 		"fileID": 3
@@ -9802,7 +9802,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "誰かが、デュナに子守歌を聞かせていた。<%br>……ということです？",
 		"tr_text": "",
 		"fileID": 3
@@ -9810,7 +9810,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうだね。子守歌を歌うのは……まぁ……<%br>普通に考えると、親……母親だろうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9818,7 +9818,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9826,7 +9826,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……<%br>どーしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -9834,7 +9834,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……えっと……その……<%br>わたし、わたしは……",
 		"tr_text": "",
 		"fileID": 3
@@ -9842,7 +9842,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……うふふ。<%br>なんでもないですよ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9850,7 +9850,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9858,7 +9858,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（言えないわね、あんなに懐かれていたら<%br>　貴方の母親じゃ……ママじゃないなんて）",
 		"tr_text": "",
 		"fileID": 3
@@ -9866,7 +9866,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "んんっ！<%br>君、君は彼らと戦った時、意識がなかったと……",
 		"tr_text": "",
 		"fileID": 3
@@ -9874,7 +9874,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "うるさいな！　なんでオレがお前の質問に<%br>答えないといけないわけ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9882,7 +9882,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "なんでって……<%br>ボクが知りたいからだ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -9890,7 +9890,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……すげー自己中心的で嫌な奴だな。<%br>お前、友達とかいないだろ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9898,7 +9898,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "とも……だち……？",
 		"tr_text": "",
 		"fileID": 3
@@ -9906,7 +9906,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "でゅなー<%br>からみてのともだち！",
 		"tr_text": "",
 		"fileID": 3
@@ -9914,7 +9914,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ケンカすんなって！　なぁ、捕食跡まで<%br>まだあるんだろ？　早く進もうぜ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9922,7 +9922,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いくよー。",
 		"tr_text": "",
 		"fileID": 3
@@ -9930,7 +9930,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……そうですね。<%br>急ぎましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 3
@@ -9938,7 +9938,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>……これ……これは……",
 		"tr_text": "",
 		"fileID": 3
@@ -9946,7 +9946,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ひでぇ……な。<%br>食い散らかされちまってる……",
 		"tr_text": "",
 		"fileID": 3
@@ -9954,7 +9954,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "んんー！　ここでも確かに捕食がされた様子。<%br>だが……んん？",
 		"tr_text": "",
 		"fileID": 3
@@ -9962,7 +9962,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "まま……<%br>どーして、こんな……こんな……",
 		"tr_text": "",
 		"fileID": 3
@@ -9970,7 +9970,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9978,7 +9978,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "んん？<%br>なぜだ。彼女はママ……母親じゃないだろう？",
 		"tr_text": "",
 		"fileID": 3
@@ -9986,7 +9986,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "トランスエネミーの生殖形態がどうなってるか<%br>極めて興味深いが繁殖可能である場合……",
 		"tr_text": "",
 		"fileID": 3
@@ -9994,7 +9994,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "おい。お前……ほんと、マジで空気読めよ。<%br>バカなの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10002,7 +10002,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "バカ……？　ボクが馬鹿だっていうのか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10010,7 +10010,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "バカだろ、小さい子供相手に何言ってんだ？<%br>お前、利口かもしれねーけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -10018,7 +10018,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "知ってるか、そういう人の気持ちを考えないの<%br>利口バカって言うんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10026,7 +10026,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……利口にも<%br>馬鹿が……いるのか……！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10034,7 +10034,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "デュナ、あいつらの話とか<%br>聞いちゃダメだぞ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10042,7 +10042,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "だめ？　なの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10050,7 +10050,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ダメだってば。悪い言葉ばっか使ってるからな。<%br>変な言葉とか、覚えそうだってば……",
 		"tr_text": "",
 		"fileID": 3
@@ -10058,7 +10058,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10066,7 +10066,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……どうしたの、暗い顔して？<%br>あっちはあんなに賑やかなのに。",
 		"tr_text": "",
 		"fileID": 3
@@ -10074,7 +10074,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……デュナに、違うよって……その<%br>言えなくって……",
 		"tr_text": "",
 		"fileID": 3
@@ -10082,7 +10082,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だって、デュナにはきっと、本物の母親がいて<%br>それで、いつかは……わたし達は……",
 		"tr_text": "",
 		"fileID": 3
@@ -10090,7 +10090,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうね。ずっと一緒にいるわけじゃない。<%br>この一連の事件が解決しても……しなくても。",
 		"tr_text": "",
 		"fileID": 3
@@ -10098,7 +10098,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "貴方は……<%br>あの子の本当の母親にはなれないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10106,7 +10106,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……はい。",
 		"tr_text": "",
 		"fileID": 3
@@ -10114,7 +10114,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……でも、あの子と別れる時まで、貴方が<%br>母親代わりをしても、いいんじゃないかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -10122,7 +10122,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "きっとあの子も貴方と同じで、理由があって<%br>生まれて……そして、ひとりなのよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10130,7 +10130,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……アネットさん、あの！",
 		"tr_text": "",
 		"fileID": 3
@@ -10138,7 +10138,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうしたの？　……ジェネ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10146,7 +10146,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "えっと……その……",
 		"tr_text": "",
 		"fileID": 3
@@ -10154,7 +10154,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "おーい！　ジェネー、アネットー！<%br>先に進むってばー！",
 		"tr_text": "",
 		"fileID": 3
@@ -10162,7 +10162,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あら……もう行かなきゃ。<%br>ジェネ、貴方……",
 		"tr_text": "",
 		"fileID": 3
@@ -10170,7 +10170,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "まま、いこー。<%br>てばー！",
 		"tr_text": "",
 		"fileID": 3
@@ -10178,7 +10178,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10186,7 +10186,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……はいっ！<%br>行きましょうか！",
 		"tr_text": "",
 		"fileID": 3
@@ -10194,7 +10194,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、クォーツドラゴン撃破<%br>お疲れ様です……それにしても、これは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10202,7 +10202,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はぁ……はぁ……<%br>こんな場所まで捕食の跡が……",
 		"tr_text": "",
 		"fileID": 3
@@ -10210,7 +10210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ひどいね……まま。",
 		"tr_text": "",
 		"fileID": 3
@@ -10218,7 +10218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "確かにな。……セラフィさん<%br>捕食跡の報告が入ったエリアは他に……",
 		"tr_text": "",
 		"fileID": 3
@@ -10226,7 +10226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "こ……これは……！",
 		"tr_text": "",
 		"fileID": 3
@@ -10234,7 +10234,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "どうしたんだってば？",
 		"tr_text": "",
 		"fileID": 3
@@ -10242,7 +10242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "前と同じ反応です……周囲の生体反応が<%br>消滅していっています……",
 		"tr_text": "",
 		"fileID": 3
@@ -10250,7 +10250,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "それって……<%br>ヘイドのときと……同じです。",
 		"tr_text": "",
 		"fileID": 3
@@ -10258,7 +10258,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はい。ですが、やはり生体反応が……<%br>以前確認したヘイドのものとは異なります。",
 		"tr_text": "",
 		"fileID": 3
@@ -10266,7 +10266,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "確か、私たちと別行動していた時も<%br>ヘイドは生体反応を変えたのよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -10274,7 +10274,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "んんっ！　捕食者としての彼の能力が<%br>生体反応の性質自体を変化させてると仮定できる。",
 		"tr_text": "",
 		"fileID": 3
@@ -10282,7 +10282,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……いい考察ね。<%br>その可能性は十分にあるわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10290,7 +10290,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "だったら、その反応……ヘイドかもしれないじゃん。<%br>そこ、急いだほうがいいんじゃないの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10298,7 +10298,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だな！　だな！！<%br>リーダー、急ごうぜ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10306,7 +10306,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いしょ……あえ……？<%br>……いそぐよー、りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10314,7 +10314,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "さぁ！　答えるんだっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10322,7 +10322,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……お前、ほんとにうぜーな。",
 		"tr_text": "",
 		"fileID": 3
@@ -10330,7 +10330,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "んっんーっ！　　君は馬鹿だから分かっていない<%br>だろうが、ボクが確認しようとしていることは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10338,7 +10338,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "うぜー？<%br>ばぁか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10346,7 +10346,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ、だめだってば。<%br>そんな言葉、覚えなくていいからな！",
 		"tr_text": "",
 		"fileID": 3
@@ -10354,7 +10354,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ないない？",
 		"tr_text": "",
 		"fileID": 3
@@ -10362,7 +10362,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい。<%br>ないない、です！",
 		"tr_text": "",
 		"fileID": 3
@@ -10370,7 +10370,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "自我があるウェポノイドが、記憶がない中で<%br>アークスに攻撃をしたんだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10378,7 +10378,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "これがどういう意味か分かっているのか？<%br>いいや、君は馬鹿だから分かっていない！",
 		"tr_text": "",
 		"fileID": 3
@@ -10386,7 +10386,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "チップ研究所の人間の目が節穴じゃなければ<%br>チップへの細工もないという報告だ！　つまりっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10394,7 +10394,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ウェポノイドの意識と関係なく操作できる技術が<%br>すでに開発されている可能性があるんだっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10402,7 +10402,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10410,7 +10410,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……それは、確かにそうなんだよね。",
 		"tr_text": "",
 		"fileID": 3
@@ -10418,7 +10418,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……えぇ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10426,7 +10426,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ふぅ？？",
 		"tr_text": "",
 		"fileID": 3
@@ -10434,7 +10434,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "つまりそれは！！<%br>新たな技術……力！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10442,7 +10442,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "こんな楽しいことはないじゃないかっ！<%br>んんーっ！　最高だっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10450,7 +10450,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……最高……って<%br>なんだよ……それ……",
 		"tr_text": "",
 		"fileID": 3
@@ -10458,7 +10458,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……あいつやっぱり、変わってるってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -10466,7 +10466,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なんだか、うれしそうです……<%br>カラミティさん……",
 		"tr_text": "",
 		"fileID": 3
@@ -10474,7 +10474,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "楽しんでる場合じゃないわよ……<%br>エネミーが来るわ、構えなさい！",
 		"tr_text": "",
 		"fileID": 3
@@ -10482,7 +10482,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10490,7 +10490,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラってば、なかなか強いじゃんかっ！　<%br>……あれ？　どうした？",
 		"tr_text": "",
 		"fileID": 3
@@ -10498,7 +10498,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……しゅとら？<%br>どーたっの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10506,7 +10506,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "カラミティ、お前……<%br>何が楽しいんだよ……？",
 		"tr_text": "",
 		"fileID": 3
@@ -10514,7 +10514,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……おや？　どうしたんだ。<%br>君は楽しくないのか、今ボクらは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10522,7 +10522,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "お前なぁっ！！<%br>どこが……っ、どこが楽しいんだよっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10530,7 +10530,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "オレ達ウェポノイドが……<%br>このままじゃ、どうなっちまうか……",
 		"tr_text": "",
 		"fileID": 3
@@ -10538,7 +10538,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "お前、真剣に考えてるのかよ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10546,7 +10546,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10554,7 +10554,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "真剣に考えるってなんだ？<%br>真剣に考えたら、事態は好転するのか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10562,7 +10562,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10570,7 +10570,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……そんなことで解決するなら、この世界に<%br>問題なんて起きない。みんな馬鹿だから気づかない。",
 		"tr_text": "",
 		"fileID": 3
@@ -10578,7 +10578,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ん？　……ん？<%br>どうした、なんでみんな黙るんだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10586,7 +10586,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ん？　……ん？<%br>どうした、なんでみんな黙るんだ？",
 		"tr_text": "",
 		"jp_buttons": [
@@ -10602,7 +10602,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……ははは。そうだね、そうしよう。<%br>ささ！　この話は終わりなっ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10610,7 +10610,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ん……？<%br>なんだ、この空気は……みんな……どうした？",
 		"tr_text": "",
 		"fileID": 3
@@ -10618,7 +10618,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "…………！",
 		"tr_text": "",
 		"fileID": 3
@@ -10626,7 +10626,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "えっと……あの……その……<%br>どうしたんだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10634,7 +10634,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……カラミティ、貴方が賢いなら分かるはずよ。<%br>貴方が、人よりずっと賢いなら……",
 		"tr_text": "",
 		"fileID": 3
@@ -10642,7 +10642,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "他人に理解されないこと。自らが大事にする……<%br>その信条さえも、否定されること。",
 		"tr_text": "",
 		"fileID": 3
@@ -10650,7 +10650,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……それがどれだけ、残酷なことか。<%br>どれだけ嫌なことか……",
 		"tr_text": "",
 		"fileID": 3
@@ -10658,7 +10658,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10666,7 +10666,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "いなかったかしら？　貴方の発見や……<%br>気づきを無視し、蔑ろにした人間は？",
 		"tr_text": "",
 		"fileID": 3
@@ -10674,7 +10674,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……っ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10682,7 +10682,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……それは、ボクが、ボクの考えを否定した<%br>馬鹿な人間と、ボクが……一緒ってことか……",
 		"tr_text": "",
 		"fileID": 3
@@ -10690,7 +10690,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "人は……見てきた景色がみんな違う。<%br>経験や体験でしか、わからないことがある。",
 		"tr_text": "",
 		"fileID": 3
@@ -10698,7 +10698,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "でも、だからと言って……まったく相手の感情に<%br>寄り添えないわけじゃ……私はないと思うの。",
 		"tr_text": "",
 		"fileID": 3
@@ -10706,7 +10706,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ボクは……その……<%br>よく、嫌な奴だ……と言われる。",
 		"tr_text": "",
 		"fileID": 3
@@ -10714,7 +10714,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……だが……馬鹿ではない。<%br>だから……さっきの発言は、撤回する。",
 		"tr_text": "",
 		"fileID": 3
@@ -10722,7 +10722,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "なんだよ……気持ちわりぃな……<%br>変な奴……",
 		"tr_text": "",
 		"fileID": 3
@@ -10730,7 +10730,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それより、さっさと行こうぜ。<%br>ヘイドの奴、捕まえねーと……",
 		"tr_text": "",
 		"fileID": 3
@@ -10738,7 +10738,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "なんで……こんなに龍族が<%br>攻撃的になってんだ……？",
 		"tr_text": "",
 		"fileID": 3
@@ -10746,7 +10746,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "うーん……そりゃあ、仲間が捕食されてるんだ。<%br>警戒もするだろうさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -10754,7 +10754,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "（おまけに、ヘイドはヘイズ・ドラール……<%br>　捕食時はエネミー体になるわけだ）",
 		"tr_text": "",
 		"fileID": 3
@@ -10762,7 +10762,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "（龍族からしたら、自分たちと近しい存在の<%br>　やつが、自分たちを捕食しに来た……）",
 		"tr_text": "",
 		"fileID": 3
@@ -10770,7 +10770,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……どうしたんだよ、おっさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -10778,7 +10778,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……はは。<%br>いや……おっさんでも、いいけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -10786,7 +10786,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……いやぁ、ね。俺は、この大所帯が<%br>気になっちゃうんだけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -10794,7 +10794,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -10818,7 +10818,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの？　……あー、うん……たのしい？<%br>うんうん、楽しいねぇ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10826,7 +10826,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……ヘイドとやらは、捕食によって能力を<%br>強化する。彼にすれば、全ての生命体は……",
 		"tr_text": "",
 		"fileID": 3
@@ -10834,7 +10834,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "食材だ。<%br>……ヘイドからしたら、食材だな。",
 		"tr_text": "",
 		"fileID": 3
@@ -10842,7 +10842,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10850,7 +10850,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -10866,7 +10866,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前らアークスはそうやって、なんにでも<%br>「理由」をつけようとする。",
 		"tr_text": "",
 		"fileID": 3
@@ -10874,7 +10874,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "それも真実なんてどうでもいい。<%br>自分たちが「納得」できる「説明」が欲しいだけだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10882,7 +10882,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイドは……食べることに「理由」がいるのかって<%br>そう言いました。",
 		"tr_text": "",
 		"fileID": 3
@@ -10890,7 +10890,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10898,7 +10898,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "彼は、アークスに強い敵意をもっています。<%br>わたし達アークスを殺すためには……",
 		"tr_text": "",
 		"fileID": 3
@@ -10906,7 +10906,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "「食べなければ」ならない……<%br>そう言っていました。",
 		"tr_text": "",
 		"fileID": 3
@@ -10914,7 +10914,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……あいつが生まれた経緯が……<%br>アークスへの殺意に関係してるんだろうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -10922,7 +10922,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "リーダー、ジェネ。私たちはロードのアジトで<%br>ブルーノの上司……情報部の「次席」に会った。",
 		"tr_text": "",
 		"fileID": 3
@@ -10930,7 +10930,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そこで彼女から……<%br>ある「仮定」を聞いたの。",
 		"tr_text": "",
 		"fileID": 3
@@ -10938,7 +10938,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "トランスエネミー「ヘイド」の元となったのは<%br>「ヘイズ・ドラール」。",
 		"tr_text": "",
 		"fileID": 3
@@ -10946,7 +10946,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ある組織で、龍族の遺伝子を改造し<%br>造り出された「造龍」よ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10954,7 +10954,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "龍族を改造する……<%br>そんなことができるのかよ！？",
 		"tr_text": "",
 		"fileID": 3
@@ -10962,7 +10962,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "その組織って……",
 		"tr_text": "",
 		"fileID": 3
@@ -10970,7 +10970,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "「虚空機関」。<%br>今は解体された、巨大組織……",
 		"tr_text": "",
 		"fileID": 3
@@ -10978,7 +10978,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……虚空機関。",
 		"tr_text": "",
 		"fileID": 3
@@ -10986,7 +10986,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ぼーいど？",
 		"tr_text": "",
 		"fileID": 3
@@ -10994,7 +10994,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ヴォイド……って、いうのよ。<%br>そこではダーカー因子の研究が行われていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11002,7 +11002,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ダーカーを捕食する能力を持つ<%br>ヘイズ・ドラールなどの「造龍」の研究もね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11010,7 +11010,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "虚空機関の研究で生まれた<%br>ヘイズ・ドラールは、空間転移の力を持っていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11018,7 +11018,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "エネミーに人の姿を与える技術を開発した<%br>E.M.A.研究所は、その空間転移能力に目をつけた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11026,7 +11026,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "かくして、虚空機関の解体後に<%br>E.M.A.は研究を引き継ぎ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11034,7 +11034,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そんで……トランスエネミーとして<%br>奴が生まれた……ってことかよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11042,7 +11042,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そのうえ、ダーカー以外も捕食することで<%br>能力を強化できる。ほんと……厄介な力よね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11050,7 +11050,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あいつ……だから、仲間のウェポノイドを……",
 		"tr_text": "",
 		"fileID": 3
@@ -11058,7 +11058,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "…………？",
 		"tr_text": "",
 		"fileID": 3
@@ -11066,7 +11066,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だから、クシャネビュラを喰ったんだ。<%br>それにあいつは、造龍だっていっても……",
 		"tr_text": "",
 		"fileID": 3
@@ -11074,7 +11074,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "龍族のことも<%br>強くなるために平気で食べるんだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11082,7 +11082,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……クシャネビュラ……を……食べた？",
 		"tr_text": "",
 		"fileID": 3
@@ -11090,7 +11090,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11098,7 +11098,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11106,7 +11106,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "あ、えっと……<%br>う……うん……",
 		"tr_text": "",
 		"fileID": 3
@@ -11114,7 +11114,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "そ……そっか。<%br>……アイツ……そっか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11122,7 +11122,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "んんっ……！<%br>んーっ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11130,7 +11130,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……どうしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -11138,7 +11138,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "いえ、いえいえ！<%br>なんでもない。そう……なんでもないっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11146,7 +11146,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "それより、早く捕食者の反応を追う。<%br>それが優先だ。リーダー、さ、急ごう。",
 		"tr_text": "",
 		"fileID": 3
@@ -11154,7 +11154,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "みなさん、ウォルガーダ撃破<%br>おめでとうございます。",
 		"tr_text": "",
 		"fileID": 3
@@ -11162,7 +11162,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "捕食者とみられる生体反応が<%br>龍祭壇エリアへ移動しています。",
 		"tr_text": "",
 		"fileID": 3
@@ -11170,7 +11170,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はぁ……はぁ……急がないと、ですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11178,7 +11178,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "移動スピードが上がってるな。<%br>これも、捕食で能力が上がってるせいなのか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11186,7 +11186,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "おそらく、そうだと。……龍祭壇エリアに進んだ<%br>生体反応は、フォトン量を増大させています。",
 		"tr_text": "",
 		"fileID": 3
@@ -11194,7 +11194,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "急ごうぜ、ヘイドのやつ<%br>どんどん強くなっちゃうんだろ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11202,7 +11202,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "急ぎましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 3
@@ -11210,7 +11210,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "りだ！　いしょぐよっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11218,7 +11218,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん……待ってください！<%br>これは……そんな、まさか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11226,7 +11226,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……何かあったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -11234,7 +11234,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……新たな捕食の報告が入りました。",
 		"tr_text": "",
 		"fileID": 3
@@ -11242,7 +11242,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "新たなって……それって……",
 		"tr_text": "",
 		"fileID": 3
@@ -11250,7 +11250,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "惑星ウォパルで、捕食事件の調査を始めた<%br>別部隊からの報告です……",
 		"tr_text": "",
 		"fileID": 3
@@ -11258,7 +11258,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "エネミーを捕食する<%br>海王種と思われる存在を確認しました。",
 		"tr_text": "",
 		"fileID": 3
@@ -11266,7 +11266,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "海王種……？　ウォパルは確か……<%br>カラミティさんが捕食を確認した惑星……",
 		"tr_text": "",
 		"fileID": 3
@@ -11274,7 +11274,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "んーっ！　やはり、あの惑星にいるんだ！<%br>まだ見ぬトランスエネミーが！",
 		"tr_text": "",
 		"fileID": 3
@@ -11282,7 +11282,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "んーっ！　やはり、あの惑星にいるんだ！<%br>まだ見ぬトランスエネミーが！",
 		"tr_text": "",
 		"jp_buttons": [
@@ -11298,7 +11298,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "…………<%br>お、オレも……オレもヘイドを追いたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -11306,7 +11306,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "とはいえ、ウォパルも放ってはおけないな。<%br>……そうだ、こうしたらどうだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11314,7 +11314,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "リーダーたちは、このまま<%br>龍祭壇エリアにいる捕食者を追う。",
 		"tr_text": "",
 		"fileID": 3
@@ -11322,7 +11322,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そして私たちが、惑星ウォパルへ行く……<%br>ということね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11330,7 +11330,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……それなら、俺たちでウォパルに向かう。<%br>アネット、カラミティ……それでいいよな？",
 		"tr_text": "",
 		"fileID": 3
@@ -11338,7 +11338,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……えぇ。<%br>そうね……カラミティ行きましょう。",
 		"tr_text": "",
 		"fileID": 3
@@ -11346,7 +11346,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "で、でもさ！　龍祭壇エリアにいるのは<%br>きっとヘイドのやつだけどさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11354,7 +11354,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ウォパルにいる、海王種の捕食者って……<%br>どんなやつかもわからないのに、危ないってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -11362,7 +11362,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なーに、おチビ。心配してくれてるわけ？<%br>あははは……大丈夫だって。",
 		"tr_text": "",
 		"fileID": 3
@@ -11370,7 +11370,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "そうよ。心配いらないわ。<%br>危ないと思えば、すぐに撤退する……",
 		"tr_text": "",
 		"fileID": 3
@@ -11378,7 +11378,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "んんっ！<%br>それより君たちも、十分注意するように！",
 		"tr_text": "",
 		"fileID": 3
@@ -11386,7 +11386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "アネットさん、ブルーノさん……<%br>カラミティさん、気を付けてくださいね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11394,7 +11394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "きおつけて、ね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11402,7 +11402,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あねっと！",
 		"tr_text": "",
 		"fileID": 3
@@ -11410,7 +11410,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの！",
 		"tr_text": "",
 		"fileID": 3
@@ -11418,7 +11418,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "からみて！",
 		"tr_text": "",
 		"fileID": 3
@@ -11426,7 +11426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "えぇ。デュナも……リーダーやジェネの側から<%br>離れちゃダメよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11434,7 +11434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ぶーの……ぶーのねぇ……<%br>アネットは呼べるようになってるのに……",
 		"tr_text": "",
 		"fileID": 3
@@ -11442,7 +11442,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "こ、子供……君は貴重なトランスエネミーの<%br>幼体だ。ケガに気を付けるように……",
 		"tr_text": "",
 		"fileID": 3
@@ -11450,7 +11450,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "はぁい！<%br>でゅな、ままといっしょ、いるねー。",
 		"tr_text": "",
 		"fileID": 3
@@ -11458,7 +11458,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "え……！<%br>は、はい……そうですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11466,7 +11466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ジェネ。<%br>ちょっと……",
 		"tr_text": "",
 		"fileID": 3
@@ -11474,7 +11474,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "浮遊大陸エリアで私が言ったこと……<%br>気にしてる？",
 		"tr_text": "",
 		"fileID": 3
@@ -11482,7 +11482,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11498,7 +11498,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……でも、あの子と別れる時まで、貴方が<%br>母親代わりをしても、いいんじゃないかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -11506,7 +11506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "デュナの親代わりをやる……自信がない？",
 		"tr_text": "",
 		"fileID": 3
@@ -11514,7 +11514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "だって……わ……わたしは<%br>本当の母親……お母さんじゃないです……",
 		"tr_text": "",
 		"fileID": 3
@@ -11522,7 +11522,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ザッカードは貴方に……一時的ではあったけど<%br>両親から受けた愛情の記憶を与えた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11530,7 +11530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "誰かから愛されたという実感は、何よりも<%br>心を強くする。貴方が一番わかっているはず。",
 		"tr_text": "",
 		"fileID": 3
@@ -11538,7 +11538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………！",
 		"tr_text": "",
 		"fileID": 3
@@ -11546,7 +11546,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "親も……兄弟もいないわたしに……<%br>できるでしょうか？",
 		"tr_text": "",
 		"fileID": 3
@@ -11554,7 +11554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "身を挺して、デュナを助けたんでしょう？<%br>モアから聞いたわ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11562,7 +11562,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "血のつながりが、すべてじゃない……",
 		"tr_text": "",
 		"fileID": 3
@@ -11570,7 +11570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "私は……ジェネ、貴方のやさしさで<%br>私自身が変わったと……そう思っている。",
 		"tr_text": "",
 		"fileID": 3
@@ -11578,7 +11578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……アネットさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -11586,7 +11586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……そんな顔しないの。<%br>それじゃあ、もう行くわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11594,7 +11594,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あ、アネットさん……！<%br>ブルーノさん、カラミティさん、気を付けて。",
 		"tr_text": "",
 		"fileID": 3
@@ -11602,7 +11602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……えぇ。貴方たちもね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11610,7 +11610,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "惑星ウォパルッ！！<%br>んーっ！　やはりここに「捕食者」がいたんだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11618,7 +11618,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "つまり！<%br>ヘイド以外の捕食者がいるっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11626,7 +11626,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "そうだな。……ヘイドとは違う。<%br>目撃情報が正しければ、海王種ってことは……",
 		"tr_text": "",
 		"fileID": 3
@@ -11634,7 +11634,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "あらブルーノ……めずらしく<%br>緊張してるのかしら？　余裕がなさそうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11642,7 +11642,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11650,7 +11650,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "あっはは……！<%br>そう見える？　ちょーっと気合入れていくか！",
 		"tr_text": "",
 		"fileID": 3
@@ -11658,7 +11658,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "でもさでもさ、捕食者がふたりいるってことは<%br>うーんっと、えっと……",
 		"tr_text": "",
 		"fileID": 3
@@ -11666,7 +11666,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "うんっとー……えっとぉ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11674,7 +11674,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ヘイドの……仲間でしょうか。",
 		"tr_text": "",
 		"fileID": 3
@@ -11682,7 +11682,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11698,7 +11698,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "食料……？<%br>持って、帰る……？",
 		"tr_text": "",
 		"fileID": 3
@@ -11706,7 +11706,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……彼には、仲間を思う気持ちなんて<%br>ないと思ってた……でも……",
 		"tr_text": "",
 		"fileID": 3
@@ -11714,7 +11714,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドと同じように特殊な能力があって……<%br>トランスエネミーとして生み出されたなら……",
 		"tr_text": "",
 		"fileID": 3
@@ -11722,7 +11722,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドみたいに<%br>すっごい強いかもしれないよな……？",
 		"tr_text": "",
 		"fileID": 3
@@ -11730,7 +11730,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "アネットたち、心配だってば。<%br>大丈夫かな……",
 		"tr_text": "",
 		"fileID": 3
@@ -11738,7 +11738,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "しんぱい……だね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11746,7 +11746,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -11754,7 +11754,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "（べつに……アイツなんか……<%br>　大丈夫、だよな……大丈夫……）",
 		"tr_text": "",
 		"fileID": 3
@@ -11762,7 +11762,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "は……早くさ、ヘイドを捕まえて……<%br>合流しようぜ、惑星ウォパルに。",
 		"tr_text": "",
 		"fileID": 3
@@ -11770,7 +11770,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……そうですね！<%br>急ぎましょう！",
 		"tr_text": "",
 		"fileID": 3
@@ -11778,7 +11778,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11786,7 +11786,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま、だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11794,7 +11794,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11802,7 +11802,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11818,7 +11818,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "血のつながりが、すべてじゃない……",
 		"tr_text": "",
 		"fileID": 3
@@ -11826,7 +11826,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……はい、大丈夫です。<%br>デュナは優しい子ですね。ありがとう。",
 		"tr_text": "",
 		"fileID": 3
@@ -11834,7 +11834,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ふへへへへ～。<%br>ほめられたぁ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11842,7 +11842,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "でもさ……凶暴化してない龍族たちも<%br>すごくピリピリしてるな……",
 		"tr_text": "",
 		"fileID": 3
@@ -11850,7 +11850,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "仕方ねーよ。ヘイド……ヘイズ・ドラールは<%br>龍族と見た目が似てる。",
 		"tr_text": "",
 		"fileID": 3
@@ -11858,7 +11858,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "龍族からしたら、そんな奴に急に<%br>自分達が襲われてるんだ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11866,7 +11866,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "警戒だってするだろ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11874,7 +11874,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そ、そうだよな……う、うん。<%br>オレも、そう思ってたってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -11882,7 +11882,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……わかってんのか？　<%br>ウェポノイドはトランスエネミーと同じだぞ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11890,7 +11890,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アークスにとって、オレ達と<%br>トランスエネミーなんて、大差ないんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11898,7 +11898,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だから、すぐに……アークスだって<%br>今の龍族みたいに、ウェポノイドに敵意を見せる。",
 		"tr_text": "",
 		"fileID": 3
@@ -11906,7 +11906,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11914,7 +11914,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……シュトラ。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -11930,7 +11930,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11938,7 +11938,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……リーダー。<%br>そう……そうですよ、シュトラさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -11946,7 +11946,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "たとえ、もしウェポノイドが悪用される……<%br>そんな日が来ても……必ず助けます。",
 		"tr_text": "",
 		"fileID": 3
@@ -11954,7 +11954,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "べ、べつに怖がってなんか……ねーよ。<%br>……そうなっても仕方ないって思ってる。",
 		"tr_text": "",
 		"fileID": 3
@@ -11962,7 +11962,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "仕方ない、なんてこと……ないです。",
 		"tr_text": "",
 		"fileID": 3
@@ -11970,7 +11970,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "意識のないシュトラさんが、何かの力で<%br>自分の意思にない攻撃をした……",
 		"tr_text": "",
 		"fileID": 3
@@ -11978,7 +11978,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もしウェポノイドが……そうなってしまう未来が<%br>来ても……必ず助けます。",
 		"tr_text": "",
 		"fileID": 3
@@ -11986,7 +11986,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうして……アンタ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11994,7 +11994,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……そのために<%br>一緒にがんばりましょう！　ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -12002,7 +12002,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……あぁ、そう……だな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12010,7 +12010,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……さ、みんなでヘイドを捕まえましょう。<%br>きっと解決できますよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12018,7 +12018,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 3
@@ -12026,7 +12026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "これは……",
 		"tr_text": "",
 		"fileID": 3
@@ -12034,7 +12034,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "間違いない。ボクが発見して<%br>報告をあげてきた捕食跡と合致する。",
 		"tr_text": "",
 		"fileID": 3
@@ -12042,7 +12042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……私たちが今まで見てきた「喰い跡」とは<%br>どうやら、大分違うようね。",
 		"tr_text": "",
 		"fileID": 3
@@ -12050,7 +12050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうだね。ヘイドとは違う「捕食者」……<%br>おそらくそいつも、トランスエネミー……",
 		"tr_text": "",
 		"fileID": 3
@@ -12058,7 +12058,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12066,7 +12066,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……私たちは、報告にあった捕食跡を確認したわ。<%br>これから、生体反応を追跡する。",
 		"tr_text": "",
 		"fileID": 3
@@ -12074,7 +12074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……アネットさん。わたし達も、もうすぐ<%br>ヘイド……捕食者の生体反応に追いつきます。",
 		"tr_text": "",
 		"fileID": 3
@@ -12082,7 +12082,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……そう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12090,7 +12090,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あねっとぉ？<%br>どったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -12098,7 +12098,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12106,7 +12106,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……お願いだから……死なないでね。<%br>いなく、ならないで……",
 		"tr_text": "",
 		"fileID": 3
@@ -12114,7 +12114,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット……さん。",
 		"tr_text": "",
 		"fileID": 3
@@ -12122,7 +12122,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫ですよ。わたし達も強くなりました……<%br>それに、リーダーが一緒です。",
 		"tr_text": "",
 		"fileID": 3
@@ -12130,7 +12130,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そ、そうだぞ！　だから、大丈夫だってば！<%br>それよりアネットこそ、気をつけろよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12138,7 +12138,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はーいはいはい。なーんかアネットが<%br>しんみりしちゃってるけど、大丈夫よ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12146,7 +12146,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "心配なさんな。<%br>……とはいえ、お互い気を付けようぜ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12154,7 +12154,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それじゃあな！",
 		"tr_text": "",
 		"fileID": 3
@@ -12162,7 +12162,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……セラフィさん<%br>捕食者の反応は近いんですよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -12170,7 +12170,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はい、すぐ近くです。",
 		"tr_text": "",
 		"fileID": 3
@@ -12178,7 +12178,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "いしょぎましょ！<%br>りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12186,7 +12186,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "グゥウオオオオオー！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12194,7 +12194,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "これ……は……",
 		"tr_text": "",
 		"fileID": 3
@@ -12202,7 +12202,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ひゅぅ……<%br>こわ、い……",
 		"tr_text": "",
 		"fileID": 3
@@ -12210,7 +12210,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ひどい……ってば……<%br>お前がっ……お前がやったのか！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12218,7 +12218,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイド……！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12226,7 +12226,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……また……お前らか。",
 		"tr_text": "",
 		"fileID": 3
@@ -12234,7 +12234,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "だが、ちょうどいい。腹は満たされた。<%br>どの程度食えばお前らを殺せるのか……",
 		"tr_text": "",
 		"fileID": 3
@@ -12242,7 +12242,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "指標になる。",
 		"tr_text": "",
 		"fileID": 3
@@ -12250,7 +12250,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイズ・ドラールは……造龍なんですよね？<%br>なのに……どうして、龍族を……",
 		"tr_text": "",
 		"fileID": 3
@@ -12258,7 +12258,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "また、お前が納得する<%br>理由が欲しいのか……くだらない。",
 		"tr_text": "",
 		"fileID": 3
@@ -12266,7 +12266,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あなたには……アークスへの殺意しか<%br>ないんじゃないかって……思っていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -12274,7 +12274,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "龍族も……仲間のウェポノイドも……<%br>アークスを殺すためなら……捕食する。",
 		"tr_text": "",
 		"fileID": 3
@@ -12282,7 +12282,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12290,7 +12290,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -12306,7 +12306,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "でも、あなたには……アークスへの殺意よりも<%br>優先する……仲間がいる。",
 		"tr_text": "",
 		"fileID": 3
@@ -12314,7 +12314,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたしは……仲間を想う気持ちがある人に<%br>心がないなんて、思いたくない……",
 		"tr_text": "",
 		"fileID": 3
@@ -12322,7 +12322,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "オンナ……お前、何が言いたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -12330,7 +12330,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……あなたは、あなたの意思で……<%br>こんなことをしているんです？",
 		"tr_text": "",
 		"fileID": 3
@@ -12338,7 +12338,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12346,7 +12346,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……うるさい、オンナだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12354,7 +12354,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "さっさと、始めるぞ。<%br>殺し合いだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12362,7 +12362,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お……おい、ジェネ……！<%br>アンタ何してんだ、離れろ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12370,7 +12370,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ヘイズ・ドラール……<%br>く……来るぞ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12378,7 +12378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "はぁ……はぁ……<%br>デュナ……だいじょうぶ、です……？",
 		"tr_text": "",
 		"fileID": 3
@@ -12386,7 +12386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……まま、うぅ……<%br>でゅな、だいじょうぶよ……まま。",
 		"tr_text": "",
 		"fileID": 3
@@ -12394,7 +12394,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12402,7 +12402,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ひゃっ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12410,7 +12410,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……リーダーの後ろに<%br>かくれてろってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -12418,7 +12418,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あいつ……やっぱり……<%br>前より強くなってる……",
 		"tr_text": "",
 		"fileID": 3
@@ -12426,7 +12426,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……この力……今までの粗雑なものとは……<%br>効果が違うな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12434,7 +12434,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "今まで食べた他の惑星の生物やウェポノイドと<%br>くらべて、この惑星のやつらは相性がいいようだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12442,7 +12442,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12450,7 +12450,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "くそ……！<%br>クシャネ……ビュラ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12458,7 +12458,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "クシャネビュラ……<%br>アイツのこと、食って……",
 		"tr_text": "",
 		"fileID": 3
@@ -12466,7 +12466,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "お前にとって、アイツは……<%br>食料でしか……なかったのかっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12474,7 +12474,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12482,7 +12482,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12490,7 +12490,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -12506,7 +12506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……り、リーダー。<%br>あり……がとう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12514,7 +12514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "お前が、この隊の将か。",
 		"tr_text": "",
 		"fileID": 3
@@ -12522,7 +12522,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前を倒すまでには……<%br>まだ俺の力は及ばない。",
 		"tr_text": "",
 		"fileID": 3
@@ -12530,7 +12530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "まだ……まだ、食べる気ですか？",
 		"tr_text": "",
 		"fileID": 3
@@ -12538,7 +12538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "当たり前だ。お前らを殺せないようでは<%br>アークスを殺し尽くすことはできない……",
 		"tr_text": "",
 		"fileID": 3
@@ -12546,7 +12546,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ここの種族は、まだ食べる価値がある。",
 		"tr_text": "",
 		"fileID": 3
@@ -12554,7 +12554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ま、まって……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12562,7 +12562,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うっ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12570,7 +12570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ままっ！<%br>だめ、けが、してう……",
 		"tr_text": "",
 		"fileID": 3
@@ -12578,7 +12578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はぁ……はぁ……<%br>ヘイド……",
 		"tr_text": "",
 		"fileID": 3
@@ -12586,7 +12586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あなた、本当に……<%br>自分の意思で、こんなことをしているの？",
 		"tr_text": "",
 		"fileID": 3
@@ -12594,7 +12594,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もしかしてあなたも、シュトラや……<%br>クシャネビュラのように……",
 		"tr_text": "",
 		"fileID": 3
@@ -12602,7 +12602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "自分の意思とは違う何かで……<%br>こんなことをしているんじゃ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12610,7 +12610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12618,7 +12618,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……くだらない。",
 		"tr_text": "",
 		"fileID": 3
@@ -12626,7 +12626,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ふぅ……ふたりとも、大丈夫か？<%br>いったん報告を入れてから、追跡を続けよう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12634,7 +12634,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……そうですか。捕食者は、２体。<%br>惑星アムドゥスキアの龍族を食らう者。",
 		"tr_text": "",
 		"fileID": 3
@@ -12642,7 +12642,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "そして、惑星ウォパルにいる……海王種。<%br>ウォパルは、最初に目撃された場所……",
 		"tr_text": "",
 		"fileID": 3
@@ -12650,7 +12650,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "たしか、カラミティ。<%br>あなたが報告をしてくれた場所でしたね。",
 		"tr_text": "",
 		"fileID": 3
@@ -12658,7 +12658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "んんっー！　そう！<%br>ボクが見つけたんだ！　このウォパルでっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12666,7 +12666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ちょ、おま、今は黙ってろ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12674,7 +12674,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "えーっと、っていうわけで、現在二手に<%br>分かれて捕食者の追跡を続けています。",
 		"tr_text": "",
 		"fileID": 3
@@ -12682,7 +12682,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "分かりました。<%br>気を付けてください。どうぞ、ご武運を……",
 		"tr_text": "",
 		"fileID": 3
@@ -12690,7 +12690,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……っと！<%br>じゃあ、進むとするか……",
 		"tr_text": "",
 		"fileID": 3
@@ -12698,7 +12698,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ぶーの！　あねっと！",
 		"tr_text": "",
 		"fileID": 3
@@ -12706,7 +12706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "うお、今度はどうした？<%br>なんだ……デュナちゃんか……",
 		"tr_text": "",
 		"fileID": 3
@@ -12714,7 +12714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "でゅなもね、つーしん、する。<%br>もしもーし！",
 		"tr_text": "",
 		"fileID": 3
@@ -12722,7 +12722,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ちょっと、デュナってば……<%br>もう、もしもしいいだろ？　代われってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -12730,7 +12730,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……何かあったの？<%br>大丈夫？",
 		"tr_text": "",
 		"fileID": 3
@@ -12738,7 +12738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "大丈夫だってば！<%br>えっとさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12746,7 +12746,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "さっき、龍族を捕食してるヘイドを<%br>見つけたんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12754,7 +12754,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ヘイドは、龍族を捕食して<%br>以前よりずっと……ずっと強くなっていました。",
 		"tr_text": "",
 		"fileID": 3
@@ -12762,7 +12762,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "やっぱ、ヘイドだったか……<%br>強くなってるってのは、厄介だね。",
 		"tr_text": "",
 		"fileID": 3
@@ -12770,7 +12770,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "わたし達は、ヘイドを追って<%br>龍祭壇エリアのさらに奥に進みます。",
 		"tr_text": "",
 		"fileID": 3
@@ -12778,7 +12778,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なぁなぁ、ブルーノ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12786,7 +12786,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "惑星ウォパルにいるさ、海王種の<%br>その捕食者って……",
 		"tr_text": "",
 		"fileID": 3
@@ -12794,7 +12794,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "捕食するってことは<%br>ヘイドと同じ能力なんだよな？",
 		"tr_text": "",
 		"fileID": 3
@@ -12802,7 +12802,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……うーん、いい線いってる気はするけど。<%br>オレは、捕食以外の能力を警戒してるかな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12810,7 +12810,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12818,7 +12818,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "捕食以外？",
 		"tr_text": "",
 		"fileID": 3
@@ -12826,7 +12826,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "まず、ヘイズ・ドラールには捕食能力がある。<%br>これは個体の能力値を上げる厄介な能力だが……",
 		"tr_text": "",
 		"fileID": 3
@@ -12834,7 +12834,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "裏を返せば強くなるのはそいつだけ……つまり<%br>能力の価値は「その個体に限定」されるわけだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12842,7 +12842,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "でも、空間転移能力は、他に利用方法がある<%br>人間にとって、「利用価値の高い能力」になる。",
 		"tr_text": "",
 		"fileID": 3
@@ -12850,7 +12850,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……それって、ヘイドは空間転移能力を<%br>悪用するために生まれた……ってことだよな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12858,7 +12858,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そう、つまり……俺たちが追う海王種の捕食者も<%br>捕食以外に能力があるってこと。",
 		"tr_text": "",
 		"fileID": 3
@@ -12866,7 +12866,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "んんっ！　……海王種で<%br>空間転移能力を持つエネミーはいないはずだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12874,7 +12874,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "じゃあ、ウォパルの捕食者は、空間転移能力<%br>ではない能力を持っている……ってことです？",
 		"tr_text": "",
 		"fileID": 3
@@ -12882,7 +12882,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そう！　「利用価値の高い能力」をね。<%br>あー、実に楽しみだ！　早く会いたいっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12890,7 +12890,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……お前なっ！<%br>カラミティ！　てめーっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12898,7 +12898,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "からみてー、しゅとらー！<%br>あしょぶのー？",
 		"tr_text": "",
 		"fileID": 3
@@ -12906,7 +12906,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……えっ？<%br>いや……遊んでるわけじゃ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12914,7 +12914,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "はーいはい、ストップストップ。<%br>どうどうどう、落ち着いて。",
 		"tr_text": "",
 		"fileID": 3
@@ -12922,7 +12922,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "今はお互い、捕食者の追跡と捕獲が最優先だ。<%br>ケンカも仲直りも、任務が終わってからな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12930,7 +12930,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それじゃ、リーダー。<%br>あとでアークスシップで落ち合おう。またな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12938,7 +12938,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "またねー、ぶーの！",
 		"tr_text": "",
 		"fileID": 3
@@ -12946,7 +12946,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……くっそ！<%br>カラミティの奴……ホントむかつく。",
 		"tr_text": "",
 		"fileID": 3
@@ -12954,7 +12954,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "落ち着けってば。シュトラ……<%br>カラミティのこと、許してやれよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12962,7 +12962,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "でゅなも<%br>ゆるしたらいいよーって、おもう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12970,7 +12970,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12978,7 +12978,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "はぁー……<%br>こんな子供に諭されてるなんて……",
 		"tr_text": "",
 		"fileID": 3
@@ -12986,7 +12986,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "うふふ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12994,7 +12994,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ、ご、ごめんなさい。任務が終わったら<%br>ケンカして……それから、仲直りもしましょ？",
 		"tr_text": "",
 		"fileID": 3
@@ -13002,7 +13002,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……わかったよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13010,7 +13010,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "よっしゃ！　じゃあヘイドのやつ追うぞ！<%br>いっくぜー！",
 		"tr_text": "",
 		"fileID": 3
@@ -13018,7 +13018,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いきましょー！<%br>りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13026,7 +13026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "周辺エネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 3
@@ -13034,7 +13034,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ヘイドの生体反応まで、あと少しです。<%br>がんばってください！",
 		"tr_text": "",
 		"fileID": 3
@@ -13042,7 +13042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……おうっ！<%br>がんばるってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -13050,7 +13050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "がんばるよー！",
 		"tr_text": "",
 		"fileID": 3
@@ -13058,7 +13058,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "しゅとら？<%br>しゅとらー？　どーたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -13066,7 +13066,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……え？<%br>あ……いや、べつに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13074,7 +13074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13090,7 +13090,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13098,7 +13098,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "（あんな嫌な奴、どうなったって……<%br>　でも……）",
 		"tr_text": "",
 		"fileID": 3
@@ -13106,7 +13106,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13122,7 +13122,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……なんなんだよ、アイツ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13130,7 +13130,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……なんなんだよ、アイツ。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -13146,7 +13146,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ち、ちげーよ。<%br>あんな奴……別に……",
 		"tr_text": "",
 		"fileID": 3
@@ -13154,7 +13154,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……ウェポノイドは……オレみたいに<%br>攻撃するために利用されるかもしれない……",
 		"tr_text": "",
 		"fileID": 3
@@ -13162,7 +13162,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だから、アイツも……<%br>カラミティも気を付けないと……",
 		"tr_text": "",
 		"fileID": 3
@@ -13170,7 +13170,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "へぇ……シュトラ、なんだかんだ言っても<%br>カラミティのこと心配してんだなっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13178,7 +13178,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……あ、あのさ。<%br>リーダー、アンタが強いのは分かった。",
 		"tr_text": "",
 		"fileID": 3
@@ -13186,7 +13186,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "その……惑星ウォパルに行ったメンツは<%br>大丈夫、なのか……",
 		"tr_text": "",
 		"fileID": 3
@@ -13194,7 +13194,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "あの人たちだけで、リーダーがいないのに<%br>捕食者と戦えるのか……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13202,7 +13202,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ぶーの！　つよーいよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13210,7 +13210,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そうそうっ！　でも、なんだかんだ言って<%br>カラミティのこと心配してんだなぁ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13218,7 +13218,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13226,7 +13226,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラ、さん？",
 		"tr_text": "",
 		"fileID": 3
@@ -13234,7 +13234,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そ、そんなんじゃ……ねーよ。<%br>別に……",
 		"tr_text": "",
 		"fileID": 3
@@ -13242,7 +13242,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "（オレは……）",
 		"tr_text": "",
 		"fileID": 3
@@ -13250,7 +13250,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "（アイツ……大丈夫、だよな。<%br>　クシャネビュラみたいに……なるなよ）",
 		"tr_text": "",
 		"fileID": 3
@@ -13258,7 +13258,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……へへへっ！<%br>シュトラのやつも、意外と優しいんだな。",
 		"tr_text": "",
 		"fileID": 3
@@ -13266,7 +13266,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "でゅな、しってるよ。<%br>しゅとら、いいこいいこっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13274,7 +13274,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "うんうんっ！<%br>素直じゃないのは、照れてるんだってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -13282,7 +13282,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "てれれる？<%br>てれ、てる？？",
 		"tr_text": "",
 		"fileID": 3
@@ -13290,7 +13290,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "おう！　はずかしいって思って<%br>かっこつけてるんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13298,7 +13298,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……おい、モア。マジで恥ずかしいから<%br>そんなことデュナに説明すんなよ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13306,7 +13306,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "うふふふ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13314,7 +13314,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ……えっと、ごめんなさい。",
 		"tr_text": "",
 		"fileID": 3
@@ -13322,7 +13322,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "でも、わたし……シュトラさんがみんなと<%br>自然にやりとりしているのが……嬉しくって。",
 		"tr_text": "",
 		"fileID": 3
@@ -13330,7 +13330,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさん、ずっと一人で使命感っていうか……<%br>追い詰められたような表情をしていたから……",
 		"tr_text": "",
 		"fileID": 3
@@ -13338,7 +13338,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13346,7 +13346,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……急ごうぜ。<%br>終わったら、ウォパルに合流しよう。",
 		"tr_text": "",
 		"fileID": 3
@@ -13354,7 +13354,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……おいおい、嫌になっちゃうね。<%br>アネット……カラミティ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13362,7 +13362,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "あれは……",
 		"tr_text": "",
 		"fileID": 3
@@ -13370,7 +13370,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……マギサ・メデューナ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13378,7 +13378,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "グォゴォゴォゴォッ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13386,7 +13386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "あの女性……<%br>……これは……歌？",
 		"tr_text": "",
 		"fileID": 3
@@ -13394,7 +13394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 3
@@ -13402,7 +13402,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "いつか　あなたは<%br>大きな夢みつけるの",
 		"tr_text": "",
 		"fileID": 3
@@ -13410,7 +13410,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "…………！",
 		"tr_text": "",
 		"fileID": 3
@@ -13418,7 +13418,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "あなた、たちは……？<%br>人間……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13426,7 +13426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "彼女が……私たちが追っていたトランスエネミー。<%br>……でも……なにこれ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13434,7 +13434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（周辺に残った喰い跡、亡骸……<%br>　海王種の鳴き声を上げ、むさぼり食った）",
 		"tr_text": "",
 		"fileID": 3
@@ -13442,7 +13442,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（なのに、なんで……<%br>　あんなに穏やかな、表情をしているの？）",
 		"tr_text": "",
 		"fileID": 3
@@ -13450,7 +13450,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……あぁ。<%br>ふたりとも、下がってろ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13458,7 +13458,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "俺たちは、あんたに危害を加える気はない。<%br>話が聞きたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -13466,7 +13466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "話……<%br>あなたたちは、一体……",
 		"tr_text": "",
 		"fileID": 3
@@ -13474,7 +13474,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "俺たちは、アークスだ。<%br>一緒にアークスシップに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13482,7 +13482,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "アークス……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13490,7 +13490,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "……いた。<%br>アイツまた、龍族を喰ったんだ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13498,7 +13498,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13506,7 +13506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "わたしは、あなたがどうして<%br>アークスを憎むのか……知りたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -13514,7 +13514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "龍族を捕食して……<%br>仲間のウェポノイドを捕食して……",
 		"tr_text": "",
 		"fileID": 3
@@ -13522,7 +13522,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "同じトランスエネミーのデュナを攻撃して……",
 		"tr_text": "",
 		"fileID": 3
@@ -13530,7 +13530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……<%br>あなたの理由を聞かせて……",
 		"tr_text": "",
 		"fileID": 3
@@ -13538,7 +13538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13546,7 +13546,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前らを全員<%br>残さず……殺すためだ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13554,7 +13554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あの日の……約束……",
 		"tr_text": "",
 		"fileID": 3
@@ -13562,7 +13562,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "やく……そく……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13570,7 +13570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "貴様らアークスが生み出した。",
 		"tr_text": "",
 		"fileID": 3
@@ -13578,7 +13578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "この世にはないはずのものを<%br>自分の賢さの証明のために……",
 		"tr_text": "",
 		"fileID": 3
@@ -13586,7 +13586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "その愚かさに……<%br>気づかないお前たちを……",
 		"tr_text": "",
 		"fileID": 3
@@ -13594,7 +13594,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "俺が……<%br>滅ぼしてやる……",
 		"tr_text": "",
 		"fileID": 3
@@ -13602,7 +13602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……まま。<%br>こわい、こわい……",
 		"tr_text": "",
 		"fileID": 3
@@ -13610,7 +13610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "大丈夫です。デュナ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13618,7 +13618,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダー、彼は憎しみを食べて強くなってる。<%br>止めなきゃ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13626,7 +13626,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "行きましょう！",
 		"tr_text": "",
 		"fileID": 3
@@ -13634,7 +13634,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……う……うぅ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13642,7 +13642,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "くっ……<%br>ジェネ、モア……大丈夫か？",
 		"tr_text": "",
 		"fileID": 3
@@ -13650,7 +13650,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "う、うん……大丈夫ってば……",
 		"tr_text": "",
 		"fileID": 3
@@ -13658,7 +13658,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "くっそ！　前のヘイドとの戦いで、ふたりとも……<%br>どうすんだよ、アイツまた強くなってる……",
 		"tr_text": "",
 		"fileID": 3
@@ -13666,7 +13666,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイズ・ドラール",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "グゥウオオオオオー！！",
 		"tr_text": "",
 		"fileID": 3
@@ -13674,7 +13674,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Haze Draal",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13682,7 +13682,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……くっ！<%br>これは……まさか……",
 		"tr_text": "",
 		"fileID": 3
@@ -13690,7 +13690,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ど、どうしたんだ……アイツ？<%br>なんで人の姿に、急に戻ったんだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -13698,7 +13698,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……ティス……今、どこに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13706,7 +13706,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……なぜだ！<%br>勝手に……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13714,7 +13714,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 3
@@ -13722,7 +13722,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "お前が死んだら……俺は……<%br>くっ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13730,7 +13730,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13746,7 +13746,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……まま……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13754,7 +13754,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "だいじょうぶ……です。<%br>それより、ヘイドが……",
 		"tr_text": "",
 		"fileID": 3
@@ -13762,7 +13762,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リーダーっ！<%br>ジェネ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13770,7 +13770,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……どうしました？",
 		"tr_text": "",
 		"fileID": 3
@@ -13778,7 +13778,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ブルーノ、ブルーノが……っ！<%br>どうしてよ、馬鹿！",
 		"tr_text": "",
 		"fileID": 3
@@ -13786,7 +13786,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "な……は、はは……たしかに馬鹿、かも俺。<%br>まったく……嫌になるよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13794,7 +13794,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "なるほど……クシャネビュラ……シュトラ。<%br>ヘイドの……空間転移能力の……代わり……",
 		"tr_text": "",
 		"fileID": 3
@@ -13802,7 +13802,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "カラミティ……わりぃ。<%br>こうなるなんて……うっ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13810,7 +13810,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13826,7 +13826,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "貴方……カラミティを……<%br>いえ、シュトラもクシャネビュラも……",
 		"tr_text": "",
 		"fileID": 3
@@ -13834,7 +13834,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "貴方が……「操った」のねっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13842,7 +13842,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "カラミティ……この者たちは、アークス。<%br>宇宙に害を成す、危険な生命体。",
 		"tr_text": "",
 		"fileID": 3
@@ -13850,7 +13850,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "あらゆる種の幸福を考えれば……<%br>私たちは、アークスを……",
 		"tr_text": "",
 		"fileID": 3
@@ -13858,7 +13858,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "滅ぼさなくてはならない。",
 		"tr_text": "",
 		"fileID": 3
@@ -13866,7 +13866,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "それぞれの「理由」",
 		"tr_text": "",
 		"fileID": 3
@@ -13882,7 +13882,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……どうしました？",
 		"tr_text": "",
 		"fileID": 4
@@ -13890,7 +13890,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ブルーノ、ブルーノが……っ！<%br>どうしてよ、馬鹿！",
 		"tr_text": "",
 		"fileID": 4
@@ -13898,7 +13898,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "わたし達が駆け付けたときには<%br>ブルーノさんは、重傷を負い<%br>アネットさんはその場に倒れて<%br>……意識を失っていました。",
 		"tr_text": "",
 		"fileID": 4
@@ -13930,7 +13930,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット……大丈夫かよ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -13938,7 +13938,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……モア、リーダー……<%br>ここは……アークスシップ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -13946,7 +13946,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "カラミティが……<%br>……そうだ……ブルーノは！？",
 		"tr_text": "",
 		"fileID": 4
@@ -13954,7 +13954,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……うっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -13962,7 +13962,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……おい、無理して起きるなって。<%br>アンタ、意識失ってたんだ。怪我もひどい。",
 		"tr_text": "",
 		"fileID": 4
@@ -13970,7 +13970,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アネットさん……！<%br>よかった……目が覚めたんですね。",
 		"tr_text": "",
 		"fileID": 4
@@ -13978,7 +13978,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ジェネ……",
 		"tr_text": "",
 		"fileID": 4
@@ -13986,7 +13986,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "今、ブルーノさんの容態について<%br>デュナと一緒に聞いてきたんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -13994,7 +13994,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ブルーノさん……意識はまだ戻ってませんが<%br>命に別条はないみたいです。",
 		"tr_text": "",
 		"fileID": 4
@@ -14002,7 +14002,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……そう。よかった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14010,7 +14010,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……わたし達が到着するまでに<%br>何があったか、聞いても大丈夫ですか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14018,7 +14018,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ……リーダーたちが駆け付けてくれる<%br>までに、起きたことを話すわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14026,7 +14026,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダーたちと離れて<%br>私、ブルーノ、カラミティの３名は<%br>惑星ウォパルへ向かった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14050,7 +14050,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "俺たちは、あんたに危害を加える気はない。<%br>話が聞きたい。",
 		"tr_text": "",
 		"fileID": 4
@@ -14058,7 +14058,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "話……<%br>あなたたちは、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -14066,7 +14066,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "俺たちは、アークスだ。<%br>一緒にアークスシップに……",
 		"tr_text": "",
 		"fileID": 4
@@ -14074,7 +14074,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "アークス……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14082,7 +14082,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "アークス……アークス……っ！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14090,7 +14090,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "……っ！<%br>アネット、カラミティ……構えろっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14098,7 +14098,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "『－－－－－－－－』",
 		"tr_text": "",
 		"fileID": 4
@@ -14106,7 +14106,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "なに……この声……！？<%br>一体何をしようとしているの……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14114,7 +14114,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット、危ない……っ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14122,7 +14122,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "コロス……アークス！",
 		"tr_text": "",
 		"fileID": 4
@@ -14130,7 +14130,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラミティのヤツ……<%br>くそっ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14138,7 +14138,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そっか……アネット……<%br>それで……どうなったんだってば？",
 		"tr_text": "",
 		"fileID": 4
@@ -14146,7 +14146,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……それで……ヘイドが現れて<%br>海王種が……途中で……うっ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14154,7 +14154,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あねっと、いたいの？<%br>だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14162,7 +14162,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……無理しちゃダメです。<%br>ゆっくり休んでください……",
 		"tr_text": "",
 		"fileID": 4
@@ -14170,7 +14170,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ……<%br>そうさせて……もらうわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14178,7 +14178,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（ここから先は……<%br>　まだジェネたちには話せない……）",
 		"tr_text": "",
 		"fileID": 4
@@ -14186,7 +14186,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "惑星ウォパルで遭遇した<%br>新たなトランスエネミー……<%br>アナティスの能力によって<%br>カラミティが「洗脳」されてしまった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14218,7 +14218,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……<%br>お前ひとりを、戦わせるわけにはいかない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14226,7 +14226,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "私たちは、ふたりきり。<%br>お前がいなくなれば、私は悲しい。",
 		"tr_text": "",
 		"fileID": 4
@@ -14234,7 +14234,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "殺す時は一緒だ。<%br>死ぬ時も……一緒だ……",
 		"tr_text": "",
 		"fileID": 4
@@ -14242,7 +14242,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "ふたり、きり……<%br>アナティス……お前……",
 		"tr_text": "",
 		"fileID": 4
@@ -14250,7 +14250,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ったく、最悪だな。<%br>アネット……、お前……まだ動けるな？",
 		"tr_text": "",
 		"fileID": 4
@@ -14258,7 +14258,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……え？<%br>えぇ……ブルーノ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14266,7 +14266,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "最悪……だけどね……<%br>お前、先逃げろ……",
 		"tr_text": "",
 		"fileID": 4
@@ -14274,7 +14274,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……っ！<%br>ふざけないで、そんなことできるわけ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14282,7 +14282,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ジェネちゃんと、おチビに……死ぬなって<%br>言った……お前が、死んだら笑えねーの。",
 		"tr_text": "",
 		"fileID": 4
@@ -14290,7 +14290,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "分かった？　さ……！<%br>アイツらそんな、足止めできないから……急げ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14298,7 +14298,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "（私だけじゃ……ヘイドひとりだって<%br>　相手にできない……それなのに……）",
 		"tr_text": "",
 		"fileID": 4
@@ -14306,7 +14306,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（どうしたら……どうしたら……）",
 		"tr_text": "",
 		"fileID": 4
@@ -14314,7 +14314,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ウオオオオオーー！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14322,7 +14322,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "え……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14330,7 +14330,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "『……アンタタチヲ助ケテヤル。<%br>　ソノ代ワリ……交換条件ダ』",
 		"tr_text": "",
 		"fileID": 4
@@ -14338,7 +14338,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "…………！！<%br>……ノワル・ドラール……なぜ、こんなところに？",
 		"tr_text": "",
 		"fileID": 4
@@ -14346,7 +14346,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "アナティス、下がれ……",
 		"tr_text": "",
 		"fileID": 4
@@ -14354,7 +14354,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14362,7 +14362,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……腹の子を、危険に晒すな。",
 		"tr_text": "",
 		"fileID": 4
@@ -14370,7 +14370,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "『ウォオォォォォォォォッ！！』",
 		"tr_text": "",
 		"fileID": 4
@@ -14378,7 +14378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "みなさん、惑星ナベリウスの凍土エリアで<%br>新たな捕食の目撃情報が報告されました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14386,7 +14386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……どうすんだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14394,7 +14394,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ブルーノのおっさんも重傷だし<%br>アネットだって戦える状態じゃねーし……",
 		"tr_text": "",
 		"fileID": 4
@@ -14402,7 +14402,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それに……カラミティだって……<%br>アイツだって……敵側に……",
 		"tr_text": "",
 		"fileID": 4
@@ -14410,7 +14410,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それに……カラミティだって……<%br>アイツだって……敵側に……",
 		"tr_text": "",
 		"jp_buttons": [
@@ -14426,7 +14426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……リーダー、アンタだってブルーノの<%br>おっさんみたいになるかもしれねーんだぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14434,7 +14434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラさん……ブルーノさんに、わたし<%br>ずっと前に、言われたことがあるんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -14442,7 +14442,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "任務は……終わらせなきゃいけない。<%br>今まで傷ついた人達のために……って。",
 		"tr_text": "",
 		"fileID": 4
@@ -14450,7 +14450,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だから、終わらせましょう。<%br>きっとブルーノさんも、そう言うと思います。",
 		"tr_text": "",
 		"fileID": 4
@@ -14458,7 +14458,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それに何より……<%br>カラミティさんのことを、助けましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -14466,7 +14466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ブルーノのおっさんみたいに……<%br>カラミティみたいに、なるかもしれねーんだぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14474,7 +14474,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それでも……行かなきゃいけないんです。<%br>リーダー、わたしも行きます。",
 		"tr_text": "",
 		"fileID": 4
@@ -14482,7 +14482,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だって……カラミティさんを助けなきゃ。<%br>きっとブルーノさんだって、そう言うと思います。",
 		"tr_text": "",
 		"fileID": 4
@@ -14490,7 +14490,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……カラミティ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14498,7 +14498,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "少し……いいかしら？<%br>リーダー、ジェネ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14506,7 +14506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……！<%br>どうしました？　大丈夫です？",
 		"tr_text": "",
 		"fileID": 4
@@ -14514,7 +14514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫よ。ありがとう。<%br>それより……",
 		"tr_text": "",
 		"fileID": 4
@@ -14522,7 +14522,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "シュトラが心配になるのは、もっともね。<%br>ただ……今が一番、彼らを捕えやすい時よ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14530,7 +14530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "どういうことだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14538,7 +14538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ブルーノの負傷後……",
 		"tr_text": "",
 		"fileID": 4
@@ -14546,7 +14546,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "私たちはカラミティを洗脳したトランスエネミーと<%br>共に、海王種に囲まれてしまった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14554,7 +14554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そこにヘイドが現れ、そのトランスエネミーを<%br>保護して、連れ帰ったの……",
 		"tr_text": "",
 		"fileID": 4
@@ -14562,7 +14562,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドは彼女を、アナティスと呼んでいた。",
 		"tr_text": "",
 		"fileID": 4
@@ -14570,7 +14570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ふたりの会話では、アナティスは<%br>何らかの理由で……普段は外に出ない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14578,7 +14578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドの口調だと……出ることを<%br>良しとされていないようだった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14586,7 +14586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -14602,7 +14602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……なぜだ！<%br>勝手に……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14610,7 +14610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "もしかして……ヘイドが食料を持って帰るって<%br>話していたのって、そのアナティスのため……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14618,7 +14618,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "確かにそれだと、アナティスが表に出られない今が<%br>捕まえやすい……ってことか。",
 		"tr_text": "",
 		"fileID": 4
@@ -14626,7 +14626,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そうよ。アナティスが表に出てこられるように<%br>なったら……更に事態は厄介になる。",
 		"tr_text": "",
 		"fileID": 4
@@ -14634,7 +14634,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "わかった、オレも行くよ……<%br>やるなら……今しかない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14642,7 +14642,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ……うん、行こうぜ！<%br>大丈夫だってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -14650,7 +14650,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……う……うん。<%br>そう……だな。",
 		"tr_text": "",
 		"fileID": 4
@@ -14658,7 +14658,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……みんな、それでも十分に気を付けて。<%br>無事を願ってるわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14666,7 +14666,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダー……みんなのこと、お願い。",
 		"tr_text": "",
 		"fileID": 4
@@ -14674,7 +14674,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "はい……行ってきます。<%br>みんなで頑張りましょうね！",
 		"tr_text": "",
 		"fileID": 4
@@ -14682,7 +14682,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "がんばるよー！<%br>りだ、いきましょ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14690,7 +14690,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん、周囲のエネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 4
@@ -14698,7 +14698,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "きゅしゅんっ！<%br>しゃ、しゃむい……ね！",
 		"tr_text": "",
 		"fileID": 4
@@ -14706,7 +14706,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……大丈夫です？",
 		"tr_text": "",
 		"fileID": 4
@@ -14714,7 +14714,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だいじょーばないけど、けど……グズッ<%br>でゅな、だいじょーぶよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14722,7 +14722,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん、捕食者の生体反応が<%br>凍土エリアから消えてしまったのですが……",
 		"tr_text": "",
 		"fileID": 4
@@ -14730,7 +14730,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ええっ！　じゃ、じゃあ戻ろうぜ……<%br>……デュナも風邪ひいちゃうってば。",
 		"tr_text": "",
 		"fileID": 4
@@ -14738,7 +14738,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ですが……その……<%br>カラミティさんの反応が、確認できました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14746,7 +14746,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14754,7 +14754,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "か、カラミティが……<%br>アイツが、いるのか？　凍土エリアに！",
 		"tr_text": "",
 		"fileID": 4
@@ -14762,7 +14762,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……はい、カラミティさんと同じ反応が<%br>凍土エリア奥地に現れました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14770,7 +14770,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "入れ替わりに、捕食者の生体反応が消失したため<%br>おそらく捕食者はヘイドかと思われます。",
 		"tr_text": "",
 		"fileID": 4
@@ -14778,7 +14778,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "空間転移能力で、カラミティさんを呼び出して<%br>ヘイドは……帰ったということ、でしょうか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14786,7 +14786,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……はい、その可能性が高いと思われます。",
 		"tr_text": "",
 		"fileID": 4
@@ -14794,7 +14794,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……行こうぜ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14802,7 +14802,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ヘイドのヤツがいないなら……<%br>カラミティを、連れ戻せるかもしれない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14810,7 +14810,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "チップ研究所とかに連れて行けば……<%br>助けられるかも、知れねーよな？",
 		"tr_text": "",
 		"fileID": 4
@@ -14818,7 +14818,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ……<%br>うん……そうだな！　そうだってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -14826,7 +14826,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "シュトラさん……<%br>助けましょう、絶対……カラミティさんを！",
 		"tr_text": "",
 		"fileID": 4
@@ -14834,7 +14834,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うんっ！<%br>いっしょに、たすけよーね。",
 		"tr_text": "",
 		"fileID": 4
@@ -14842,7 +14842,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あぁ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14850,7 +14850,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……リーダー、ジェネ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14858,7 +14858,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……！<%br>もう、大丈夫なんですか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14866,7 +14866,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ。どうにか……",
 		"tr_text": "",
 		"fileID": 4
@@ -14874,7 +14874,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "戦闘には、まだ参加は難しいけれど……<%br>私は動ける範囲で、調べ物をしているわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14882,7 +14882,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "調べものって……<%br>アネット、なに調べてるんだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14890,7 +14890,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あねっと……しらべもの？",
 		"tr_text": "",
 		"fileID": 4
@@ -14898,7 +14898,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "カラミティを操った女性……アナティス。<%br>その元となったマギサ・メデューナについてよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14906,7 +14906,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "マギサ・メデューナには……<%br>本来は、洗脳なんて特殊な能力はないのよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14914,7 +14914,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……じゃあ、なんでアナティスは<%br>洗脳なんて力……使えるんだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14922,7 +14922,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "わからない……ただ、アナティスの元となった<%br>個体に能力が加えられた可能性は、あるわね。",
 		"tr_text": "",
 		"fileID": 4
@@ -14930,7 +14930,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "惑星ウォパルの海王種は<%br>虚空機関の生体実験で生まれた人工生命体。",
 		"tr_text": "",
 		"fileID": 4
@@ -14938,7 +14938,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ならば……そこに「何か」を加えることも<%br>可能だと思う。",
 		"tr_text": "",
 		"fileID": 4
@@ -14946,7 +14946,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "それってさ！　ぼいどってところと<%br>E.M.A.がいっしょに悪いことしたってことか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14954,7 +14954,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "わるいことー？<%br>だめだよね。まま。",
 		"tr_text": "",
 		"fileID": 4
@@ -14962,7 +14962,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……そう、ですね。悪いことはダメです。<%br>でも、虚空機関は解体されてるんですよね？",
 		"tr_text": "",
 		"fileID": 4
@@ -14970,7 +14970,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ。E.M.A.が虚空機関の研究を<%br>引き継いだんじゃないか……そう思っている。",
 		"tr_text": "",
 		"fileID": 4
@@ -14978,7 +14978,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "E.M.A.にとって、虚空機関が生み出した<%br>マギサ・メデューナは必要だった……",
 		"tr_text": "",
 		"fileID": 4
@@ -14986,7 +14986,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……必要って言っても。悪用するためだろ？<%br>カラミティは……そのせいでっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14994,7 +14994,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラさん……",
 		"tr_text": "",
 		"fileID": 4
@@ -15002,7 +15002,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なぁ！　アンタたち……<%br>ずっとE.M.A.のこと追ってたんだろ！？",
 		"tr_text": "",
 		"fileID": 4
@@ -15010,7 +15010,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "なんで……なんで気づかなかったんだよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -15018,7 +15018,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アナティスのことも……ヘイドのことも……<%br>アンタ達がもっと早く……気づいてたら……",
 		"tr_text": "",
 		"fileID": 4
@@ -15026,7 +15026,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そしたらアイツ……<%br>オレみたいにならずに済んだのにっ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15034,7 +15034,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラ。<%br>あのさ……えっと……",
 		"tr_text": "",
 		"fileID": 4
@@ -15042,7 +15042,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……っ！　ごめん。<%br>アンタたちが、悪いわけじゃないのに……",
 		"tr_text": "",
 		"fileID": 4
@@ -15050,7 +15050,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ほんとに……ごめん……オレ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15058,7 +15058,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラさん、行きましょう。<%br>カラミティさんを助けに……ね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15066,7 +15066,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15074,7 +15074,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……リーダー、ジェネ。<%br>私はもう少し調べなきゃいけないことがある。",
 		"tr_text": "",
 		"fileID": 4
@@ -15082,7 +15082,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "こちらの用件が済んだら、合流するわ。<%br>それまで、無理だけはしないで……",
 		"tr_text": "",
 		"fileID": 4
@@ -15090,7 +15090,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "はい……わたし達は、このままカラミティさんの<%br>反応を追って、凍土エリアを進みます。",
 		"tr_text": "",
 		"fileID": 4
@@ -15098,7 +15098,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あねっと、またねー。",
 		"tr_text": "",
 		"fileID": 4
@@ -15106,7 +15106,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "？？？",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……いいのかよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15114,7 +15114,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "???",
 		"jp_text": "……あら、何が？",
 		"tr_text": "",
 		"fileID": 4
@@ -15122,7 +15122,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ジェネに……<%br>アイツらに、オレのこと話さなくて……",
 		"tr_text": "",
 		"fileID": 4
@@ -15130,7 +15130,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "……そうね。<%br>今はまだ……話せないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15138,7 +15138,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……みなさん、止まってください！",
 		"tr_text": "",
 		"fileID": 4
@@ -15146,7 +15146,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "おかしいです。カラミティさんの反応は<%br>確かにこの地点から……",
 		"tr_text": "",
 		"fileID": 4
@@ -15154,7 +15154,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "どこだってば？<%br>なーんも周りにいないぞ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15162,7 +15162,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いないよ？<%br>からみて、いないね、まま？",
 		"tr_text": "",
 		"fileID": 4
@@ -15170,7 +15170,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "お……おい、あれっ！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15178,7 +15178,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "あれは……ヘイドの……",
 		"tr_text": "",
 		"fileID": 4
@@ -15186,7 +15186,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "オ、オ、オ、マエラ……ガ、シタコトダ。<%br>アーアーアー、アークス……",
 		"tr_text": "",
 		"fileID": 4
@@ -15194,7 +15194,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラミティ……さん……",
 		"tr_text": "",
 		"fileID": 4
@@ -15202,7 +15202,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……カラミティのやつ洗脳されちゃったんだな。<%br>あいつ、オレたちことわかんないのかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -15210,7 +15210,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "違う……洗脳されてても<%br>オレ達の声はカラミティに聞こえてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -15218,7 +15218,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -15226,7 +15226,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "カラミティ……助けてやるよ。<%br>お前を……絶対に……",
 		"tr_text": "",
 		"fileID": 4
@@ -15234,7 +15234,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だから……リーダー、カラミティと戦おう。<%br>アイツの動きを抑えないと……",
 		"tr_text": "",
 		"fileID": 4
@@ -15242,7 +15242,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アイツは今、自分の意思で体をコントロール<%br>できる状態じゃないんだ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15250,7 +15250,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アークス……コロス。",
 		"tr_text": "",
 		"fileID": 4
@@ -15258,7 +15258,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "みなさん……気を付けてください！<%br>ウォルガーダが現れました！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15266,7 +15266,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "リーダー、行きましょう！",
 		"tr_text": "",
 		"fileID": 4
@@ -15274,7 +15274,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>カラミティ……さん……",
 		"tr_text": "",
 		"fileID": 4
@@ -15282,7 +15282,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "コロス……コロス……アー、アークス……",
 		"tr_text": "",
 		"fileID": 4
@@ -15290,7 +15290,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "みなさん、ウォルガーダ撃破<%br>確認できました……",
 		"tr_text": "",
 		"fileID": 4
@@ -15298,7 +15298,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "周辺にエネミーは確認できません。<%br>今なら、カラミティさんを確保できます！",
 		"tr_text": "",
 		"fileID": 4
@@ -15306,7 +15306,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "カラミティ……<%br>痛い思いさせて……悪かったな……",
 		"tr_text": "",
 		"fileID": 4
@@ -15314,7 +15314,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ア、アークス……利用、実験……ソノ結果ガ<%br>アークス……コロス……コロ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15322,7 +15322,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "あぶなーよ！<%br>しゅとら！",
 		"tr_text": "",
 		"fileID": 4
@@ -15330,7 +15330,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15338,7 +15338,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "まだだ……まだ、働いてもらうぞ。<%br>カラミティ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15346,7 +15346,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイドサマ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15354,7 +15354,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "戻るぞ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15362,7 +15362,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "おい……！<%br>カラミティ……行くなぁ！",
 		"tr_text": "",
 		"fileID": 4
@@ -15370,7 +15370,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15378,7 +15378,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラ……ミティ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15386,7 +15386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "あとちょっとのところでさ……<%br>カラミティ助けられたのに……！",
 		"tr_text": "",
 		"fileID": 4
@@ -15394,7 +15394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……カラミティを、保護できなかったのは残念ね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15402,7 +15402,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "それにしても……ヘイドの空間転移能力は<%br>思った以上に厄介な能力ね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15410,7 +15410,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あねっと、もう、へいき！<%br>なのーっ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15418,7 +15418,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あら、もうそんなにお喋りできるように<%br>なったのね、賢い子。",
 		"tr_text": "",
 		"fileID": 4
@@ -15426,7 +15426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……もう大丈夫よ。<%br>リーダー……私もチームに戻るわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15434,7 +15434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……もう大丈夫よ。<%br>リーダー……私もチームに戻るわ。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -15450,7 +15450,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうですよ。アネットさん、無理はダメです。<%br>もう少し休んでた方が……",
 		"tr_text": "",
 		"fileID": 4
@@ -15458,7 +15458,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あら？　ジェネに言われたくないわ。<%br>いつも無理ばっかりしてるじゃない……",
 		"tr_text": "",
 		"fileID": 4
@@ -15466,7 +15466,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……えっと、え……わ、わたしはそんな！",
 		"tr_text": "",
 		"fileID": 4
@@ -15474,7 +15474,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ふふ。大丈夫よ、ほんとに。<%br>ありがとう。",
 		"tr_text": "",
 		"fileID": 4
@@ -15482,7 +15482,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうだってば！　アネットがいたら<%br>むずかしーことも、すぐわかるし！",
 		"tr_text": "",
 		"fileID": 4
@@ -15490,7 +15490,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "わかるー。あねっとすごーい！",
 		"tr_text": "",
 		"fileID": 4
@@ -15498,7 +15498,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……うふふ。<%br>ありがとう、ふたりとも。",
 		"tr_text": "",
 		"fileID": 4
@@ -15506,7 +15506,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん、ほんとに無理だけは<%br>しないでください。約束……ですよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15514,7 +15514,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ええ。そうするわ。……私を庇って<%br>重傷を負ったブルーノにも……悪いしね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15522,7 +15522,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ブルーノのおっさん、大丈夫なのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -15530,7 +15530,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……さすがというか、致命傷になりそうな<%br>攻撃は、すべて避けていたみたい。",
 		"tr_text": "",
 		"fileID": 4
@@ -15538,7 +15538,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうはいっても……<%br>当分、動けそうもないみたいだけど。",
 		"tr_text": "",
 		"fileID": 4
@@ -15546,7 +15546,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ぶ……ブルーノがいなくっても<%br>オレの活躍で余裕だってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -15554,7 +15554,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "もあ、ぶーののぶんも、がんばるんだよねー。<%br>でゅなも、がんばるね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15562,7 +15562,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。<%br>貴方、がんばれる？",
 		"tr_text": "",
 		"fileID": 4
@@ -15570,7 +15570,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ふゅ？<%br>がんばるよ？　でゅな、がんばるよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15578,7 +15578,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15586,7 +15586,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……？<%br>どうしたんです……何か、あったんです……？",
 		"tr_text": "",
 		"fileID": 4
@@ -15594,7 +15594,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、お話のところ<%br>すみません……",
 		"tr_text": "",
 		"fileID": 4
@@ -15602,7 +15602,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "捕食者の生体反応が<%br>惑星リリーパで確認できました！",
 		"tr_text": "",
 		"fileID": 4
@@ -15610,7 +15610,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ひとまず……リリーパへ向かいましょう。<%br>……話はそれからでも出来るわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15618,7 +15618,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……そうですね。<%br>惑星リリーパに行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 4
@@ -15626,7 +15626,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みなさん、周辺エネミーの撃破<%br>お疲れ様でした。",
 		"tr_text": "",
 		"fileID": 4
@@ -15634,7 +15634,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……さっき、シップ内でした話だけど<%br>あの話の続き、してくれるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15642,7 +15642,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "えぇ。……人は、毒を作るときに……<%br>必ず合わせて薬も作るの。",
 		"tr_text": "",
 		"fileID": 4
@@ -15650,7 +15650,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "解毒薬や抗体がなければ、どれだけ殺傷能力の<%br>高い毒を作っても、利用価値は低くなる。",
 		"tr_text": "",
 		"fileID": 4
@@ -15658,7 +15658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "むー？<%br>もあ、わかる？",
 		"tr_text": "",
 		"fileID": 4
@@ -15666,7 +15666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "わかん……わかるってば！<%br>でゅ、デュナには、まだ早いけどなっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -15674,7 +15674,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "つまり……",
 		"tr_text": "",
 		"fileID": 4
@@ -15682,7 +15682,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アナティスの「洗脳」の力を使うために<%br>必ず「洗脳を解除」する力が必要になるの。",
 		"tr_text": "",
 		"fileID": 4
@@ -15690,7 +15690,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……アナティスの洗脳が毒なら<%br>それを解くための、薬がいるってことか？",
 		"tr_text": "",
 		"fileID": 4
@@ -15698,7 +15698,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "えぇ、おそらく。アナティスには「解除の能力」を<%br>持たせなかったはず。",
 		"tr_text": "",
 		"fileID": 4
@@ -15706,7 +15706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ま、待ってください。<%br>アネットさん……まさか、解除の能力って……",
 		"tr_text": "",
 		"fileID": 4
@@ -15714,7 +15714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……この子が持っているのよ。<%br>シュトラの洗脳を解除したのは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15722,7 +15722,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -15738,7 +15738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "コロ……ころ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15746,7 +15746,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "デュナ、貴方がウェポノイドの洗脳を解く鍵よ。<%br>がんばれる……わね？",
 		"tr_text": "",
 		"fileID": 4
@@ -15754,7 +15754,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "かーぎー？<%br>でゅなは、でゅなだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15762,7 +15762,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "かぎじゃ、ないよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15770,7 +15770,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "でも、でゅながんばるよ！<%br>ね、まま！",
 		"tr_text": "",
 		"fileID": 4
@@ -15778,7 +15778,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15786,7 +15786,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま？",
 		"tr_text": "",
 		"fileID": 4
@@ -15794,7 +15794,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……あ、アネットさん。<%br>えっと……それって……",
 		"tr_text": "",
 		"fileID": 4
@@ -15802,7 +15802,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ジェネ……私、ずっと考えていたの。<%br>トランスエネミーがなんで生まれたのかって……",
 		"tr_text": "",
 		"fileID": 4
@@ -15810,7 +15810,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "こんなこと、言いたくないけど……",
 		"tr_text": "",
 		"fileID": 4
@@ -15818,7 +15818,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "どんな綺麗ごとを言ったって<%br>人が何かを生み出すとき、そこには理由がある。",
 		"tr_text": "",
 		"fileID": 4
@@ -15826,7 +15826,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "必ず……<%br>利用価値があって、研究が進むの。",
 		"tr_text": "",
 		"fileID": 4
@@ -15834,7 +15834,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15842,7 +15842,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そ、それって……！<%br>デュナも、戦いに利用するためってことかよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15850,7 +15850,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……中には純粋な好奇心で、研究が進む場合も<%br>あるけれど……トランスエネミーは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15858,7 +15858,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "戦闘要員として生まれたのが、ダンテたち。<%br>そして、特殊能力を利用するために……",
 		"tr_text": "",
 		"fileID": 4
@@ -15866,7 +15866,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドやアナティスが<%br>生まれたって……ことですか。",
 		"tr_text": "",
 		"fileID": 4
@@ -15874,7 +15874,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……ままー？",
 		"tr_text": "",
 		"fileID": 4
@@ -15882,7 +15882,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナのこと、わたしが守ります。<%br>だから……大丈夫です。",
 		"tr_text": "",
 		"fileID": 4
@@ -15890,7 +15890,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……まま、どうしたの？<%br>かなしーの？　どこかいたい？",
 		"tr_text": "",
 		"fileID": 4
@@ -15898,7 +15898,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……だい、じょうぶです。",
 		"tr_text": "",
 		"fileID": 4
@@ -15906,7 +15906,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ジェネ……言いたくはないことだけど……<%br>でも……これからの戦いで、私たちは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15914,7 +15914,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "きっと、アネットさんが言っている……<%br>その通りだと……思います。",
 		"tr_text": "",
 		"fileID": 4
@@ -15922,7 +15922,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "悪い人がいないとか……そんなこと<%br>もう、思ったりは……していません。",
 		"tr_text": "",
 		"fileID": 4
@@ -15930,7 +15930,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたしももう、一人前のアークスです。<%br>だから……大丈夫です。",
 		"tr_text": "",
 		"fileID": 4
@@ -15938,7 +15938,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ただ……<%br>それでも、わたしは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15946,7 +15946,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "利用されたり、誰かを傷つけるために生まれた……<%br>それだけじゃ、やっぱり悲しいです。",
 		"tr_text": "",
 		"fileID": 4
@@ -15954,7 +15954,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "利用されたり、誰かを傷つけるために生まれた……<%br>それだけじゃ、やっぱり悲しいです。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -15970,7 +15970,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どう……どうって、それは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15978,7 +15978,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま、りだ？<%br>むずかしーおはなしね。でゅなわかんないよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15986,7 +15986,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そうだよね……むずかしいこと<%br>わかんないよね……ただね……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15994,7 +15994,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "え……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16002,7 +16002,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……どう生まれてきたとしても……それだけで<%br>幸せか不幸かなんて、決まらないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16010,7 +16010,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット……さん……<%br>そう……ですよね。",
 		"tr_text": "",
 		"fileID": 4
@@ -16018,7 +16018,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナ、わたしは……<%br>デュナと会えてよかったです。",
 		"tr_text": "",
 		"fileID": 4
@@ -16026,7 +16026,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "会えて……よかったです。",
 		"tr_text": "",
 		"fileID": 4
@@ -16034,7 +16034,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……まま。<%br>でゅな、ままに、ずっとあいたかったの。",
 		"tr_text": "",
 		"fileID": 4
@@ -16042,7 +16042,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "えへへ～。",
 		"tr_text": "",
 		"fileID": 4
@@ -16050,7 +16050,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん、捕食者の場所が捕捉できました。<%br>急いでください！",
 		"tr_text": "",
 		"fileID": 4
@@ -16058,7 +16058,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……はい！<%br>リーダー、みなさん、行きましょう！",
 		"tr_text": "",
 		"fileID": 4
@@ -16066,7 +16066,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "いきましょー！",
 		"tr_text": "",
 		"fileID": 4
@@ -16074,7 +16074,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はぁ……はぁ……<%br>これは……",
 		"tr_text": "",
 		"fileID": 4
@@ -16082,7 +16082,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ひどいな……ここら一帯のリリーパ族……<%br>もしかして……全部……",
 		"tr_text": "",
 		"fileID": 4
@@ -16090,7 +16090,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16098,7 +16098,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま、だいじょーぶ？<%br>どーしたの、かなしいの？　おこってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -16106,7 +16106,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。<%br>うん……悲しいし、怒ってます。",
 		"tr_text": "",
 		"fileID": 4
@@ -16114,7 +16114,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "リリーパ族さんのことを想うと悲しいし……<%br>止められなかった自分に……怒ってます。",
 		"tr_text": "",
 		"fileID": 4
@@ -16122,7 +16122,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -16130,7 +16130,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "なぁ、アネット。あのさ、デュナがその……<%br>アナティスの能力解除のために……えっと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16138,7 +16138,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "だからさ、それってふたりとも<%br>同じところで生まれたんだよな？",
 		"tr_text": "",
 		"fileID": 4
@@ -16146,7 +16146,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ええ。……それも、アナティスのあとに<%br>デュナが生まれたんだと、私は考えてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -16154,7 +16154,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "だったらさ、ダンテとか、フェルとかレヴィ<%br>みたいな……えっと……だからさ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16162,7 +16162,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "仲間とか、兄弟みたいな、そんな感じだろ？<%br>なのに、ヘイドはなんで……デュナのこと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16170,7 +16170,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……そうね。でも<%br>それも目的の邪魔になるなら話は別。",
 		"tr_text": "",
 		"fileID": 4
@@ -16178,7 +16178,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドにとって、デュナが邪魔な理由……<%br>アナティスの能力を相殺するから、だと思うわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16186,7 +16186,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……へいど……<%br>あなてぅ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16194,7 +16194,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "敵の名前だってば！<%br>覚えておいた方が、いいぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16202,7 +16202,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "はいっ！<%br>おぼえるよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16210,7 +16210,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "それってさ、えっと……ヘイドはアナティスの<%br>能力を利用、しよーとしてんのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -16218,7 +16218,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "私は……そうね……<%br>そうだと、思っているわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16226,7 +16226,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "わたしには……<%br>そうは見えませんでした。",
 		"tr_text": "",
 		"fileID": 4
@@ -16234,7 +16234,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あの時だって……ヘイドはわたし達との戦いの後<%br>あわててアナティスの元へ向かいました。",
 		"tr_text": "",
 		"fileID": 4
@@ -16242,7 +16242,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたしには、あのヘイドの様子は……<%br>心配して、助けに行ったように見えました。",
 		"tr_text": "",
 		"fileID": 4
@@ -16250,7 +16250,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "助けに……<%br>確かに……あの時……",
 		"tr_text": "",
 		"fileID": 4
@@ -16258,7 +16258,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "カラミティが洗脳されて、ブルーノが負傷した。<%br>そして……最悪なことに、そこにヘイドが現れた。",
 		"tr_text": "",
 		"fileID": 4
@@ -16266,7 +16266,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16282,7 +16282,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16290,7 +16290,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……腹の子を、危険に晒すな。",
 		"tr_text": "",
 		"fileID": 4
@@ -16298,7 +16298,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……アナティスは……身ごもってる。<%br>なんで私、こんな大事なこと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16306,7 +16306,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "子供……ヘイドは、アナティスを<%br>やっぱり守ろうと……している。",
 		"tr_text": "",
 		"fileID": 4
@@ -16314,7 +16314,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……デュナが、もしアイツらの仲間でもさ<%br>優先順位があるんだろ……ヘイドにも。",
 		"tr_text": "",
 		"fileID": 4
@@ -16322,7 +16322,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "みんな、そうだろ。仲間だって口で言っても<%br>自分にとって、大事なヤツの順位はある。",
 		"tr_text": "",
 		"fileID": 4
@@ -16330,7 +16330,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "誰かひとりのために、その他がどうなっても<%br>いいってヤツだって、いるんだよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16338,7 +16338,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……あら、随分大人びたことを言うのね。",
 		"tr_text": "",
 		"fileID": 4
@@ -16346,7 +16346,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ふん、ガキ扱いすんな。<%br>オレは、モアとはちげーんだよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16354,7 +16354,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "なっ！　なんだってー！",
 		"tr_text": "",
 		"fileID": 4
@@ -16362,7 +16362,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……！！<%br>デュナ……危ないっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16370,7 +16370,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わぁっ……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16378,7 +16378,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "お前らを……<%br>このままにはしておけない……",
 		"tr_text": "",
 		"fileID": 4
@@ -16386,7 +16386,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "デュナ……お前は邪魔だ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16394,7 +16394,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ひぅ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16402,7 +16402,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "コロ、コロス……アークスハ<%br>宇宙ニ害ヲナス……",
 		"tr_text": "",
 		"fileID": 4
@@ -16410,7 +16410,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラミティ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16418,7 +16418,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "デュナ、お前……洗脳を解いてやれるんだろ？<%br>カラミティを助けてやってくれよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16426,7 +16426,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ふゅ？<%br>えっと……えっとぉ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16434,7 +16434,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "おい、シュトラ……<%br>そんな急にデュナに言ったって……",
 		"tr_text": "",
 		"fileID": 4
@@ -16442,7 +16442,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16450,7 +16450,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そいつの能力に気づいたか……<%br>やはり邪魔だな、デュナ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16458,7 +16458,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "死んでもらおう<%br>オレとアナティスの約束のために……",
 		"tr_text": "",
 		"fileID": 4
@@ -16466,7 +16466,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16474,7 +16474,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "く……うっ……アークス、アークスッ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16482,7 +16482,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "まだ……まだ足りないか。<%br>お前らを殺すには、オレはまだ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16490,7 +16490,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "アーク……ヘイド……サマ……<%br>アークス……コロ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16498,7 +16498,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -16506,7 +16506,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "なぁ……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16514,7 +16514,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "しゅとら？",
 		"tr_text": "",
 		"fileID": 4
@@ -16522,7 +16522,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "頼むよ……お前なら、カラミティの洗脳<%br>解けるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16530,7 +16530,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ、落ち着きなさい。今は、それよりも<%br>ヘイドとカラミティを捕獲することを……",
 		"tr_text": "",
 		"fileID": 4
@@ -16538,7 +16538,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットは、頭のいい研究者なんだよな？<%br>アンタの言ってたこと、当たってるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16546,7 +16546,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "だったら……！<%br>デュナなら、カラミティを助けられるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16554,7 +16554,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……でゅな……わか……わかんない。",
 		"tr_text": "",
 		"fileID": 4
@@ -16562,7 +16562,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そうか、まだ……<%br>まだ力の使い方を覚えていない……か。",
 		"tr_text": "",
 		"fileID": 4
@@ -16570,7 +16570,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "覚える前に……お前は殺さないとならない……<%br>だが……それにはアークス。",
 		"tr_text": "",
 		"fileID": 4
@@ -16578,7 +16578,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前らを殺す力が……オレには足りない。",
 		"tr_text": "",
 		"fileID": 4
@@ -16586,7 +16586,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16610,7 +16610,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……くそ！　くそ……力があっても<%br>使えないんじゃ……意味なんて、ねーじゃん。",
 		"tr_text": "",
 		"fileID": 4
@@ -16618,7 +16618,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……ごめんね。<%br>ごめんね、しゅとら……",
 		"tr_text": "",
 		"fileID": 4
@@ -16626,7 +16626,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "りだ……<%br>まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -16634,7 +16634,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あのね、でゅなは<%br>しゅとらのおねがい、できなかった……",
 		"tr_text": "",
 		"fileID": 4
@@ -16642,7 +16642,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16650,7 +16650,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "からみて……からみて……<%br>たすけるの、でゅな、できなかった……",
 		"tr_text": "",
 		"fileID": 4
@@ -16658,7 +16658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ、大丈夫です。<%br>みんなで、カラミティさんを助けましょう？",
 		"tr_text": "",
 		"fileID": 4
@@ -16666,7 +16666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "みんな？",
 		"tr_text": "",
 		"fileID": 4
@@ -16674,7 +16674,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はい……<%br>みんなで、カラミティさんを助けましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -16682,7 +16682,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナと、わたしと……<%br>リーダーと、アネットさん……",
 		"tr_text": "",
 		"fileID": 4
@@ -16690,7 +16690,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさんに……モアも一緒に。",
 		"tr_text": "",
 		"fileID": 4
@@ -16698,7 +16698,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それで、ブルーノさんにカラミティさんを<%br>助けたよって、報告するんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -16706,7 +16706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "しゅとら、ぶーの、よろこぶ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16714,7 +16714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "もちろんです。<%br>だから、大丈夫ですよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16722,7 +16722,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナは、たくさん頑張ってるんですから<%br>……そうだ、何かご褒美とか……えーっと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16730,7 +16730,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま、ねえ、まま！<%br>おうたうたって……こもりうた？",
 		"tr_text": "",
 		"fileID": 4
@@ -16738,7 +16738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "こもり……歌……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16746,7 +16746,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "いつもね、でゅなね<%br>ままのおなかのなかでね、きいてたの。",
 		"tr_text": "",
 		"fileID": 4
@@ -16754,7 +16754,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "いつもね、でゅなね<%br>ままのおなかのなかでね、きいてたの。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -16770,7 +16770,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "んっとぉねー……<%br>る～るる～……♪",
 		"tr_text": "",
 		"fileID": 4
@@ -16778,7 +16778,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "る～る～ん？<%br>うん……？　うまく、うたえない。",
 		"tr_text": "",
 		"fileID": 4
@@ -16786,7 +16786,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "え？　え……えっとぉ……<%br>げんきに、おーきく、なーあーれー？",
 		"tr_text": "",
 		"fileID": 4
@@ -16794,7 +16794,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……まま、ちがうよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16802,7 +16802,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "いいわね……ほのぼのタイム。<%br>お邪魔しても、いいかしら？",
 		"tr_text": "",
 		"fileID": 4
@@ -16810,7 +16810,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……<%br>あの……シュトラさんは？",
 		"tr_text": "",
 		"fileID": 4
@@ -16818,7 +16818,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……少し落ち込んでいるみたいだけど<%br>本人だって、状況は理解してるわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16826,7 +16826,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "それより、また惑星アムドゥスキアで<%br>捕食者の生体反応が確認できたそうよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16834,7 +16834,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アムドゥスキア……また、龍族を……<%br>ヘイドは……",
 		"tr_text": "",
 		"fileID": 4
@@ -16842,7 +16842,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "モアとシュトラも待ってるわ。<%br>行きましょう、アムドゥスキアに……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16850,7 +16850,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "周辺エネミーの撃破、お疲れ様です。捕食者の<%br>反応はエリアの奥地で確認できています。",
 		"tr_text": "",
 		"fileID": 4
@@ -16858,7 +16858,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "はぁ……はぁ……急がないと、ですね。<%br>それにしても、龍族の姿が、見えないです……",
 		"tr_text": "",
 		"fileID": 4
@@ -16866,7 +16866,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ここら一帯の龍族……<%br>全部ヘイドが、食いつくしたんじゃねーの……",
 		"tr_text": "",
 		"fileID": 4
@@ -16874,7 +16874,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ヘイドのあの様子だと、焦っているのよ。<%br>だから、龍族を捕食して能力強化を急いでる。",
 		"tr_text": "",
 		"fileID": 4
@@ -16882,7 +16882,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "焦ってる……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16890,7 +16890,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナが、アナティスの洗脳解除できるって<%br>私たちが気づいた。それに危機感を覚えた……",
 		"tr_text": "",
 		"fileID": 4
@@ -16898,7 +16898,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アナティスの能力に、デュナが対抗できるから<%br>ヘイドはデュナを、狙ったんでしょうか……",
 		"tr_text": "",
 		"fileID": 4
@@ -16906,7 +16906,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "キィィィイイイイーーーー！！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16922,7 +16922,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（まだだ……まだ、足りない。まだ力が……<%br>　もっと、食わねば……）",
 		"tr_text": "",
 		"fileID": 4
@@ -16930,7 +16930,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（アナティス……お前を……）",
 		"tr_text": "",
 		"fileID": 4
@@ -16938,7 +16938,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "惑星ウォパルでのブルーノら襲撃後",
 		"tr_text": "",
 		"fileID": 4
@@ -16954,7 +16954,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "どうして、ひとりで出た……？<%br>ここから出るな……アークスは強い、危険だ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16962,7 +16962,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前だけが戦うのが、嫌なんだ。<%br>アークスが強いなら、なおさら……",
 		"tr_text": "",
 		"fileID": 4
@@ -16970,7 +16970,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "私は、ここにいた奴らではない。<%br>お前を利用することはしたくないんだ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16978,7 +16978,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16994,7 +16994,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……どうしてだ。<%br>どうして、そんな言葉を……言う？",
 		"tr_text": "",
 		"fileID": 4
@@ -17002,7 +17002,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 4
@@ -17010,7 +17010,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……好きにしろ。<%br>ただ、無理はするな……",
 		"tr_text": "",
 		"fileID": 4
@@ -17018,7 +17018,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "らーらーらぁー♪<%br>むー？　……ちがうなぁ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -17026,7 +17026,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "何してんだ、デュナ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17034,7 +17034,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "おうたーうたったの。あのね、あんまりね<%br>おぼえてないの。でゅなも、ままも……",
 		"tr_text": "",
 		"fileID": 4
@@ -17042,7 +17042,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あは……はは、忘れちゃって……",
 		"tr_text": "",
 		"fileID": 4
@@ -17050,7 +17050,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……子守歌。<%br>お腹には子供……解除する能力……",
 		"tr_text": "",
 		"fileID": 4
@@ -17058,7 +17058,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダー……デュナの母親は……<%br>ヘイド側にいると思う？",
 		"tr_text": "",
 		"fileID": 4
@@ -17066,7 +17066,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダー……デュナの母親は……<%br>ヘイド側にいると思う？",
 		"tr_text": "",
 		"jp_buttons": [
@@ -17082,7 +17082,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "私も、同じ意見。<%br>でも……ヘイドはデュナを殺そうとしてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -17090,7 +17090,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "この任務……間違えたら私たちは……<%br>デュナの肉親と戦うことになるわね。",
 		"tr_text": "",
 		"fileID": 4
@@ -17098,7 +17098,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダー……<%br>そうね……私も、そう思いたい。",
 		"tr_text": "",
 		"fileID": 4
@@ -17106,7 +17106,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "だってそうじゃなきゃ……私たちは……<%br>デュナの肉親と戦うことに、なってしまうもの。",
 		"tr_text": "",
 		"fileID": 4
@@ -17114,7 +17114,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そんなの……悲しすぎる。",
 		"tr_text": "",
 		"fileID": 4
@@ -17122,7 +17122,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あ、あのさ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17130,7 +17130,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "りだー！　あねっと！",
 		"tr_text": "",
 		"fileID": 4
@@ -17138,7 +17138,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "うわー、もう！<%br>先ひとりで走ったら危ないってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -17146,7 +17146,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "みなさん、捕食者の生体反応が<%br>近くで確認できました。急いでください！",
 		"tr_text": "",
 		"fileID": 4
@@ -17154,7 +17154,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "……急ごうぜ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17162,7 +17162,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……これ……これを……<%br>全部お前が食ったのか……ヘイド！",
 		"tr_text": "",
 		"fileID": 4
@@ -17170,7 +17170,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……お前たちか。",
 		"tr_text": "",
 		"fileID": 4
@@ -17178,7 +17178,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "カラミティは……アイツはどこだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17186,7 +17186,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……く……はっ……は……はぁ……<%br>まだ……腹には入れてない……",
 		"tr_text": "",
 		"fileID": 4
@@ -17194,7 +17194,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "なんだか……様子がおかしいです。<%br>どうしたんでしょう……",
 		"tr_text": "",
 		"fileID": 4
@@ -17202,7 +17202,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ま、まま……こわい。",
 		"tr_text": "",
 		"fileID": 4
@@ -17210,7 +17210,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……ヘイド、貴方やアナティスを生み出し<%br>利用しようとした組織は……人間は、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -17218,7 +17218,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "一体誰なの？<%br>貴方は、誰の命令でこんなことをして……",
 		"tr_text": "",
 		"fileID": 4
@@ -17226,7 +17226,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ふ……ふははは。",
 		"tr_text": "",
 		"fileID": 4
@@ -17234,7 +17234,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "また、それか。<%br>お前たちは、どうしても理由を作りたがるな。",
 		"tr_text": "",
 		"fileID": 4
@@ -17242,7 +17242,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "理由……そうね。貴方の行動や発言が<%br>私の中で結びつかないのよ、ごめんなさいね。",
 		"tr_text": "",
 		"fileID": 4
@@ -17250,7 +17250,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "命令などない。俺を生み出した人間は……<%br>とっくに殺した。",
 		"tr_text": "",
 		"fileID": 4
@@ -17258,7 +17258,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "俺が、最初に捕食した人間だ。<%br>なんの力にもならない、無駄な捕食だった。",
 		"tr_text": "",
 		"fileID": 4
@@ -17266,7 +17266,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17274,7 +17274,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "命令なんてものはない……<%br>俺はただ……約束を……守るだけだ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17282,7 +17282,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17298,7 +17298,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "グゥウオオオオオーー！！",
 		"tr_text": "",
 		"fileID": 4
@@ -17306,7 +17306,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ぐっ……はぁっ！<%br>う……はぁ、はぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -17314,7 +17314,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "くっ……！<%br>はぁ……はぁ……ヘイド……",
 		"tr_text": "",
 		"fileID": 4
@@ -17322,7 +17322,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "くっ……！<%br>はぁ……はぁ……ヘイド……",
 		"tr_text": "",
 		"jp_buttons": [
@@ -17338,7 +17338,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "はい……大丈夫です、リーダー……",
 		"tr_text": "",
 		"fileID": 4
@@ -17346,7 +17346,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドを、ここで仕留めましょう。<%br>彼になんの理由があっても、危険よ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17354,7 +17354,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん、まってください……",
 		"tr_text": "",
 		"fileID": 4
@@ -17362,7 +17362,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……リーダー……ヘイドを、捕まえましょう。<%br>彼をそのまま殺したら、何もわからないです。",
 		"tr_text": "",
 		"fileID": 4
@@ -17370,7 +17370,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうして、ヘイドやアナティスが生まれたのか<%br>それに、デュナだって……",
 		"tr_text": "",
 		"fileID": 4
@@ -17378,7 +17378,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "わたしは……ヘイド、あなたが<%br>そこまでアークスを憎むなら……",
 		"tr_text": "",
 		"fileID": 4
@@ -17386,7 +17386,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "知りたいです……<%br>どうして、そんなに憎むの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17394,7 +17394,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……オンナ。<%br>お前は、知ってどうするんだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17402,7 +17402,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "今さら何ができる？<%br>俺は……俺たちは……地獄を見た。",
 		"tr_text": "",
 		"fileID": 4
@@ -17410,7 +17410,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……地獄。",
 		"tr_text": "",
 		"fileID": 4
@@ -17418,7 +17418,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "お前らは、なんの犠牲もなく<%br>俺や、アナティスが生まれたと思うのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17426,7 +17426,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "この世界に存在しないはずのものを<%br>生み出すことの傲慢さと……愚かさをっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17434,7 +17434,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "犠牲……<%br>……ヘイド、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -17442,7 +17442,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "いくら貴方が、被害者だとしても……<%br>私は貴方をここで捕まえる。",
 		"tr_text": "",
 		"fileID": 4
@@ -17450,7 +17450,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "私は、私の大事な人を守らないといけない……<%br>リーダー……終わらせましょう！",
 		"tr_text": "",
 		"fileID": 4
@@ -17458,7 +17458,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -17466,7 +17466,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17482,7 +17482,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "『ヘイド、死ぬな。<%br>　もし死なれたら、私はここにひとりだ。』",
 		"tr_text": "",
 		"fileID": 4
@@ -17490,7 +17490,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "大事な人……か。",
 		"tr_text": "",
 		"fileID": 4
@@ -17498,7 +17498,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "あ、アネットさん……！<%br>リーダー……ダメです！",
 		"tr_text": "",
 		"fileID": 4
@@ -17506,7 +17506,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……待って！<%br>わたしは……あなたと話したい……",
 		"tr_text": "",
 		"fileID": 4
@@ -17514,7 +17514,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……俺は死ねない。",
 		"tr_text": "",
 		"fileID": 4
@@ -17522,7 +17522,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17538,7 +17538,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -17546,7 +17546,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……目が覚めたか？<%br>よかった……もう少し眠るんだ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17554,7 +17554,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……よく帰ってきてくれた。<%br>こんなに傷を負って……それでも……",
 		"tr_text": "",
 		"fileID": 4
@@ -17562,7 +17562,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "私を……ひとりにしないでくれて……<%br>ありがとう、ヘイド。",
 		"tr_text": "",
 		"fileID": 4
@@ -17570,7 +17570,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "……アナ……ティス……",
 		"tr_text": "",
 		"fileID": 4
@@ -17578,7 +17578,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前はここで休んでいろ。<%br>私が行ってくる……",
 		"tr_text": "",
 		"fileID": 4
@@ -17586,7 +17586,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "ふ……<%br>どうしてだ。どうして、同じことを言う……",
 		"tr_text": "",
 		"fileID": 4
@@ -17594,7 +17594,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "俺をひとりにしたのは、お前じゃないか……<%br>アナティス……",
 		"tr_text": "",
 		"fileID": 4
@@ -17602,7 +17602,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……わたしです。<%br>貴方が話していた、例の件ですが……",
 		"tr_text": "",
 		"fileID": 4
@@ -17610,7 +17610,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……会って、話をしていただけましたか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17618,7 +17618,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "はい……<%br>本人に会い、確認しました。",
 		"tr_text": "",
 		"fileID": 4
@@ -17626,7 +17626,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "信じても、いいと……<%br>そう、思えました。それでは……",
 		"tr_text": "",
 		"fileID": 4
@@ -17634,7 +17634,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ずいぶん……簡単に信じてくれるんだな。<%br>市街地で暴れまわった、トランスエネミーだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17642,7 +17642,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "……別に、簡単に信じたわけではありません。",
 		"tr_text": "",
 		"fileID": 4
@@ -17650,7 +17650,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "わたしが信じる人が、貴方を信じた。<%br>それが理由です。",
 		"tr_text": "",
 		"fileID": 4
@@ -17658,7 +17658,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "それと……部下の命を救ってくださって<%br>ありがとうございました。",
 		"tr_text": "",
 		"fileID": 4
@@ -17666,7 +17666,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……べ、べつに……交換条件だ。<%br>レヴィを……助けてくれるなら……",
 		"tr_text": "",
 		"fileID": 4
@@ -17674,7 +17674,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "……アークスの持つ医療技術と<%br>アネットのフォトンと人体に関する知見があれば……",
 		"tr_text": "",
 		"fileID": 4
@@ -17682,7 +17682,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "貴方の仲間を救うことも、できます。<%br>安心してください。",
 		"tr_text": "",
 		"fileID": 4
@@ -17690,7 +17690,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ああ……",
 		"tr_text": "",
 		"fileID": 4
@@ -17698,7 +17698,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "『……アンタタチヲ助ケテヤル。<%br>　ソノ代ワリ……交換条件ダ』",
 		"tr_text": "",
 		"fileID": 4
@@ -17706,7 +17706,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "貴方……フェル！？<%br>……どうして……まさか、助けてくれるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17714,7 +17714,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "『……レヴィヲ……助ケラレルカ？』",
 		"tr_text": "",
 		"fileID": 4
@@ -17722,7 +17722,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17730,7 +17730,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ、もちろんよ。<%br>私が、貴方の大事な人を助ける。",
 		"tr_text": "",
 		"fileID": 4
@@ -17738,7 +17738,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "だから……お願い。<%br>助けて……私の仲間を……",
 		"tr_text": "",
 		"fileID": 4
@@ -17746,7 +17746,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "フェル",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "『……アリガトウ』",
 		"tr_text": "",
 		"fileID": 4
@@ -17754,7 +17754,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Fel",
 		"jp_text": "みなさん、惑星ウォパルの「海底エリア」で<%br>再び、捕食者の生体反応が確認できました。",
 		"tr_text": "",
 		"fileID": 4
@@ -17762,7 +17762,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "よっしゃ！<%br>みんなで海底エリアにしゅっぱーつ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17770,7 +17770,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "うんっ！<%br>しゅっぱーつ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17778,7 +17778,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あー、あねっとどこいってたの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17786,7 +17786,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ふふ……ブルーノの代わりにね。<%br>彼の上司に、報告をしに行ってたのよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17794,7 +17794,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドのことをね……",
 		"tr_text": "",
 		"fileID": 4
@@ -17802,7 +17802,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイド……",
 		"tr_text": "",
 		"fileID": 4
@@ -17810,7 +17810,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……どうしたの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17818,7 +17818,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "みなさん……この任務を達成した先に<%br>何が待っているんでしょうか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17826,7 +17826,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "物語の中だと……ひとりの悪い人を<%br>倒したら、平和になって幸せになります。",
 		"tr_text": "",
 		"fileID": 4
@@ -17834,7 +17834,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドやアナティスと戦って……勝ったとして<%br>それで……平和になるんでしょうか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17842,7 +17842,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ジェネ……貴方、ヘイドが言ってたこと<%br>気にしているのね。",
 		"tr_text": "",
 		"fileID": 4
@@ -17850,7 +17850,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17866,7 +17866,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "この世界に存在しないはずのものを<%br>生み出すことの傲慢さと……愚かさをっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17874,7 +17874,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……わからないんです。ヘイドを倒せば<%br>彼がいなくなれば、平和になるのか……",
 		"tr_text": "",
 		"fileID": 4
@@ -17882,7 +17882,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "彼らに殺意を植え付けた……それが<%br>一番本当の敵なんじゃ……ないでしょうか……",
 		"tr_text": "",
 		"fileID": 4
@@ -17890,7 +17890,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もし……そうなら……そんなヘイドとの戦いに<%br>わたしは……誰も巻き込みたくないです。",
 		"tr_text": "",
 		"fileID": 4
@@ -17898,7 +17898,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "もし……そうなら……そんなヘイドとの戦いに<%br>わたしは……誰も巻き込みたくないです。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -17914,7 +17914,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……っ。<%br>わたしは……",
 		"tr_text": "",
 		"fileID": 4
@@ -17922,7 +17922,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……うぬぼれすぎよ、ジェネ。<%br>そもそも貴方ひとりで、勝てると思ってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17930,7 +17930,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "それは……そう、ですけど。ただ……みんなに<%br>悲しい気持ちになって欲しくないんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -17938,7 +17938,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……でゅなも、ままに……<%br>かなしい、なってほしくない。",
 		"tr_text": "",
 		"fileID": 4
@@ -17946,7 +17946,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 4
@@ -17954,7 +17954,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "そうね。貴方のいうように、誰かを倒して<%br>平和が訪れるなんて単純なものじゃないと思う。",
 		"tr_text": "",
 		"fileID": 4
@@ -17962,7 +17962,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "でも……戦いが終わって平和がこなかったら<%br>私たちは、貴方のいう「本当の敵」と戦うだけ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17970,7 +17970,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "違うかしら？",
 		"tr_text": "",
 		"fileID": 4
@@ -17978,7 +17978,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……でゅなも、いっしょたたかう！<%br>みんなで、でしょっ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17986,7 +17986,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……",
 		"tr_text": "",
 		"fileID": 4
@@ -17994,7 +17994,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……でゅなね、つぎはね。<%br>しゅとらのおねがい、する……の。",
 		"tr_text": "",
 		"fileID": 4
@@ -18002,7 +18002,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "オレの……お願い？",
 		"tr_text": "",
 		"fileID": 4
@@ -18010,7 +18010,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18026,7 +18026,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "からみて……からみて……<%br>たすけるの、でゅな、できなかった……",
 		"tr_text": "",
 		"fileID": 4
@@ -18034,7 +18034,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナは、カラミティさんの<%br>洗脳を解除したいって、思ってるんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -18042,7 +18042,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それが、シュトラさんのお願いだから……",
 		"tr_text": "",
 		"fileID": 4
@@ -18050,7 +18050,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……！<%br>……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18058,7 +18058,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……えへへ。<%br>でゅなもね、からみて、たすけたいの！",
 		"tr_text": "",
 		"fileID": 4
@@ -18066,7 +18066,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そう……ですね。<%br>みんなで、一緒に……戦いましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -18074,7 +18074,7 @@
 	{
 		"eventNo": "39",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うんっ！<%br>……みんなで、うぉぱるいくよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18082,7 +18082,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ほぉ～……",
 		"tr_text": "",
 		"fileID": 4
@@ -18090,7 +18090,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はぁ～……",
 		"tr_text": "",
 		"fileID": 4
@@ -18098,7 +18098,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "どうしたんだよ、デュナ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18106,7 +18106,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なんかね、ここいいところだね。<%br>でゅな、すき。",
 		"tr_text": "",
 		"fileID": 4
@@ -18114,7 +18114,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "そっかぁ？　オレは海岸エリアの方が<%br>海だぜっ！　って感じで好きだぞ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18122,7 +18122,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ここは、確かに不思議なところですよね。<%br>ふふ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18130,7 +18130,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ねぇねぇ、もあ。<%br>ままちょっとだけ、げんきなったかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -18138,7 +18138,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ジェネか？<%br>そうだな……悩んで落ち込んでたもんな。",
 		"tr_text": "",
 		"fileID": 4
@@ -18146,7 +18146,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ねぇねぇ、もあ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18154,7 +18154,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "うん？　どうしたんだよ、デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18162,7 +18162,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あのね、しゅとらはどうしたら<%br>げんき……なるかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -18170,7 +18170,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "からみて、たすけたら、げんきなるかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -18178,7 +18178,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18186,7 +18186,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……べ、別にオレは……その……アイツが<%br>戻ってきたからって、うれしくなんかねーよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18194,7 +18194,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "うれしくないの？<%br>でゅなはままといると、うれしいよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18202,7 +18202,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "オレは……うれしいとかじゃなくって<%br>ただ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18210,7 +18210,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18218,7 +18218,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18226,7 +18226,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "（ただ……アイツに悪いなって……<%br>　そう思ってるだけだ）",
 		"tr_text": "",
 		"fileID": 4
@@ -18234,7 +18234,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "みなさん、周辺エネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 4
@@ -18242,7 +18242,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "ふぅー！<%br>このくらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -18250,7 +18250,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "もあ、すごいねー！",
 		"tr_text": "",
 		"fileID": 4
@@ -18258,7 +18258,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "へへへーん！<%br>だろー？　",
 		"tr_text": "",
 		"fileID": 4
@@ -18266,7 +18266,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18274,7 +18274,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ん？　シュトラ、どうしたんだ？<%br>むすーっとしてると、変な顔になるぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18282,7 +18282,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なるよー？",
 		"tr_text": "",
 		"fileID": 4
@@ -18290,7 +18290,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……変な顔って……考え事してたんだよ。<%br>アネット、アンタに聞きたいんだけど……",
 		"tr_text": "",
 		"fileID": 4
@@ -18298,7 +18298,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アナティスの洗脳の能力……<%br>アークスに効くと思うか？",
 		"tr_text": "",
 		"fileID": 4
@@ -18306,7 +18306,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……いい質問ね。<%br>その解答は、「おそらく効かない」。",
 		"tr_text": "",
 		"fileID": 4
@@ -18314,7 +18314,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "これは研究者視点の話と<%br>今までの事象を並べた結果、仮定できる話。",
 		"tr_text": "",
 		"fileID": 4
@@ -18322,7 +18322,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ねえ、ねえ、もあ。<%br>あねっと、なにいってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -18330,7 +18330,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……こ、子供にはまだ、早いってば！<%br>お、オレはなんとなく、わかるけどさ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18338,7 +18338,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "アークスを洗脳できれば……単純に<%br>捕食で力を強める必要は、ないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18346,7 +18346,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "確かに……今まで洗脳されたのは<%br>全部ウェポノイド……だもんな。",
 		"tr_text": "",
 		"fileID": 4
@@ -18354,7 +18354,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それに、もともと……",
 		"tr_text": "",
 		"fileID": 4
@@ -18362,7 +18362,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "イノセントブルーによって<%br>ザッカードが生み出したのが<%br>ウェポノイド。<%br>E.M.A.はウェポノイドを<%br>悪用しようとした。",
 		"tr_text": "",
 		"fileID": 4
@@ -18386,7 +18386,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "そう……ですね。<%br>アネットさん……それって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18394,7 +18394,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "えぇ、そのために、E.M.A.は<%br>虚空機関の研究を引き継いだ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18402,7 +18402,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "マギサ・メデューナに洗脳の力なんてない。<%br>でも……おそらくあの力は……",
 		"tr_text": "",
 		"fileID": 4
@@ -18410,7 +18410,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネット、貴方に伝えておくことがあります。<%br>虚空機関の研究についてです。",
 		"tr_text": "",
 		"fileID": 4
@@ -18418,7 +18418,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "虚空機関は、ダークファルスに関する研究も<%br>行っていました。そしてその研究から……",
 		"tr_text": "",
 		"fileID": 4
@@ -18426,7 +18426,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ダークファルス【若人】の能力が<%br>マギサ・メデューナに移植された。",
 		"tr_text": "",
 		"fileID": 4
@@ -18434,7 +18434,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "そして、E.M.A.がその研究を引き継いだことで<%br>トランスエネミー「アナティス」が生まれた。",
 		"tr_text": "",
 		"fileID": 4
@@ -18442,7 +18442,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "クーナ",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "……そう考えています。",
 		"tr_text": "",
 		"fileID": 4
@@ -18450,7 +18450,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Quna",
 		"jp_text": "ダークファルス【若人】の……魅了能力。<%br>その能力が、アナティスに移植されている。",
 		"tr_text": "",
 		"fileID": 4
@@ -18458,7 +18458,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あぷれん……てぃす？",
 		"tr_text": "",
 		"fileID": 4
@@ -18466,7 +18466,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ダークファルスの能力とか……そんなの！<%br>そんなの使えるってヒキョーじゃんか！",
 		"tr_text": "",
 		"fileID": 4
@@ -18474,7 +18474,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ダークファルスはわたし達の……<%br>宇宙の敵ですよね？",
 		"tr_text": "",
 		"fileID": 4
@@ -18482,7 +18482,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "なのに……なんでその能力を……<%br>また悪用しようとするなんて……ひどいです。",
 		"tr_text": "",
 		"fileID": 4
@@ -18490,7 +18490,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "それにさ……なんか、ヘイドとかアナティスが<%br>ちょっとだけ、かわいそうだってば……",
 		"tr_text": "",
 		"fileID": 4
@@ -18498,7 +18498,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 4
@@ -18506,7 +18506,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "オレやカラミティは、そのダークファルスの力で<%br>洗脳されたのか……",
 		"tr_text": "",
 		"fileID": 4
@@ -18514,7 +18514,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "あの場所で、そんな研究してたのかよ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18522,7 +18522,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……あの、場所？",
 		"tr_text": "",
 		"fileID": 4
@@ -18530,7 +18530,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "シュトラ……彼は隠し事をしている。<%br>恐らく……",
 		"tr_text": "",
 		"fileID": 4
@@ -18538,7 +18538,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ねぇ、シュトラ。<%br>貴方に聞きたいことがあるの。",
 		"tr_text": "",
 		"fileID": 4
@@ -18546,7 +18546,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "え……？<%br>なんだよ……聞きたいことって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18554,7 +18554,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ、貴方は<%br>私たちに隠していることがある。違う……？",
 		"tr_text": "",
 		"fileID": 4
@@ -18562,7 +18562,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "アネットさん……<%br>一体、何を言ってるんです？",
 		"tr_text": "",
 		"fileID": 4
@@ -18570,7 +18570,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18578,7 +18578,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "貴方を……追い詰めたいわけじゃないの。<%br>それは、カラミティが望んでいない。",
 		"tr_text": "",
 		"fileID": 4
@@ -18586,7 +18586,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 4
@@ -18594,7 +18594,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アネットさん……何を……",
 		"tr_text": "",
 		"fileID": 4
@@ -18602,7 +18602,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18610,7 +18610,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……話の続きは後にしましょう。<%br>囲まれてるわ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -18618,7 +18618,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18626,7 +18626,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どういうことだよ……カラミティが<%br>その……望んでいないって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18634,7 +18634,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……シュトラ、貴方に聞いてほしい。<%br>カラミティがなんて言っていたか……",
 		"tr_text": "",
 		"fileID": 4
@@ -18642,7 +18642,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18666,7 +18666,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "またねー、ぶーの！",
 		"tr_text": "",
 		"fileID": 4
@@ -18674,7 +18674,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はぁーい。<%br>またねー。デュナちゃん。",
 		"tr_text": "",
 		"fileID": 4
@@ -18682,7 +18682,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18690,7 +18690,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……なんだよ、ふたりしてその目。",
 		"tr_text": "",
 		"fileID": 4
@@ -18698,7 +18698,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それより、さっきリーダーたちに話していたこと<%br>だけど、これから会うトランスエネミーは……",
 		"tr_text": "",
 		"fileID": 4
@@ -18706,7 +18706,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドの空間転移能力とは異なる、特殊能力を<%br>持っている可能性がある……ってことよね。",
 		"tr_text": "",
 		"fileID": 4
@@ -18714,7 +18714,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "なーに？　アネット、怖いわけ？<%br>あらら～、意外だね。",
 		"tr_text": "",
 		"fileID": 4
@@ -18722,7 +18722,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "……逆よ。少しほっとしてるの。未確定な敵に<%br>対峙するのが、私たちでよかった……って。",
 		"tr_text": "",
 		"fileID": 4
@@ -18730,7 +18730,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……あいかわらずの、過保護。",
 		"tr_text": "",
 		"fileID": 4
@@ -18738,7 +18738,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "ただなぁ……嫌だよね……<%br>なんの能力か見当つかないのはなぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18746,7 +18746,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "あら……<%br>怖がってるのはブルーノ、貴方じゃない。",
 		"tr_text": "",
 		"fileID": 4
@@ -18754,7 +18754,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "ははは……俺はね、無駄死にとか<%br>リスク背負うのとか、基本は嫌なのよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18762,7 +18762,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "命を粗末にしない。<%br>それが俺のモットーなの。",
 		"tr_text": "",
 		"fileID": 4
@@ -18770,7 +18770,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "いい心がけね。……カラミティ、貴方は<%br>これから会う、トランスエネミーの能力は何だと思う？",
 		"tr_text": "",
 		"fileID": 4
@@ -18778,7 +18778,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "そうっ！　そのとーり！<%br>敵に対峙するのがボクらでよかった……！",
 		"tr_text": "",
 		"fileID": 4
@@ -18786,7 +18786,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "何故なら、新たなトランスエネミーに<%br>いち早く接触、観察することができるっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18794,7 +18794,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "カラミティ……それはさっきの話よ。今は<%br>能力の考察。貴方……どうしたの、さっきから変よ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18802,7 +18802,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あー……あの……あれだ。<%br>その……恐らくだけど……",
 		"tr_text": "",
 		"fileID": 4
@@ -18810,7 +18810,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ボクは頭はいいが、嘘をついたことも<%br>隠し事をしたこともない。",
 		"tr_text": "",
 		"fileID": 4
@@ -18818,7 +18818,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "その必要が今までなかったからだ……<%br>だから、これ以上は……お手上げだ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18826,7 +18826,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……？",
 		"tr_text": "",
 		"fileID": 4
@@ -18834,7 +18834,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "シュトラ……彼は隠し事をしている。<%br>恐らく……",
 		"tr_text": "",
 		"fileID": 4
@@ -18842,7 +18842,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "ヘイドの指示で君たちアークスに攻撃した時<%br>その時の記憶を……彼は持ってる。",
 		"tr_text": "",
 		"fileID": 4
@@ -18850,7 +18850,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "意識をなくしていたわけじゃない<%br>肉体の指示系統だけが奪われた……",
 		"tr_text": "",
 		"fileID": 4
@@ -18858,7 +18858,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "その可能性がある。<%br>だから……",
 		"tr_text": "",
 		"fileID": 4
@@ -18866,7 +18866,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "「だからシュトラ……彼はあそこまで真剣なんだ。<%br>　事の深刻さを一番理解している」",
 		"tr_text": "",
 		"fileID": 4
@@ -18874,7 +18874,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "「ボクは……そんな彼を傷つけた」",
 		"tr_text": "",
 		"fileID": 4
@@ -18882,7 +18882,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "これが、カラミティの洗脳される前の……<%br>最後の言葉。",
 		"tr_text": "",
 		"fileID": 4
@@ -18890,7 +18890,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18898,7 +18898,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……あの時、彼が何故そう結論付けたのかまで<%br>確認する時間がなかった。",
 		"tr_text": "",
 		"fileID": 4
@@ -18906,7 +18906,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "続きを確認する前に、私たちは<%br>アナティスと対峙してしまった。",
 		"tr_text": "",
 		"fileID": 4
@@ -18914,7 +18914,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "シュトラ……貴方が、ヘイドやアナティスに<%br>洗脳されていたその時の記憶があって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18922,7 +18922,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "もし……黙っていたなら……<%br>アナティスの能力だって貴方は……知っていた。",
 		"tr_text": "",
 		"fileID": 4
@@ -18930,7 +18930,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18938,7 +18938,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "シュトラ……さん……",
 		"tr_text": "",
 		"fileID": 4
@@ -18946,7 +18946,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18962,7 +18962,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アイツは今、自分の意思で体をコントロール<%br>できる状態じゃないんだ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18970,7 +18970,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "お……オレは……オレは……っ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18978,7 +18978,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "お……オレは……オレは……っ。",
 		"tr_text": "",
 		"jp_buttons": [
@@ -18994,7 +18994,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 4
@@ -19002,7 +19002,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "オレ、わかるってば。<%br>怖いよな……自分だけが見たこと……",
 		"tr_text": "",
 		"fileID": 4
@@ -19010,7 +19010,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "自分だけが知ってること……それを<%br>どうしたらいいのか……わかんないよな。",
 		"tr_text": "",
 		"fileID": 4
@@ -19018,7 +19018,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "うん……オレも、カラミティはやっぱ<%br>変だけど優しいやつだって思う。",
 		"tr_text": "",
 		"fileID": 4
@@ -19026,7 +19026,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "きっと……シュトラのことを考えて考えて<%br>あいつ、お前に聞けなかったんだ。",
 		"tr_text": "",
 		"fileID": 4
@@ -19034,7 +19034,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "からみて、しゅとらの<%br>ともだちだもんねー。",
 		"tr_text": "",
 		"fileID": 4
@@ -19042,7 +19042,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……オレ……ごめん……<%br>ごめ……ん……",
 		"tr_text": "",
 		"fileID": 4
@@ -19050,7 +19050,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "……！<%br>こ、この……歌……",
 		"tr_text": "",
 		"fileID": 4
@@ -19058,7 +19058,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "うた？",
 		"tr_text": "",
 		"fileID": 4
@@ -19066,7 +19066,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あれ……このおうた……",
 		"tr_text": "",
 		"fileID": 4
@@ -19074,7 +19074,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -19082,7 +19082,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "いつか　あなたは<%br>大きな夢みつけるの",
 		"tr_text": "",
 		"fileID": 4
@@ -19090,7 +19090,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "アークス……よくもヘイドを……<%br>傷つけたな。",
 		"tr_text": "",
 		"fileID": 4
@@ -19098,7 +19098,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "あなたが……アナティス！",
 		"tr_text": "",
 		"fileID": 4
@@ -19106,7 +19106,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "あ……あ……",
 		"tr_text": "",
 		"fileID": 4
@@ -19114,7 +19114,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……？<%br>大丈夫か……どうしたんだってば……",
 		"tr_text": "",
 		"fileID": 4
@@ -19122,7 +19122,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "いつか……あなたは……<%br>おおきな……ゆめ……みつけるの……",
 		"tr_text": "",
 		"fileID": 4
@@ -19130,7 +19130,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "はやく……あいたい……<%br>かけがえのない……ぬくもり……",
 		"tr_text": "",
 		"fileID": 4
@@ -19138,7 +19138,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "……デュナ。<%br>あなた……その歌……",
 		"tr_text": "",
 		"fileID": 4
@@ -19146,7 +19146,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "うわぁああああああああああ！！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -19154,7 +19154,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "な……なんて声なの……！<%br>みんな、来るわ……構えて……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -19162,7 +19162,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19194,7 +19194,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "お前たちは……ダメだ……<%br>私の子は……渡さない……",
 		"tr_text": "",
 		"fileID": 4
@@ -19202,7 +19202,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "はぁ……はぁ……うっ……うぅ……",
 		"tr_text": "",
 		"fileID": 4
@@ -19210,7 +19210,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ジェネ……しっかりして……！",
 		"tr_text": "",
 		"fileID": 4
@@ -19218,7 +19218,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "大丈夫……です……それより……<%br>デュナが……",
 		"tr_text": "",
 		"fileID": 4
@@ -19226,7 +19226,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "……まま、ま……ふぇ……<%br>まま……まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -19234,7 +19234,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "わ……私は、私の腹の子は……<%br>渡さない……！",
 		"tr_text": "",
 		"fileID": 4
@@ -19242,7 +19242,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19266,7 +19266,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "リーダー！<%br>あいつ、混乱して……おかしいって！",
 		"tr_text": "",
 		"fileID": 4
@@ -19274,7 +19274,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "もう一回攻撃しかけて……そんで捕まえて<%br>カラミティ助けようぜ！",
 		"tr_text": "",
 		"fileID": 4
@@ -19282,7 +19282,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "……だ、ダメだ……あれは……",
 		"tr_text": "",
 		"fileID": 4
@@ -19290,7 +19290,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "アナティス……帰ろう……帰ろう……<%br>今は……何も考えるな……",
 		"tr_text": "",
 		"fileID": 4
@@ -19298,7 +19298,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19314,7 +19314,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "くっそー！　リーダー、ジェネ……！<%br>って……",
 		"tr_text": "",
 		"fileID": 4
@@ -19322,7 +19322,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "デュナ……どうしたんだってば？",
 		"tr_text": "",
 		"fileID": 4
@@ -19330,7 +19330,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "ひぅ……ひゃう……まま……<%br>まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -19338,7 +19338,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "デュナ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -19346,7 +19346,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……そっか……そっか……<%br>お母さん、だったんですね……",
 		"tr_text": "",
 		"fileID": 4
@@ -19354,7 +19354,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……<%br>一緒に、お母さんを助けに行きましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -19362,7 +19362,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……？",
 		"tr_text": "",
 		"fileID": 4
@@ -19370,7 +19370,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "ううん……わたしは、デュナのママ……<%br>お母さんじゃない。",
 		"tr_text": "",
 		"fileID": 4
@@ -19378,7 +19378,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "まま……まま、まま、まま……<%br>ちがうよ、ままが、ままだもん……",
 		"tr_text": "",
 		"fileID": 4
@@ -19386,7 +19386,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "聞いて、デュナ……わたしはあなたに<%br>幸せになってほしいから……",
 		"tr_text": "",
 		"fileID": 4
@@ -19394,7 +19394,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "だから、あなたの本当のお母さんを<%br>助けたいです。",
 		"tr_text": "",
 		"fileID": 4
@@ -19402,7 +19402,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナのお母さんに、何があったのか<%br>どうしてこんなことになったのか、分からない。",
 		"tr_text": "",
 		"fileID": 4
@@ -19410,7 +19410,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "でも……子守歌は、母親が子供に贈る<%br>特別なプレゼントです。",
 		"tr_text": "",
 		"fileID": 4
@@ -19418,7 +19418,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナは、愛されてる。<%br>だから……一緒にお母さんを助けましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -19426,7 +19426,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -19434,7 +19434,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -19442,7 +19442,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "いつか　あなたは<%br>大きな夢みつけるの",
 		"tr_text": "",
 		"fileID": 4
@@ -19450,7 +19450,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "早く　会いたい　<%br>かけがえのない温もり",
 		"tr_text": "",
 		"fileID": 4
@@ -19458,7 +19458,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "いまは母に包まれて<%br>ねむれ　ねむれよ",
 		"tr_text": "",
 		"fileID": 4
@@ -19466,7 +19466,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "アナティス……お前……",
 		"tr_text": "",
 		"fileID": 4
@@ -19474,7 +19474,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "ヘイド……私の子は腹の中だ。<%br>アークスは、私の子を奪おうとする。",
 		"tr_text": "",
 		"fileID": 4
@@ -19482,7 +19482,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "やはり……みな殺さなくてはいけない。<%br>あの子供も……一緒に、殺そう。",
 		"tr_text": "",
 		"fileID": 4
@@ -19490,7 +19490,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "歌の続き",
 		"tr_text": "",
 		"fileID": 4

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -2946,7 +2946,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "若い研究員",
-		"tr_name": "Older Researcher",
+		"tr_name": "Younger researcher",
 		"jp_text": "イノセントブルー？　こんなものを<%br>生み出したのか……まさに化け物ですね。",
 		"tr_text": "",
 		"fileID": 1
@@ -2954,7 +2954,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "老年の研究員",
-		"tr_name": "Younger researcher",
+		"tr_name": "Older Researcher",
 		"jp_text": "第二研究所が挙げた最大の成果だ。<%br>それをあのバカは……",
 		"tr_text": "",
 		"fileID": 1
@@ -4194,7 +4194,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "若い研究員",
-		"tr_name": "",
+		"tr_name": "Younger researcher",
 		"jp_text": "これはアークスの発展！<%br>すなわち、宇宙の全生命体の為なんだ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4210,7 +4210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "老年の研究員",
-		"tr_name": "Younger researcher",
+		"tr_name": "Older Researcher",
 		"jp_text": "……ま、まずい、まずいぞ……なんでだ……<%br>いや、これだけでも……どうにかっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -4218,7 +4218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "Older Researcher",
+		"tr_name": "Hade",
 		"jp_text": "アナティス……ここから出られる。<%br>俺たちはもう、自由だ……",
 		"tr_text": "",
 		"fileID": 2
@@ -4226,7 +4226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4234,7 +4234,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "アナティス……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4242,7 +4242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -4258,7 +4258,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4266,7 +4266,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……あぁ、どうした？",
 		"tr_text": "",
 		"fileID": 2
@@ -4274,7 +4274,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "私も、外へ出たほうがいいだろうか？<%br>お前ひとりに……させるわけには……",
 		"tr_text": "",
 		"fileID": 2
@@ -4282,7 +4282,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……いや、アナティス。<%br>ここにいろ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4298,7 +4298,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "塞がれた世界",
 		"tr_text": "",
 		"fileID": 2
@@ -4330,7 +4330,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "あら、リーダー、ジェネ。<%br>……それにブルーノも、どうしたの？",
 		"tr_text": "",
 		"fileID": 2
@@ -4338,7 +4338,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……アネットさん。<%br>あの……シュトラさんの体は……大丈夫です？",
 		"tr_text": "",
 		"fileID": 2
@@ -4346,7 +4346,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ええ、体調は回復しているわ。ここから先は<%br>チップ研究所に任せることになる。",
 		"tr_text": "",
 		"fileID": 2
@@ -4370,7 +4370,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……はい、命令されたことだけを<%br>ただただ、しようとしているようでした。",
 		"tr_text": "",
 		"fileID": 2
@@ -4386,7 +4386,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "なるほどねぇ……ウェポノイドを悪用する術を<%br>E.M.A.研究所は作ろうとしてた。",
 		"tr_text": "",
 		"fileID": 2
@@ -4402,7 +4402,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "はい。そのはず……でした。<%br>なのに……なのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -4418,7 +4418,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4426,7 +4426,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……寝ちゃったみたいです。",
 		"tr_text": "",
 		"fileID": 2
@@ -4434,7 +4434,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……まだ、幼いものね。子どもはよく寝るものよ。<%br>トランスエネミーの子も、一緒だわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4442,7 +4442,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "にしても……ダンテたちを追ってたはずが<%br>「捕食事件」にデュナちゃん……だもんなぁ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4450,7 +4450,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "Bruno",
+		"tr_name": "More",
 		"jp_text": "どうしたんだよ、ブルーノ？<%br>なんか落ち込んでるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -4458,7 +4458,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "More",
+		"tr_name": "Bruno",
 		"jp_text": "いやぁー、最初に「捕食事件」のことを聞いた時は<%br>ここまで大ごとになるって思ってなかったわけよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4474,7 +4474,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "Bruno",
+		"tr_name": "Seraphy",
 		"jp_text": "ちょ……ちょっとまってください！<%br>まだチームへの正式な紹介が……",
 		"tr_text": "",
 		"fileID": 2
@@ -4482,7 +4482,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "Seraphy",
+		"tr_name": "Bruno",
 		"jp_text": "……ん？<%br>なんだか、部屋の外が騒がしいな。",
 		"tr_text": "",
 		"fileID": 2
@@ -4490,7 +4490,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "アークスはほんとに馬鹿ばっかり！<%br>「捕食事件」にしてもそうだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -4498,7 +4498,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "???",
+		"tr_name": "More",
 		"jp_text": "だ、誰だ、お前ってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -4506,7 +4506,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "か、カラミティさん……せめて私の<%br>紹介を待ってください。",
 		"tr_text": "",
 		"fileID": 2
@@ -4514,7 +4514,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "Seraphy",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！　それは失礼した。<%br>しっかりボクの紹介をしてくれ、頼んだよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4522,7 +4522,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "Calamity",
+		"tr_name": "Seraphy",
 		"jp_text": "以前お伝えした、惑星ウォパルで起きていた<%br>「捕食事件」。その報告者が彼なんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -4530,7 +4530,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "Seraphy",
+		"tr_name": "Calamity",
 		"jp_text": "そうっ！　ボクだっ！<%br>君たちアークスはボクの報告を聞かなかった。",
 		"tr_text": "",
 		"fileID": 2
@@ -4554,7 +4554,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "Calamity",
+		"tr_name": "More",
 		"jp_text": "……おい、やめろってば！<%br>今ちょっとだけ、ブルーノ落ち込んでるんだぞ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4562,7 +4562,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……で？<%br>セラフィさん、まさか彼……",
 		"tr_text": "",
 		"fileID": 2
@@ -4570,7 +4570,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "はい。えっと……今回の任務、カラミティさんにも<%br>参加していただきたいと思っています。",
 		"tr_text": "",
 		"fileID": 2
@@ -4578,7 +4578,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "うえぇぇぇー！",
 		"tr_text": "",
 		"fileID": 2
@@ -4586,7 +4586,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "カラミティさん、よろしくお願いします。<%br>わたし、ジェネっていいます！",
 		"tr_text": "",
 		"fileID": 2
@@ -4594,7 +4594,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4610,7 +4610,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4618,7 +4618,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "ボクはトランスエネミーの存在も<%br>独自の調査で気づいた。優秀だから当然だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4634,7 +4634,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "Calamity",
+		"tr_name": "More",
 		"jp_text": "……なんかさ。<%br>アイツ……変なヤツだってば。",
 		"tr_text": "",
 		"fileID": 2
@@ -4642,7 +4642,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "いいじゃない。本当に単独でトランスエネミーの<%br>存在までたどり着いたなら、賢いことは確か。",
 		"tr_text": "",
 		"fileID": 2
@@ -4666,7 +4666,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！　改めて。<%br>ボクの名前はカラミティ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4682,7 +4682,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "でゅー！<%br>でゅな！",
 		"tr_text": "",
 		"fileID": 2
@@ -4690,7 +4690,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "Duna",
+		"tr_name": "Calamity",
 		"jp_text": "ひいっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -4706,7 +4706,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "ふぇ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4714,7 +4714,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "それでは、カラミティさんの挨拶も済んだので<%br>次の任務について説明させていただきます。",
 		"tr_text": "",
 		"fileID": 2
@@ -4730,7 +4730,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "それって、ヘイド……彼かもしれない<%br>ってことですよね？",
 		"tr_text": "",
 		"fileID": 2
@@ -4738,7 +4738,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "えぇ、ですが……前回確認できた、ヘイドの<%br>生体反応と同一のものとは断定できていません。",
 		"tr_text": "",
 		"fileID": 2
@@ -4746,7 +4746,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "Seraphy",
+		"tr_name": "Calamity",
 		"jp_text": "……うーん、なるほどっ！　興味があります。<%br>さっそく目撃情報が挙がった場所へ……",
 		"tr_text": "",
 		"fileID": 2
@@ -4754,7 +4754,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "いや。カラミティと……アネット。ふたりは俺と<%br>一緒に、ロードたちのアジトに行くぞ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4762,7 +4762,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "……アジト？",
 		"tr_text": "",
 		"fileID": 2
@@ -4770,7 +4770,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "ウェポノイドを生み出す仕組みを作った科学者<%br>ザッカードが作ったアジトだ。……興味ない？",
 		"tr_text": "",
 		"fileID": 2
@@ -4778,7 +4778,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "んんっー！！　<%br>それはもう、ぜひとも行きたい……！",
 		"tr_text": "",
 		"fileID": 2
@@ -4786,7 +4786,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……ちょっと待って。捕食者は追わないの？<%br>今更あのアジトに、何をしに行くっていうの？",
 		"tr_text": "",
 		"fileID": 2
@@ -4794,7 +4794,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "まぁ……！　ここはリーダーにも相談なんだけど<%br>俺としては、二手に分かれて任務を続けたい。",
 		"tr_text": "",
 		"fileID": 2
@@ -4826,7 +4826,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "それって……ブルーノさんが言っていた<%br>「当て」……の人のところに相談に行くんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -4834,7 +4834,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "そう、正解！<%br>奴らのアジトはアークスの通信が使えない。",
 		"tr_text": "",
 		"fileID": 2
@@ -4850,7 +4850,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -4866,7 +4866,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "……どうしたんだよ？<%br>アネット……？",
 		"tr_text": "",
 		"fileID": 2
@@ -4874,7 +4874,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……ブルーノの、言いたいことはわかった。<%br>でも……私は………",
 		"tr_text": "",
 		"fileID": 2
@@ -4914,7 +4914,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……大丈夫です。<%br>リーダーも、モアも……デュナもいます。",
 		"tr_text": "",
 		"fileID": 2
@@ -4922,7 +4922,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……知ってるわよ。<%br>心配なんか……していないわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -4930,7 +4930,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ？？？",
 		"tr_text": "",
 		"fileID": 2
@@ -4938,7 +4938,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "よーし、こっちも終わったらすぐに<%br>合流するからさ。命大事に、無茶しないようにね。",
 		"tr_text": "",
 		"fileID": 2
@@ -4946,7 +4946,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "はい！　リーダー、モア……デュナ<%br>わたし達も捕食者を追いましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -4954,7 +4954,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "おうっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -4962,7 +4962,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -4970,7 +4970,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "それでは、「捕食跡」の報告が入った<%br>惑星リリーパへ向かってください！",
 		"tr_text": "",
 		"fileID": 2
@@ -4978,7 +4978,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "よっしゃあ！<%br>このぐらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -4994,7 +4994,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "はい、ヘイドの生体反応は捕捉できていませんが<%br>目撃情報を元に追跡を開始しましょう。",
 		"tr_text": "",
 		"fileID": 2
@@ -5002,7 +5002,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "……惑星リリーパでの捕食……もしかして<%br>リリーパ族さんも……",
 		"tr_text": "",
 		"fileID": 2
@@ -5010,7 +5010,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "じぇね？<%br>いたいの？　けがー？",
 		"tr_text": "",
 		"fileID": 2
@@ -5018,7 +5018,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。いいえ、大丈夫です。<%br>ただ、少しだけね、悲しいなって思って。",
 		"tr_text": "",
 		"fileID": 2
@@ -5026,7 +5026,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "かなしー？",
 		"tr_text": "",
 		"fileID": 2
@@ -5034,7 +5034,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい。<%br>悲しいは、心がしゅんってなるんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -5042,7 +5042,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "しゅーん……？<%br>かなしい、かなしい？",
 		"tr_text": "",
 		"fileID": 2
@@ -5050,7 +5050,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ジェネ、落ち込んでる場合じゃないってば！<%br>まだ、助けられるかもしれないんだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5058,7 +5058,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……モア。<%br>そうですね。悲しんでる場合じゃないですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5066,7 +5066,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "……でもさ、デュナを連れてきて大丈夫なのか？<%br>ヘイドのヤツと、戦うかもしれないのにさ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5074,7 +5074,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5082,7 +5082,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "そうですね。ただ……アークスシップ内で<%br>デュナちゃんの存在を誤魔化し続けるのも難しく……",
 		"tr_text": "",
 		"fileID": 2
@@ -5098,7 +5098,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "あぁ、そっか。たしかに、ジェネが離れようとしたら<%br>デュナ、すごい泣き出しちゃったもんな……",
 		"tr_text": "",
 		"fileID": 2
@@ -5106,7 +5106,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……デュナを、ちゃんと……守らないと。",
 		"tr_text": "",
 		"fileID": 2
@@ -5146,7 +5146,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "そうだってば！<%br>ジェネにはオレとリーダーがついてんだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5154,7 +5154,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "そうですね。<%br>うふふ……ありがとうございます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5170,7 +5170,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ？<%br>まーもる？",
 		"tr_text": "",
 		"fileID": 2
@@ -5178,7 +5178,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "おうっ！<%br>任せとけってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5186,7 +5186,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……リーダー、あのっ！<%br>えっと……さっきは、ありがとうございます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5210,7 +5210,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "あ……ジェネ！　リーダーだけじゃないってば。<%br>オレたちもいるぞ。な、セラフィさん？",
 		"tr_text": "",
 		"fileID": 2
@@ -5218,7 +5218,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "あ、えっと！　ごめんなさい……<%br>そういう意味じゃなくって……",
 		"tr_text": "",
 		"fileID": 2
@@ -5226,7 +5226,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "もちろんです。私も全力で、みなさんの任務を<%br>サポートさせていただきますね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5234,7 +5234,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はい！　きっとこの捕食の跡の先に……<%br>ヘイドがいるはずです、行きましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5250,7 +5250,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、だーじょぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5258,7 +5258,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……はい、大丈夫です。<%br>わたし、少しだけ疲れやすくって。",
 		"tr_text": "",
 		"fileID": 2
@@ -5266,7 +5266,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ちゅかれる？",
 		"tr_text": "",
 		"fileID": 2
@@ -5274,7 +5274,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……うふふ。つ、か、れ、る。です！<%br>デュナはすぐ言葉を覚える、いい子ですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5282,7 +5282,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "あら、学習能力が高いのね。<%br>いいことじゃない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5290,7 +5290,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん！",
 		"tr_text": "",
 		"fileID": 2
@@ -5298,7 +5298,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "私たちは、これからロードがいた……<%br>あのアジト内部に入るわ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5314,7 +5314,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "アネット、気をつけてなっ！　ブルーノ……<%br>アネットがケガしないようにしろよ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5322,7 +5322,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "More",
+		"tr_name": "Bruno",
 		"jp_text": "はーい、分かってるって……",
 		"tr_text": "",
 		"fileID": 2
@@ -5330,7 +5330,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "アークスの通信が使えないなんて、一体どんな<%br>仕組みで……あぁー、いい、すごくいい！",
 		"tr_text": "",
 		"fileID": 2
@@ -5338,7 +5338,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "……カラミティとも仲良くしてるんで<%br>ご心配なく。ははは……",
 		"tr_text": "",
 		"fileID": 2
@@ -5346,7 +5346,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "そっちも、気を付けるのよ。彼……<%br>ヘイドはまた、ウェポノイドを使うかもしれない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5354,7 +5354,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "ウェポノイド……。シュトラさんのように<%br>ウェポノイドを悪用するかもしれないんですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5362,7 +5362,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……詳しくはシュトラのチップ解析結果を<%br>待つしかないけれど……ヘイドには……",
 		"tr_text": "",
 		"fileID": 2
@@ -5386,7 +5386,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……はい。<%br>アネットさん達も気を付けてくださいね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5394,7 +5394,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "……さ！<%br>話も済んだことだし、行くとするかねぇ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5402,7 +5402,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Bruno",
+		"tr_name": "More",
 		"jp_text": "そういえばセラフィさん、デュナとかさ……<%br>その、ヘイドのことって今、どうなってるんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5418,7 +5418,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "",
-		"tr_name": "More",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -5426,7 +5426,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "なぁ、デュナのことは、どーするんだよ？<%br>アイツ……ヘイドがあんなことしたんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -5442,7 +5442,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……モア。",
 		"tr_text": "",
 		"fileID": 2
@@ -5450,7 +5450,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "モアくん……気にしないでください。私が<%br>協力したいと思って自分で判断したことですから。",
 		"tr_text": "",
 		"fileID": 2
@@ -5466,7 +5466,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "セラフィさん……<%br>ありがとってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5474,7 +5474,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "ヘイドについては、トランスエネミーではなく<%br>ヘイズ・ドラールの異常種として報告してます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5490,7 +5490,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさんは、どうなったんです？<%br>今、チップ研究所なんですよね……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5498,7 +5498,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "「捕食者」追跡任務で巻き込まれた<%br>ウェポノイドとして報告しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -5514,7 +5514,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "ってことは、やっぱりあんまり<%br>隠せることじゃないってことなんだな……",
 		"tr_text": "",
 		"fileID": 2
@@ -5522,7 +5522,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "えぇ、なのでブルーノさんの「当て」が<%br>当てにならなかった場合、困りますね……",
 		"tr_text": "",
 		"fileID": 2
@@ -5530,7 +5530,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "うー！　頼りになんかしたくないけど<%br>ブルーノがどうにかするってば！　きっと！",
 		"tr_text": "",
 		"fileID": 2
@@ -5538,7 +5538,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "はい……！　今は、ブルーノさんを信じて<%br>わたし達は、わたし達の任務を頑張りましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5546,7 +5546,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "おうっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5554,7 +5554,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5562,7 +5562,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "ふふ……！<%br>デュナも、一緒に頑張ろうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -5570,7 +5570,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、前方にグワナーダの反応が<%br>確認できました。気を付けてください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5578,7 +5578,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はい！<%br>行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5586,7 +5586,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、グワナーダ撃破おめでとうございます！",
 		"tr_text": "",
 		"fileID": 2
@@ -5594,7 +5594,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Seraphy",
+		"tr_name": "Duna",
 		"jp_text": "ふゅぅ……うゅ……",
 		"tr_text": "",
 		"fileID": 2
@@ -5602,7 +5602,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>デュナ、大丈夫ですよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -5610,7 +5610,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "もう怖いのはいなくなったからな？",
 		"tr_text": "",
 		"fileID": 2
@@ -5618,7 +5618,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "ひゅう？<%br>いない、ない？",
 		"tr_text": "",
 		"fileID": 2
@@ -5626,7 +5626,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい……よく我慢しましたね。<%br>いい子です。",
 		"tr_text": "",
 		"fileID": 2
@@ -5634,7 +5634,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ひゃぁー！<%br>いいこ、いいこ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5642,7 +5642,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、「地下坑道」エリアで<%br>ヘイドと思われる反応が確認できました！",
 		"tr_text": "",
 		"fileID": 2
@@ -5650,7 +5650,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "よっしゃ！<%br>リーダー、ジェネ急ぐってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -5674,7 +5674,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "はい！",
 		"tr_text": "",
 		"fileID": 2
@@ -5682,7 +5682,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "一点、報告させてください。<%br>以前のヘイドの反応と異なる点があります。",
 		"tr_text": "",
 		"fileID": 2
@@ -5698,7 +5698,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "そ、それってヘイドの仲間かもしれないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -5706,7 +5706,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "その可能性は、ゼロではありません。<%br>警戒してください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5714,7 +5714,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "Seraphy",
+		"tr_name": "Duna",
 		"jp_text": "ふぁ……？<%br>むぅ？　むぅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -5722,7 +5722,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "デュナ、気になるのか？<%br>ここ、迷路みたいだからはぐれちゃダメだぞ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5738,7 +5738,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "はぁい。<%br>まいご、ならない。",
 		"tr_text": "",
 		"fileID": 2
@@ -5754,7 +5754,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……！<%br>はい、デュナはわたしの側にいてください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5762,7 +5762,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、反応が近づいています。<%br>ここからはより慎重に進んでください。",
 		"tr_text": "",
 		"fileID": 2
@@ -5770,7 +5770,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "おう！<%br>反応が、ヘイドのものかわからないもんな！",
 		"tr_text": "",
 		"fileID": 2
@@ -5778,7 +5778,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "そうですね、行きましょう。<%br>リーダー、モア……デュナも、ね！",
 		"tr_text": "",
 		"fileID": 2
@@ -5786,7 +5786,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "おー！",
 		"tr_text": "",
 		"fileID": 2
@@ -5794,7 +5794,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "ここでも……ヘイドに、「捕食」……<%br>されたんでしょうか？",
 		"tr_text": "",
 		"fileID": 2
@@ -5802,7 +5802,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……ふゅぅ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -5810,7 +5810,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……大丈夫です。怖くないですよ。<%br>デュナ……",
 		"tr_text": "",
 		"fileID": 2
@@ -5818,7 +5818,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "……ここ近辺の生体反応が、数時間前に<%br>消失していることが確認できます。",
 		"tr_text": "",
 		"fileID": 2
@@ -5834,7 +5834,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "な、なぁ……セラフィさん。最初に「捕食」の<%br>報告があったのってどこだっけ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5842,7 +5842,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさんが、惑星ナベリウスで発見するまで<%br>惑星ウォパルでしか報告はありませんでした。",
 		"tr_text": "",
 		"fileID": 2
@@ -5850,7 +5850,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "……ヘイズ・ドラールってさ、龍族だろ？<%br>なんで惑星ウォパルなんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -5858,7 +5858,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "確かに、そうですよね。<%br>……どうして、ウォパルにいたんでしょうか。",
 		"tr_text": "",
 		"fileID": 2
@@ -5866,7 +5866,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "現在、惑星ウォパルで報告された<%br>「捕食」については調査を開始しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -5898,7 +5898,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -5930,7 +5930,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "そうだってば！<%br>オレたちはヘイドを捕まえるんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -5938,7 +5938,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "でゅなも、つかまえる！",
 		"tr_text": "",
 		"fileID": 2
@@ -5946,7 +5946,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "不安……",
 		"tr_text": "",
 		"fileID": 2
@@ -5962,7 +5962,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "そうそう！　またオレたちが<%br>活躍しちゃうから、大丈夫だって！",
 		"tr_text": "",
 		"fileID": 2
@@ -5970,7 +5970,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "か、つやく、しちゃう！",
 		"tr_text": "",
 		"fileID": 2
@@ -5978,7 +5978,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい……！<%br>そうですね、わたし達にできることを……",
 		"tr_text": "",
 		"fileID": 2
@@ -5986,7 +5986,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "リーダー、ジェネちゃん！<%br>この先に反応を確認しました。",
 		"tr_text": "",
 		"fileID": 2
@@ -5994,7 +5994,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "行きましょう！<%br>リーダー！",
 		"tr_text": "",
 		"fileID": 2
@@ -6018,7 +6018,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "待ってください、今、最新の情報を……",
 		"tr_text": "",
 		"fileID": 2
@@ -6034,7 +6034,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……危ない……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6042,7 +6042,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -6050,7 +6050,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "リーダー！<%br>ジェネちゃん、モアくん……大丈夫ですか！？",
 		"tr_text": "",
 		"fileID": 2
@@ -6058,7 +6058,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "うぅ……<%br>だい、じょうぶ……です……",
 		"tr_text": "",
 		"fileID": 2
@@ -6066,7 +6066,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ……？<%br>じぇね？　どったの？",
 		"tr_text": "",
 		"fileID": 2
@@ -6074,7 +6074,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "オンナ……いい反応だ。<%br>よくかわしたな。",
 		"tr_text": "",
 		"fileID": 2
@@ -6082,7 +6082,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "ジェネ！　大丈夫か！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6090,7 +6090,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、いたいの？<%br>いたいいたい？",
 		"tr_text": "",
 		"fileID": 2
@@ -6098,7 +6098,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……大丈夫です。<%br>このくらい……なんてことないですよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6106,7 +6106,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6114,7 +6114,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "ひゃっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6122,7 +6122,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……あなた、デュナを今、攻撃しましたね？",
 		"tr_text": "",
 		"fileID": 2
@@ -6138,7 +6138,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……「トランスエネミー」？<%br>またお前らは、「名前」をつけるのか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6154,7 +6154,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 2
@@ -6162,7 +6162,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6170,7 +6170,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "……ひゅ？",
 		"tr_text": "",
 		"fileID": 2
@@ -6178,7 +6178,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "お前らの相手をするのは、まだ先でいい……",
 		"tr_text": "",
 		"fileID": 2
@@ -6186,7 +6186,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "……な、なに言ってんだよさっきから！<%br>先とかじゃないってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6210,7 +6210,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "ウェポノイドは……アークスに使われることを<%br>選んだ。お前らは、ただの道具だろ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6226,7 +6226,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……！<%br>また、ウェポノイドが……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6242,7 +6242,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Gene",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "コロ……ス……コ……ロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6250,7 +6250,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Duna",
 		"jp_text": "ひゃぁっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6290,7 +6290,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Duna",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "コロス、コロス……<%br>アークス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6298,7 +6298,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Gene",
 		"jp_text": "彼女も……<%br>アークスに攻撃をする、ウェポノイド……",
 		"tr_text": "",
 		"fileID": 2
@@ -6306,7 +6306,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "なんで……<%br>なんでだってば……",
 		"tr_text": "",
 		"fileID": 2
@@ -6314,7 +6314,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -6322,7 +6322,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……クレイモア。<%br>これが……アークスが、しようとしたことだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6338,7 +6338,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ぶ……ブリュー・リンガーダ……！？",
 		"tr_text": "",
 		"fileID": 2
@@ -6346,7 +6346,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "クシャネビュラ、コイツをつかえ。<%br>……あとは適当に、相手をしてやれ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6354,7 +6354,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "あ！<%br>ヘイド、……ま、ま、まてってば！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6370,7 +6370,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "More",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "コロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -6378,7 +6378,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "More",
 		"jp_text": "クシャネ……ビュラ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6386,7 +6386,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア、来ますよ……<%br>クシャネビュラと戦わないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -6394,7 +6394,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Gene",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "うぅううああああ……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -6402,7 +6402,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "More",
 		"jp_text": "お、おい……<%br>どうしたんだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6410,7 +6410,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "More",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "ヘイド……サマ……<%br>くっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6418,7 +6418,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Gene",
 		"jp_text": "ま、まって……！<%br>うっ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -6426,7 +6426,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、いたいいたいなの？<%br>いたいの……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6434,7 +6434,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……ジェネ、大丈夫か？　さっきヘイドの<%br>攻撃からデュナを庇った時にケガしたんだろ？",
 		"tr_text": "",
 		"fileID": 2
@@ -6442,7 +6442,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……大丈夫です。それより、クシャネビュラが<%br>……逃げてしまいました。",
 		"tr_text": "",
 		"fileID": 2
@@ -6450,7 +6450,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "うん……。なぁ、アネットたちにも<%br>クシャネビュラのこと伝えたほうがいいよな。",
 		"tr_text": "",
 		"fileID": 2
@@ -6458,7 +6458,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "そうですね。でも、あのアジトは通信が使えない<%br>はずです。……一度、試してみましょうか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6466,7 +6466,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "あねと……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6474,7 +6474,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6482,7 +6482,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "あぁあぁ！　すばらしい！<%br>ここは天国だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6490,7 +6490,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "……って、なーにほっつき歩いてんだ<%br>カラミティ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6498,7 +6498,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "許してあげなさいよ。抑圧された好奇心が<%br>ようやく満たされてるんだから。",
 		"tr_text": "",
 		"fileID": 2
@@ -6506,7 +6506,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……ま、いいけど。",
 		"tr_text": "",
 		"fileID": 2
@@ -6514,7 +6514,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "それより、ジェネたちも心配。<%br>早く「当て」とやらに、会わせてちょうだい。",
 		"tr_text": "",
 		"fileID": 2
@@ -6522,7 +6522,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6530,7 +6530,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "……ここにボクを連れてきてくれた！<%br>君たちはすばらしいっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6562,7 +6562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……ところで、どうして私を連れてきたの？<%br>リーダーでも、ジェネでもなくて……",
 		"tr_text": "",
 		"fileID": 2
@@ -6570,7 +6570,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……なんでだと、思う？",
 		"tr_text": "",
 		"fileID": 2
@@ -6578,7 +6578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "さぁ……？<%br>単に戦力バランスを考えて、かしら。",
 		"tr_text": "",
 		"fileID": 2
@@ -6586,7 +6586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……ははは。なーに、そんなにジェネちゃんや<%br>おチビと離れるのが嫌だったのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6594,7 +6594,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6602,7 +6602,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "……あのー……その、あれだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6618,7 +6618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "Calamity",
+		"tr_name": "More",
 		"jp_text": "……やっぱり<%br>アネットたちに通信、つながらないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6626,7 +6626,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "はい。やはりあそこは、アークスの通信を<%br>妨害する仕組みが働いているようですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -6634,7 +6634,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "……アネットさん達もきっと、デュナや<%br>ウェポノイドのために頑張ってくれてるんです。",
 		"tr_text": "",
 		"fileID": 2
@@ -6650,7 +6650,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "よっしゃあ！<%br>このくらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -6658,7 +6658,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "てばーっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -6666,7 +6666,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……デュナ、もう怖くないのか？<%br>大丈夫なのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -6674,7 +6674,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "でゅな、ないよ。<%br>こわない。",
 		"tr_text": "",
 		"fileID": 2
@@ -6690,7 +6690,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 2
@@ -6698,7 +6698,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -6706,7 +6706,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "どうして……デュナはあなたと同じ<%br>トランスエネミーなのに……",
 		"tr_text": "",
 		"fileID": 2
@@ -6714,7 +6714,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……「トランスエネミー」？<%br>またお前らは、「名前」をつけるのか。",
 		"tr_text": "",
 		"fileID": 2
@@ -6730,7 +6730,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ……？<%br>じぇね？？",
 		"tr_text": "",
 		"fileID": 2
@@ -6754,7 +6754,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "あ……いえ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6810,7 +6810,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "……なんか、ヘイドは怖いってば。<%br>れ、レヴィとかも、ちょっと怖かったけど……",
 		"tr_text": "",
 		"fileID": 2
@@ -6826,7 +6826,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "みゅぅ……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6834,7 +6834,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -6874,7 +6874,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "？？？",
-		"tr_name": "Hade",
+		"tr_name": "???",
 		"jp_text": "う……あぁ……これは……<%br>わた、私は……",
 		"tr_text": "",
 		"fileID": 2
@@ -6882,7 +6882,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "???",
+		"tr_name": "Hade",
 		"jp_text": "〔お前だけだ。アナティス。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6890,7 +6890,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "……あなて……アナティス？",
 		"tr_text": "",
 		"fileID": 2
@@ -6898,7 +6898,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔お前の名前だ。ここのやつらは、お前を<%br>　そう呼んでいる。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6906,7 +6906,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "アナティス、わた……私、私の名……",
 		"tr_text": "",
 		"fileID": 2
@@ -6914,7 +6914,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔……そうだ。俺はやつらの言葉を理解している。<%br>　特殊な能力のために、ここに連れてこられた。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6930,7 +6930,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "つか、われる？",
 		"tr_text": "",
 		"fileID": 2
@@ -6938,7 +6938,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔実験だ。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6946,7 +6946,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "実験……？",
 		"tr_text": "",
 		"fileID": 2
@@ -6954,7 +6954,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔人間は実験が好きだ。未知を嫌い<%br>　全てを理解しようとする。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -6978,7 +6978,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Hade",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "ヘイド、サマ……",
 		"tr_text": "",
 		"fileID": 2
@@ -6986,7 +6986,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Hade",
 		"jp_text": "……なんだ。<%br>殺せなかったのか……",
 		"tr_text": "",
 		"fileID": 2
@@ -7002,7 +7002,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "セラフィ",
-		"tr_name": "Hade",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、ヘイドの生体反応が動きを<%br>止めました……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7018,7 +7018,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はい……！<%br>急ぎましょう、リーダー、モア！",
 		"tr_text": "",
 		"fileID": 2
@@ -7026,7 +7026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "おい……！<%br>あれ……クシャネビュラじゃ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7034,7 +7034,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "More",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "う……うぅ……うぅぅ……<%br>く……",
 		"tr_text": "",
 		"fileID": 2
@@ -7042,7 +7042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Gene",
 		"jp_text": "……さっきの戦いで、すごく傷ついて<%br>弱っていますね……",
 		"tr_text": "",
 		"fileID": 2
@@ -7050,7 +7050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "お、オレ……クシャネビュラと……<%br>戦いたくない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7074,7 +7074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -7106,7 +7106,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "大丈夫だってば。オレ……<%br>アイツを助けたいんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7114,7 +7114,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "うん。そうだね、モア……<%br>助けましょう、クシャネビュラを一緒に！",
 		"tr_text": "",
 		"fileID": 2
@@ -7122,7 +7122,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "クシャネビュラ……お前と戦いたくないんだ。<%br>ケガ……たくさんしてるだろ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7138,7 +7138,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "More",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "う……アークス、コロス、アークス……",
 		"tr_text": "",
 		"fileID": 2
@@ -7146,7 +7146,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Hade",
 		"jp_text": "……そうだ、クシャネビュラ。<%br>アークスは殺せ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7154,7 +7154,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7162,7 +7162,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "……ふん。",
 		"tr_text": "",
 		"fileID": 2
@@ -7178,7 +7178,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "モア、危ないです！<%br>今度は空間から、ゼッシュレイダを……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7194,7 +7194,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Gene",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "うあぁぁぁぁぁぁっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7202,7 +7202,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "More",
 		"jp_text": "クシャネビュラーっ！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7210,7 +7210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "More",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "ぐぐぐ……あ、アークスころ、コロス……",
 		"tr_text": "",
 		"fileID": 2
@@ -7218,7 +7218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Gene",
 		"jp_text": "どうして……",
 		"tr_text": "",
 		"fileID": 2
@@ -7226,7 +7226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "なんでまだ、アークスをオレたちを<%br>敵だって思ってるんだ……クシャネビュラ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7242,7 +7242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -7274,7 +7274,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……「保護」か。<%br>また偽りの、聞こえのいい言葉を……",
 		"tr_text": "",
 		"fileID": 2
@@ -7282,7 +7282,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "へ、ヘイド……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -7290,7 +7290,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……俺に気づいたか？",
 		"tr_text": "",
 		"fileID": 2
@@ -7298,7 +7298,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……<%br>あなた、何を……",
 		"tr_text": "",
 		"fileID": 2
@@ -7306,7 +7306,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クシャネビュラ",
-		"tr_name": "Gene",
+		"tr_name": "Kuscha Nebula",
 		"jp_text": "あ、あ、……アークス……コロ、ス。",
 		"tr_text": "",
 		"fileID": 2
@@ -7314,7 +7314,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Kuscha Nebula",
+		"tr_name": "Hade",
 		"jp_text": "……クシャネビュラ。<%br>お前はもう無理だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7330,7 +7330,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "グシャ……グシャ……",
 		"tr_text": "",
 		"fileID": 2
@@ -7338,7 +7338,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -7346,7 +7346,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "ひゃぅぅ……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7354,7 +7354,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "どうして……そんな……",
 		"tr_text": "",
 		"fileID": 2
@@ -7362,7 +7362,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "こ、このやろーっ！！<%br>ゆるさないぞー！",
 		"tr_text": "",
 		"fileID": 2
@@ -7370,7 +7370,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "まだだ……<%br>まだ、アークスと戦う力が足りない……",
 		"tr_text": "",
 		"fileID": 2
@@ -7378,7 +7378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "もあ、……だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7386,7 +7386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……お、おう！　大丈夫だってば……<%br>それより、早くヘイドを捕まえないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -7410,7 +7410,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "……モアくん。",
 		"tr_text": "",
 		"fileID": 2
@@ -7442,7 +7442,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "……じゃあ、ヘイドのやつはクシャネビュラを<%br>食べて、強くなったって言うのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -7450,7 +7450,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "はい。捕食の目的は、やはり<%br>能力の強化の為かと思われます。",
 		"tr_text": "",
 		"fileID": 2
@@ -7458,7 +7458,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "フェル達は、強くなるために<%br>自分の体に強力なフォトンを取り込みました。",
 		"tr_text": "",
 		"fileID": 2
@@ -7474,7 +7474,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "それって、すごい危ないってば。<%br>早く、捕まえないと……",
 		"tr_text": "",
 		"fileID": 2
@@ -7490,7 +7490,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "……みなさん、確認ができました。<%br>ヘイドは採掘場跡エリアへ移動しています。",
 		"tr_text": "",
 		"fileID": 2
@@ -7498,7 +7498,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "行きましょう、リーダー、モア！",
 		"tr_text": "",
 		"fileID": 2
@@ -7506,7 +7506,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "でゅな！",
 		"tr_text": "",
 		"fileID": 2
@@ -7514,7 +7514,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7538,7 +7538,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "じぇね、だーじょぶ？<%br>だーじょうぶ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7546,7 +7546,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……はい。大丈夫ですよ。<%br>このくらい……",
 		"tr_text": "",
 		"fileID": 2
@@ -7554,7 +7554,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "急ごう。オレたちで、捕まえなきゃいけないんだ。<%br>アネットたちは居ないんだから。",
 		"tr_text": "",
 		"fileID": 2
@@ -7562,7 +7562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "あねと、いなーない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7570,7 +7570,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "なーにその、不満でいっぱいの目は。<%br>ふぅ……それなのに付いてきてくれたの？",
 		"tr_text": "",
 		"fileID": 2
@@ -7578,7 +7578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "不満はあるけど、貴方が無意味な判断を<%br>この状況でするとは思っていない。",
 		"tr_text": "",
 		"fileID": 2
@@ -7586,7 +7586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……驚いた。<%br>随分信頼されてんのね、俺。",
 		"tr_text": "",
 		"fileID": 2
@@ -7594,7 +7594,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……信頼なんてしてないわよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7602,7 +7602,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -7610,7 +7610,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "でも、信用ならしている。",
 		"tr_text": "",
 		"fileID": 2
@@ -7618,7 +7618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "そう？　頼ってくれてもいいんだけどねー。<%br>ま、そういうのはリーダーに任せるとするよ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7650,7 +7650,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "そうね。ウェポノイドは回収……最悪、処分。<%br>デュナも研究所行きでしょうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -7658,7 +7658,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……<%br>そこまでわかってて、ずいぶん余裕そうだな？",
 		"tr_text": "",
 		"fileID": 2
@@ -7666,7 +7666,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "もう私は……「ひとりで頑張らない」って<%br>そう……ジェネと約束したから。",
 		"tr_text": "",
 		"fileID": 2
@@ -7682,7 +7682,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……変わったねぇ……ほんとに。",
 		"tr_text": "",
 		"fileID": 2
@@ -7714,7 +7714,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "",
-		"tr_name": "Bruno",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 2
@@ -7730,7 +7730,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（「次席」……?<%br>　ブルーノがそう呼ぶってことは情報部の……）",
 		"tr_text": "",
 		"fileID": 2
@@ -7754,7 +7754,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "おっと！　この方はこう見えても、俺よりずっと<%br>上の地位にいる人だ。言葉には気を付けてな？",
 		"tr_text": "",
 		"fileID": 2
@@ -7762,7 +7762,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "ど、どこから出てきたんだ！？<%br>す、すごいぞ……こんなのありえない……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7770,7 +7770,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "カラミティ……少し、黙ってて。",
 		"tr_text": "",
 		"fileID": 2
@@ -7778,7 +7778,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "次席と呼ばれた女性",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "……初めまして。<%br>あなたがアネット、ですね？",
 		"tr_text": "",
 		"fileID": 2
@@ -7786,7 +7786,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "えぇ。私は貴方を存じてませんが<%br>貴方は私を知っている……ということは……",
 		"tr_text": "",
 		"fileID": 2
@@ -7802,7 +7802,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "理解が早くて助かるよ。<%br>やっぱ、お前を次席に会わせたのは正解だな。",
 		"tr_text": "",
 		"fileID": 2
@@ -7810,7 +7810,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "クーナ",
-		"tr_name": "Bruno",
+		"tr_name": "Quna",
 		"jp_text": "いきなりですので、どこまで信用いただけるかは<%br>わかりませんが……",
 		"tr_text": "",
 		"fileID": 2
@@ -7858,7 +7858,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "あの「組織」？<%br>E.M.A.研究所のこと？",
 		"tr_text": "",
 		"fileID": 2
@@ -7866,7 +7866,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "……すみません。これは単なるわたしの憶測。<%br>少し言葉がすぎました。",
 		"tr_text": "",
 		"fileID": 2
@@ -7890,7 +7890,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "………………",
 		"tr_text": "",
 		"fileID": 2
@@ -7914,7 +7914,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "……えぇ。それは心配しないでください。",
 		"tr_text": "",
 		"fileID": 2
@@ -7930,7 +7930,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "……悠長なことは、言ってられない。<%br>そういうこと……ね。",
 		"tr_text": "",
 		"fileID": 2
@@ -7938,7 +7938,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "彼が、あなたをわたしに会わせたということは<%br>信じるに足ると、判断したのでしょう。",
 		"tr_text": "",
 		"fileID": 2
@@ -7946,7 +7946,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -7954,7 +7954,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……ま、俺もお前を信用してるってことだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -7978,7 +7978,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ？<%br>この先何かって、何が起きるっていうんだ？",
 		"tr_text": "",
 		"fileID": 2
@@ -7986,7 +7986,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "……さぁねぇ？<%br>まぁ、念のためってやつだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8002,7 +8002,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -8010,7 +8010,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "あぁ、そうだアネット。これからは研究報告は<%br>お前から直接してくれよ？　",
 		"tr_text": "",
 		"fileID": 2
@@ -8018,7 +8018,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……分かったわ。<%br>改めて、どうぞよろしく。",
 		"tr_text": "",
 		"fileID": 2
@@ -8026,7 +8026,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、ヘイドはもうすぐそこです。<%br>急いでください……！",
 		"tr_text": "",
 		"fileID": 2
@@ -8034,7 +8034,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "わ、わかってるってば！<%br>行くぞ、リーダー、ジェネ……っとデュナもな！",
 		"tr_text": "",
 		"fileID": 2
@@ -8042,7 +8042,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "もな！",
 		"tr_text": "",
 		"fileID": 2
@@ -8050,7 +8050,7 @@
 	{
 		"eventNo": "39",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい、急ぎましょう！",
 		"tr_text": "",
 		"fileID": 2
@@ -8058,7 +8058,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 2
@@ -8066,7 +8066,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "追いついたぞ！　ヘイド！<%br>お前のこと、オレは絶対許さないってば！！",
 		"tr_text": "",
 		"fileID": 2
@@ -8074,7 +8074,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……どうして、どうして<%br>クシャネビュラを……仲間を……食べたのっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8082,7 +8082,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……「食べる」。<%br>それに理由がいるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8090,7 +8090,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 2
@@ -8098,7 +8098,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "お前らアークスはそうやって、なんにでも<%br>「理由」をつけようとする。",
 		"tr_text": "",
 		"fileID": 2
@@ -8114,7 +8114,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……どういう、意味です？",
 		"tr_text": "",
 		"fileID": 2
@@ -8122,7 +8122,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "俺が食べることに理由はない。<%br>オンナ、お前は呼吸や、瞬きに理由がいるのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8138,7 +8138,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……クシャネビュラを……捕食したのは<%br>生きる上で、必要だった？",
 		"tr_text": "",
 		"fileID": 2
@@ -8146,7 +8146,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "あぁ、アークスという強大な力の前に<%br>今の俺では叶わない……",
 		"tr_text": "",
 		"fileID": 2
@@ -8162,7 +8162,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "あなたは、どうして……<%br>アークスを殺したいと、思うんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -8178,7 +8178,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……どうしてお前らアークスは<%br>俺や、そこのクレイモアを作り出した？",
 		"tr_text": "",
 		"fileID": 2
@@ -8202,7 +8202,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "へ、ヘイド……<%br>あなたは、誰に作られたんです……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8218,7 +8218,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……ひゅあっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8226,7 +8226,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "デュナ？　どうしました……",
 		"tr_text": "",
 		"fileID": 2
@@ -8234,7 +8234,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "手にした力を試すにはちょうどいい。<%br>コドモ、お前もここで死ぬんだ……",
 		"tr_text": "",
 		"fileID": 2
@@ -8242,7 +8242,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "デュナは下がるんだ！<%br>ジェネ、リーダー……アイツを止めるってば！",
 		"tr_text": "",
 		"fileID": 2
@@ -8250,7 +8250,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "これは！！　みなさん、気を付けてください！<%br>ヘイドのフォトン量が異常に増加しています！",
 		"tr_text": "",
 		"fileID": 2
@@ -8258,7 +8258,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はい……っ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8266,7 +8266,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "『ウォオォォォォォォォッ！！』",
 		"tr_text": "",
 		"fileID": 2
@@ -8298,7 +8298,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ま、まって……！<%br>ヘイド……！！",
 		"tr_text": "",
 		"fileID": 2
@@ -8306,7 +8306,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "逃げんなー！<%br>ヘイド、お前は、お前だけは許せないんだ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8322,7 +8322,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "……もあ？<%br>どったの……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8330,7 +8330,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "デュナ……心配してくれたのか？<%br>へへ、ありがとな、大丈夫だぜ？",
 		"tr_text": "",
 		"fileID": 2
@@ -8370,7 +8370,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 2
@@ -8378,7 +8378,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、無事帰還できてよかったです。<%br>モアくん、辛い思いをしましたね……",
 		"tr_text": "",
 		"fileID": 2
@@ -8386,7 +8386,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "……落ち込んでなんかいられないってば<%br>だって……他のウェポノイドを守るんだかんなっ！",
 		"tr_text": "",
 		"fileID": 2
@@ -8394,7 +8394,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "うん、そうだね……モア。<%br>一緒に頑張りましょうね。",
 		"tr_text": "",
 		"fileID": 2
@@ -8402,7 +8402,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……ふぁ……。じぇね……ねぇねぇー。<%br>おーたうたって。",
 		"tr_text": "",
 		"fileID": 2
@@ -8410,7 +8410,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "デュナ？<%br>どうしたんです？",
 		"tr_text": "",
 		"fileID": 2
@@ -8418,7 +8418,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "おーた、うたって？",
 		"tr_text": "",
 		"fileID": 2
@@ -8426,7 +8426,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "なんだ？　デュナのやつ、眠そうじゃないか？<%br>あれだ、ジェネに子守歌歌ってほしいんだな？",
 		"tr_text": "",
 		"fileID": 2
@@ -8434,7 +8434,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "こ、子守歌……です？",
 		"tr_text": "",
 		"fileID": 2
@@ -8442,7 +8442,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "なんだか、デュナって<%br>ジェネのことママだと思ってんじゃないか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8450,7 +8450,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "えぇ！？<%br>ママ、に見えます？",
 		"tr_text": "",
 		"fileID": 2
@@ -8458,7 +8458,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……？",
 		"tr_text": "",
 		"fileID": 2
@@ -8474,7 +8474,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "えへへ。<%br>なんだか、ちょっと嬉しいです。",
 		"tr_text": "",
 		"fileID": 2
@@ -8482,7 +8482,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "あっ、そーだ！　なぁなぁ、セラフィさん<%br>アネットたちはまだ戻ってきてないのか？",
 		"tr_text": "",
 		"fileID": 2
@@ -8490,7 +8490,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "はい……今も通信は繋がらないので<%br>恐らく、まだアジト内部にいるのだと思います。",
 		"tr_text": "",
 		"fileID": 2
@@ -8498,7 +8498,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "そっか……大丈夫かな？",
 		"tr_text": "",
 		"fileID": 2
@@ -8506,7 +8506,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "心配ですね……",
 		"tr_text": "",
 		"fileID": 2
@@ -8514,7 +8514,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "貴方が言っていた、「あの組織」……<%br>E.M.A.じゃないなら……",
 		"tr_text": "",
 		"fileID": 2
@@ -8530,7 +8530,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "ブルーノ……彼女は確かに<%br>あなたの報告通り、勘がいいですね。",
 		"tr_text": "",
 		"fileID": 2
@@ -8538,7 +8538,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "ブルーノ",
-		"tr_name": "Quna",
+		"tr_name": "Bruno",
 		"jp_text": "……でしょう？<%br>ま、ややマイナス思考なところはありますが。",
 		"tr_text": "",
 		"fileID": 2
@@ -8546,7 +8546,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "虚空機関は様々な、人体・生物実験を<%br>していたと言われる研究機関……",
 		"tr_text": "",
 		"fileID": 2
@@ -8562,7 +8562,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "……はい。その虚空機関の研究がE.M.A.に<%br>引き継がれて……生み出されたと考えています。",
 		"tr_text": "",
 		"fileID": 2
@@ -8570,7 +8570,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "ヘイド",
-		"tr_name": "Quna",
+		"tr_name": "Hade",
 		"jp_text": "……アークス。<%br>お前らは、恐ろしい生き物だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8610,7 +8610,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "人間、あの……<%br>白い衣をまとった生物のことか。",
 		"tr_text": "",
 		"fileID": 2
@@ -8618,7 +8618,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔あぁ。実験はこの世界の摂理で起きない事象を<%br>　無理やり起こす。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8650,7 +8650,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "なんという……<%br>なんでだ！　知るために、殺すのか！",
 		"tr_text": "",
 		"fileID": 2
@@ -8658,7 +8658,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔……憎いか？　人間が。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8666,7 +8666,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "憎い……<%br>憎まずにおれるのか！",
 		"tr_text": "",
 		"fileID": 2
@@ -8674,7 +8674,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔俺は明日、お前と同じ「実験」を受ける。<%br>　ほとんどの確率で「失敗」するだろう。〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8682,7 +8682,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 2
@@ -8690,7 +8690,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔俺は、人の言葉が理解できる。<%br>　奴らの言葉を、ずっと聞いてきた……〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8706,7 +8706,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "……死ぬな。",
 		"tr_text": "",
 		"fileID": 2
@@ -8714,7 +8714,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔……〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8722,7 +8722,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "死なないでくれ。<%br>名を……名を教えてくれ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8730,7 +8730,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "〔……ヘイド〕",
 		"tr_text": "",
 		"fileID": 2
@@ -8738,7 +8738,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド、死ぬな。<%br>もし死なれたら、私はここにひとりだ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8754,7 +8754,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……アークス。<%br>お前らは、恐ろしい生き物だ。",
 		"tr_text": "",
 		"fileID": 2
@@ -8762,7 +8762,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "塞がれた世界",
 		"tr_text": "",
 		"fileID": 2
@@ -8802,7 +8802,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "（俺の今の力では……あいつらを<%br>　アークスを殺すことはできない）",
 		"tr_text": "",
 		"fileID": 3
@@ -8818,7 +8818,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 3
@@ -8834,7 +8834,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……いや。<%br>それより……機嫌がいいな。",
 		"tr_text": "",
 		"fileID": 3
@@ -8842,7 +8842,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ふふ……<%br>すこし、腹の子が大きくなったと思わないか？",
 		"tr_text": "",
 		"fileID": 3
@@ -8850,7 +8850,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -8866,7 +8866,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "それぞれの「理由」",
 		"tr_text": "",
 		"fileID": 3
@@ -8874,7 +8874,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "セラフィ",
-		"tr_name": "",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、先ほどブルーノさんたち<%br>３名が、無事帰還されました。",
 		"tr_text": "",
 		"fileID": 3
@@ -8882,7 +8882,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "Seraphy",
+		"tr_name": "Bruno",
 		"jp_text": "あははー、思いのほか時間かかっちゃってね。<%br>ごめんねー？",
 		"tr_text": "",
 		"fileID": 3
@@ -8898,7 +8898,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "ブルーノさん……アネットさん、カラミティさん<%br>ありがとうございます！　よかった……",
 		"tr_text": "",
 		"fileID": 3
@@ -8906,7 +8906,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの、あねと、からみて……<%br>ありあとー。",
 		"tr_text": "",
 		"fileID": 3
@@ -8914,7 +8914,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……あら。ずいぶん喋れるようになったのね。<%br>ヒトよりずっと、成長が早いわね。",
 		"tr_text": "",
 		"fileID": 3
@@ -8922,7 +8922,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん……１点、ご報告があります。",
 		"tr_text": "",
 		"fileID": 3
@@ -8938,7 +8938,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "Seraphy",
+		"tr_name": "Bruno",
 		"jp_text": "……そっか。うーん……？<%br>でもたしかに、あの時様子は違ったよね。",
 		"tr_text": "",
 		"fileID": 3
@@ -8946,7 +8946,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……確か、戦ったあと……この子が……<%br>デュナがシュトラを撫でた……わよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -8954,7 +8954,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……ふゅ？",
 		"tr_text": "",
 		"fileID": 3
@@ -8962,7 +8962,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……アネット……さん？",
 		"tr_text": "",
 		"fileID": 3
@@ -8970,7 +8970,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "この子はどんな能力を利用されるために……<%br>トランスエネミーとして生まれたのかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -8978,7 +8978,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……あにぇっと？<%br>どーしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -8986,7 +8986,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "ま！　デュナちゃんのことは、ヘイドを<%br>追っていけば、自然と分かるんじゃないかな？",
 		"tr_text": "",
 		"fileID": 3
@@ -8994,7 +8994,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "みゅ？　わかる？<%br>ふぅー？",
 		"tr_text": "",
 		"fileID": 3
@@ -9002,7 +9002,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……そうね。デュナがシュトラを撫でたことが<%br>紐づいているとは、まだ断定できないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9010,7 +9010,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "そうっ！<%br>その面白いウェポノイド！",
 		"tr_text": "",
 		"fileID": 3
@@ -9034,7 +9034,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "面白いウェポノイド……？<%br>何言ってんだよお前！",
 		"tr_text": "",
 		"fileID": 3
@@ -9042,7 +9042,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "シュトラ……！<%br>お前、もう……えっと、その……",
 		"tr_text": "",
 		"fileID": 3
@@ -9050,7 +9050,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……アンタたちに、攻撃なんかもうしない。<%br>その……記憶がないんだ、攻撃したときの。",
 		"tr_text": "",
 		"fileID": 3
@@ -9066,7 +9066,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……シュトラは悪くないって思うぞ。<%br>それより、よかった……よかったってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -9074,7 +9074,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "More",
+		"tr_name": "Calamity",
 		"jp_text": "記憶がない。……チップに異常もない。<%br>そもそも自我を持つウェポノイドに……",
 		"tr_text": "",
 		"fileID": 3
@@ -9082,7 +9082,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "アンタが、リーダーだって聞いた。<%br>オレを任務に、このチームに加えてくれないか？",
 		"tr_text": "",
 		"fileID": 3
@@ -9114,7 +9114,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "でゅなもー、いっしょ、がんばるね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9122,7 +9122,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "リーダー！<%br>オレからもお願いだってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -9130,7 +9130,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "でゅなもー。ねがい、てば。<%br>ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9138,7 +9138,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "リーダーの心配もわかるけど、私は賛成よ。<%br>いいんじゃないかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -9154,7 +9154,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "よーしっ！　ってことで、シュトラ。<%br>そんな気ぃ張りすぎるなよ、よろしくな。",
 		"tr_text": "",
 		"fileID": 3
@@ -9162,7 +9162,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "……うん、その……よろしく。",
 		"tr_text": "",
 		"fileID": 3
@@ -9170,7 +9170,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさん、一緒にがんばりましょうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9178,7 +9178,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "がんばりーしょーね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9186,7 +9186,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……あ……あぁ、うん。",
 		"tr_text": "",
 		"fileID": 3
@@ -9194,7 +9194,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "……で、君。リーダー達との戦闘中<%br>記憶がないって言っていたが……",
 		"tr_text": "",
 		"fileID": 3
@@ -9210,7 +9210,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "うっせぇな。お前、なんなんだよ。<%br>……オレはこのチームに入ったんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9226,7 +9226,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "…………！！",
 		"tr_text": "",
 		"fileID": 3
@@ -9242,7 +9242,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "おーられた。<%br>……からみて、いいこいいこ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9250,7 +9250,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9258,7 +9258,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "いいこ、いいこ。<%br>いちゃいの、ないない！",
 		"tr_text": "",
 		"fileID": 3
@@ -9266,7 +9266,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9274,7 +9274,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "ち、近づくな、子供！<%br>そしてボクをな、なでるなぁ……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9282,7 +9282,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Calamity",
+		"tr_name": "Seraphy",
 		"jp_text": "……みなさん、今しがたこのチームに<%br>「特例」が適用されることになりました。",
 		"tr_text": "",
 		"fileID": 3
@@ -9306,7 +9306,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "……なぁ、これがブルーノが<%br>「あて」とか言ってたやつのことか？",
 		"tr_text": "",
 		"fileID": 3
@@ -9314,7 +9314,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……これで私たちの、ヘイド捕獲任務は<%br>内密に行われることになるわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9322,7 +9322,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "俺の上司っていうのかな……お願いしたのよ。<%br>この任務の指示系統を、通常と分けてほしいって。",
 		"tr_text": "",
 		"fileID": 3
@@ -9338,7 +9338,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "つまりは、ボクらのお陰でトランスエネミーの<%br>子供は捕獲されずにすむ、ということだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9346,7 +9346,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……「ボクら」じゃなくて、それってその<%br>おっさんの上司のお陰じゃね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9354,7 +9354,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "おっさん……おっさんかぁ……<%br>いいけどね。うん。",
 		"tr_text": "",
 		"fileID": 3
@@ -9362,7 +9362,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの？<%br>かなしー？　だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9370,7 +9370,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "あはは！　にぎやかになってきましたね。<%br>リーダー、これからどうします？",
 		"tr_text": "",
 		"fileID": 3
@@ -9394,7 +9394,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "んー！　んー！　行くべきだっ……！<%br>さぁ……行こう、ウォパルッ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9402,7 +9402,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Calamity",
+		"tr_name": "Gene",
 		"jp_text": "たしか、カラミティさんが捕食跡を<%br>目撃したのも、惑星ウォパルでしたね！",
 		"tr_text": "",
 		"fileID": 3
@@ -9410,7 +9410,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん……今入った報告によりますと<%br>惑星アムドゥスキアで捕食跡が見つかりました。",
 		"tr_text": "",
 		"fileID": 3
@@ -9418,7 +9418,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ブルーノ",
-		"tr_name": "Seraphy",
+		"tr_name": "Bruno",
 		"jp_text": "まずいな……次の捕食対象は、龍族か？<%br>ウォパルは後回しにするしかないね……",
 		"tr_text": "",
 		"fileID": 3
@@ -9426,7 +9426,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "セラフィ",
-		"tr_name": "Bruno",
+		"tr_name": "Seraphy",
 		"jp_text": "……捕食の報告はあれから上がってきては……<%br>ま、待ってください……！",
 		"tr_text": "",
 		"fileID": 3
@@ -9442,7 +9442,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Seraphy",
+		"tr_name": "Annette",
 		"jp_text": "ヘイズ・ドラールは造龍よ。<%br>まさか、龍族を……",
 		"tr_text": "",
 		"fileID": 3
@@ -9450,7 +9450,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "とにかく急ぎましょう、リーダー！<%br>惑星アムドゥスキアに……！",
 		"tr_text": "",
 		"fileID": 3
@@ -9458,7 +9458,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "ごほんっ！　んーんーっ！<%br>ところで、子供はどうする？",
 		"tr_text": "",
 		"fileID": 3
@@ -9466,7 +9466,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "こどもー？",
 		"tr_text": "",
 		"fileID": 3
@@ -9474,7 +9474,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "Duna",
+		"tr_name": "Calamity",
 		"jp_text": "君、君のことだ！　君は子供だろ？<%br>そして近寄るな！　少しボクから離れたまえ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9482,7 +9482,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "どうするって……戦いに連れて行くわけには<%br>いかねーだろ。置いていこうぜ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9490,7 +9490,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "……うーん。<%br>いやぁ……でもねぇ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9498,7 +9498,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……連れて行きましょう。そうしないとまずい。<%br>そうでしょう、ブルーノ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9506,7 +9506,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "……ど、ど、どういうことだってば？",
 		"tr_text": "",
 		"fileID": 3
@@ -9514,7 +9514,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "ん……？<%br>連れてくのは、危ないですよ……ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -9522,7 +9522,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "……ま！　こっからはアムドゥスキアに<%br>移動してから、説明するよ。行こうか！",
 		"tr_text": "",
 		"fileID": 3
@@ -9554,7 +9554,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "……トランスエネミーのデュナや、アークスに<%br>危害を加えたオレは、このままではいられない？",
 		"tr_text": "",
 		"fileID": 3
@@ -9562,7 +9562,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ、今はまだ貴方もアークスに害を<%br>加えたウェポノイドだとは報告していないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9578,7 +9578,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "存在が偉い奴に知られると<%br>こんな子供まで、検査されたりすんのかよ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9586,7 +9586,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "はははーん！　シュトラ、君は馬鹿か。<%br>いや、馬鹿だ。わかっていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -9618,7 +9618,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "黙ってカラミティ。十分よ。確かに<%br>こうして任務に連れて来るのは危険だけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -9626,7 +9626,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "デュナをひとり置いていくのも、危ない……<%br>ってことですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9634,7 +9634,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "（それに……気になることがある。<%br>　この子の能力は……もしかしたら……）",
 		"tr_text": "",
 		"fileID": 3
@@ -9642,7 +9642,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "でもさ、でもさ！<%br>チームの人数すげー増えるよな？",
 		"tr_text": "",
 		"fileID": 3
@@ -9650,7 +9650,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "はい！　仲間が増えて、うれしいです。<%br>みんなでがんばりましょうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9658,7 +9658,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "がんばる！　<%br>でゅなも、がんばうよー！　まま！",
 		"tr_text": "",
 		"fileID": 3
@@ -9666,7 +9666,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット&ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Annette & Bruno",
 		"jp_text": "……まま？",
 		"tr_text": "",
 		"fileID": 3
@@ -9674,7 +9674,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette & Bruno",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、周囲のエネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 3
@@ -9682,7 +9682,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……なんだか、龍族の様子が……<%br>すこし、いつもと違いますね……",
 		"tr_text": "",
 		"fileID": 3
@@ -9690,7 +9690,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……りゅーぞく？",
 		"tr_text": "",
 		"fileID": 3
@@ -9698,7 +9698,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい。この惑星アムドゥスキアに住んでいる……<%br>……えーっと。",
 		"tr_text": "",
 		"fileID": 3
@@ -9706,7 +9706,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "惑星アムドゥスキアに住む種族のこと。<%br>姿はさまざまだが、全て龍族という種だ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9722,7 +9722,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "おはなしできう。……しゅごいね。<%br>しゅごいねー、まま！",
 		"tr_text": "",
 		"fileID": 3
@@ -9730,7 +9730,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……す、すごいですねぇ。<%br>えぇっと……まま、じゃ……うぅ……",
 		"tr_text": "",
 		"fileID": 3
@@ -9738,7 +9738,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "まま……って。<%br>いつの間にこんな短期間で、母親になったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -9746,7 +9746,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "うぅ……モアがママみたいだって<%br>言ったんですよ。それで……",
 		"tr_text": "",
 		"fileID": 3
@@ -9754,7 +9754,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "だってさぁ、デュナがすっげージェネに懐いて<%br>子守歌うたってーって言うんだぜ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9770,7 +9770,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……子守歌？<%br>デュナという名前……それに……",
 		"tr_text": "",
 		"fileID": 3
@@ -9778,7 +9778,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……母親が、いるのかねぇ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9786,7 +9786,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "母親……です？",
 		"tr_text": "",
 		"fileID": 3
@@ -9794,7 +9794,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "名前なら研究者がつけた可能性がある。<%br>でも、子守歌をこの子が知っているのは……",
 		"tr_text": "",
 		"fileID": 3
@@ -9802,7 +9802,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "誰かが、デュナに子守歌を聞かせていた。<%br>……ということです？",
 		"tr_text": "",
 		"fileID": 3
@@ -9810,7 +9810,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "そうだね。子守歌を歌うのは……まぁ……<%br>普通に考えると、親……母親だろうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -9818,7 +9818,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9826,7 +9826,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……<%br>どーしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -9834,7 +9834,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……えっと……その……<%br>わたし、わたしは……",
 		"tr_text": "",
 		"fileID": 3
@@ -9850,7 +9850,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -9866,7 +9866,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！<%br>君、君は彼らと戦った時、意識がなかったと……",
 		"tr_text": "",
 		"fileID": 3
@@ -9874,7 +9874,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "うるさいな！　なんでオレがお前の質問に<%br>答えないといけないわけ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9882,7 +9882,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "なんでって……<%br>ボクが知りたいからだ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -9890,7 +9890,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……すげー自己中心的で嫌な奴だな。<%br>お前、友達とかいないだろ？",
 		"tr_text": "",
 		"fileID": 3
@@ -9898,7 +9898,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "とも……だち……？",
 		"tr_text": "",
 		"fileID": 3
@@ -9906,7 +9906,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "でゅなー<%br>からみてのともだち！",
 		"tr_text": "",
 		"fileID": 3
@@ -9914,7 +9914,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ケンカすんなって！　なぁ、捕食跡まで<%br>まだあるんだろ？　早く進もうぜ！",
 		"tr_text": "",
 		"fileID": 3
@@ -9922,7 +9922,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "いくよー。",
 		"tr_text": "",
 		"fileID": 3
@@ -9930,7 +9930,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……そうですね。<%br>急ぎましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 3
@@ -9946,7 +9946,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "ひでぇ……な。<%br>食い散らかされちまってる……",
 		"tr_text": "",
 		"fileID": 3
@@ -9954,7 +9954,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "んんー！　ここでも確かに捕食がされた様子。<%br>だが……んん？",
 		"tr_text": "",
 		"fileID": 3
@@ -9962,7 +9962,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "まま……<%br>どーして、こんな……こんな……",
 		"tr_text": "",
 		"fileID": 3
@@ -9970,7 +9970,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 3
@@ -9978,7 +9978,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "んん？<%br>なぜだ。彼女はママ……母親じゃないだろう？",
 		"tr_text": "",
 		"fileID": 3
@@ -9994,7 +9994,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "おい。お前……ほんと、マジで空気読めよ。<%br>バカなの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10002,7 +10002,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "バカ……？　ボクが馬鹿だっていうのか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10010,7 +10010,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "バカだろ、小さい子供相手に何言ってんだ？<%br>お前、利口かもしれねーけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -10026,7 +10026,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "……利口にも<%br>馬鹿が……いるのか……！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10034,7 +10034,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Calamity",
+		"tr_name": "More",
 		"jp_text": "デュナ、あいつらの話とか<%br>聞いちゃダメだぞ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10042,7 +10042,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "だめ？　なの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10050,7 +10050,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ダメだってば。悪い言葉ばっか使ってるからな。<%br>変な言葉とか、覚えそうだってば……",
 		"tr_text": "",
 		"fileID": 3
@@ -10058,7 +10058,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10066,7 +10066,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……どうしたの、暗い顔して？<%br>あっちはあんなに賑やかなのに。",
 		"tr_text": "",
 		"fileID": 3
@@ -10074,7 +10074,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……デュナに、違うよって……その<%br>言えなくって……",
 		"tr_text": "",
 		"fileID": 3
@@ -10090,7 +10090,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "そうね。ずっと一緒にいるわけじゃない。<%br>この一連の事件が解決しても……しなくても。",
 		"tr_text": "",
 		"fileID": 3
@@ -10106,7 +10106,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……はい。",
 		"tr_text": "",
 		"fileID": 3
@@ -10114,7 +10114,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……でも、あの子と別れる時まで、貴方が<%br>母親代わりをしても、いいんじゃないかしら。",
 		"tr_text": "",
 		"fileID": 3
@@ -10130,7 +10130,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……アネットさん、あの！",
 		"tr_text": "",
 		"fileID": 3
@@ -10138,7 +10138,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "どうしたの？　……ジェネ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10146,7 +10146,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "えっと……その……",
 		"tr_text": "",
 		"fileID": 3
@@ -10154,7 +10154,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "おーい！　ジェネー、アネットー！<%br>先に進むってばー！",
 		"tr_text": "",
 		"fileID": 3
@@ -10162,7 +10162,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "あら……もう行かなきゃ。<%br>ジェネ、貴方……",
 		"tr_text": "",
 		"fileID": 3
@@ -10170,7 +10170,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "まま、いこー。<%br>てばー！",
 		"tr_text": "",
 		"fileID": 3
@@ -10178,7 +10178,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10194,7 +10194,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、クォーツドラゴン撃破<%br>お疲れ様です……それにしても、これは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10202,7 +10202,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>こんな場所まで捕食の跡が……",
 		"tr_text": "",
 		"fileID": 3
@@ -10210,7 +10210,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ひどいね……まま。",
 		"tr_text": "",
 		"fileID": 3
@@ -10218,7 +10218,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "確かにな。……セラフィさん<%br>捕食跡の報告が入ったエリアは他に……",
 		"tr_text": "",
 		"fileID": 3
@@ -10226,7 +10226,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "Bruno",
+		"tr_name": "Seraphy",
 		"jp_text": "こ……これは……！",
 		"tr_text": "",
 		"fileID": 3
@@ -10234,7 +10234,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "どうしたんだってば？",
 		"tr_text": "",
 		"fileID": 3
@@ -10242,7 +10242,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "前と同じ反応です……周囲の生体反応が<%br>消滅していっています……",
 		"tr_text": "",
 		"fileID": 3
@@ -10250,7 +10250,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "それって……<%br>ヘイドのときと……同じです。",
 		"tr_text": "",
 		"fileID": 3
@@ -10258,7 +10258,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "はい。ですが、やはり生体反応が……<%br>以前確認したヘイドのものとは異なります。",
 		"tr_text": "",
 		"fileID": 3
@@ -10266,7 +10266,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Seraphy",
+		"tr_name": "Annette",
 		"jp_text": "確か、私たちと別行動していた時も<%br>ヘイドは生体反応を変えたのよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -10274,7 +10274,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！　捕食者としての彼の能力が<%br>生体反応の性質自体を変化させてると仮定できる。",
 		"tr_text": "",
 		"fileID": 3
@@ -10282,7 +10282,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……いい考察ね。<%br>その可能性は十分にあるわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10290,7 +10290,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "だったら、その反応……ヘイドかもしれないじゃん。<%br>そこ、急いだほうがいいんじゃないの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10298,7 +10298,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "だな！　だな！！<%br>リーダー、急ごうぜ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10306,7 +10306,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "いしょ……あえ……？<%br>……いそぐよー、りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10314,7 +10314,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "Duna",
+		"tr_name": "Calamity",
 		"jp_text": "さぁ！　答えるんだっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10322,7 +10322,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……お前、ほんとにうぜーな。",
 		"tr_text": "",
 		"fileID": 3
@@ -10330,7 +10330,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "んっんーっ！　　君は馬鹿だから分かっていない<%br>だろうが、ボクが確認しようとしていることは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10338,7 +10338,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "うぜー？<%br>ばぁか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10346,7 +10346,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……デュナ、だめだってば。<%br>そんな言葉、覚えなくていいからな！",
 		"tr_text": "",
 		"fileID": 3
@@ -10354,7 +10354,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "ないない？",
 		"tr_text": "",
 		"fileID": 3
@@ -10362,7 +10362,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい。<%br>ないない、です！",
 		"tr_text": "",
 		"fileID": 3
@@ -10370,7 +10370,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "自我があるウェポノイドが、記憶がない中で<%br>アークスに攻撃をしたんだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10402,7 +10402,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10410,7 +10410,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "……それは、確かにそうなんだよね。",
 		"tr_text": "",
 		"fileID": 3
@@ -10418,7 +10418,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10426,7 +10426,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……ふぅ？？",
 		"tr_text": "",
 		"fileID": 3
@@ -10434,7 +10434,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "Duna",
+		"tr_name": "Calamity",
 		"jp_text": "つまりそれは！！<%br>新たな技術……力！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10450,7 +10450,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……最高……って<%br>なんだよ……それ……",
 		"tr_text": "",
 		"fileID": 3
@@ -10458,7 +10458,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……あいつやっぱり、変わってるってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -10466,7 +10466,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "なんだか、うれしそうです……<%br>カラミティさん……",
 		"tr_text": "",
 		"fileID": 3
@@ -10474,7 +10474,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "楽しんでる場合じゃないわよ……<%br>エネミーが来るわ、構えなさい！",
 		"tr_text": "",
 		"fileID": 3
@@ -10482,7 +10482,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10490,7 +10490,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "シュトラってば、なかなか強いじゃんかっ！　<%br>……あれ？　どうした？",
 		"tr_text": "",
 		"fileID": 3
@@ -10498,7 +10498,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "……しゅとら？<%br>どーたっの？",
 		"tr_text": "",
 		"fileID": 3
@@ -10506,7 +10506,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "カラミティ、お前……<%br>何が楽しいんだよ……？",
 		"tr_text": "",
 		"fileID": 3
@@ -10514,7 +10514,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "……おや？　どうしたんだ。<%br>君は楽しくないのか、今ボクらは……",
 		"tr_text": "",
 		"fileID": 3
@@ -10522,7 +10522,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "お前なぁっ！！<%br>どこが……っ、どこが楽しいんだよっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10546,7 +10546,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10562,7 +10562,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -10570,7 +10570,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "……そんなことで解決するなら、この世界に<%br>問題なんて起きない。みんな馬鹿だから気づかない。",
 		"tr_text": "",
 		"fileID": 3
@@ -10602,7 +10602,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "……ははは。そうだね、そうしよう。<%br>ささ！　この話は終わりなっ？",
 		"tr_text": "",
 		"fileID": 3
@@ -10610,7 +10610,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "ん……？<%br>なんだ、この空気は……みんな……どうした？",
 		"tr_text": "",
 		"fileID": 3
@@ -10634,7 +10634,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……カラミティ、貴方が賢いなら分かるはずよ。<%br>貴方が、人よりずっと賢いなら……",
 		"tr_text": "",
 		"fileID": 3
@@ -10658,7 +10658,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10666,7 +10666,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "いなかったかしら？　貴方の発見や……<%br>気づきを無視し、蔑ろにした人間は？",
 		"tr_text": "",
 		"fileID": 3
@@ -10674,7 +10674,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "……っ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -10690,7 +10690,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "人は……見てきた景色がみんな違う。<%br>経験や体験でしか、わからないことがある。",
 		"tr_text": "",
 		"fileID": 3
@@ -10706,7 +10706,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "……ボクは……その……<%br>よく、嫌な奴だ……と言われる。",
 		"tr_text": "",
 		"fileID": 3
@@ -10722,7 +10722,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "なんだよ……気持ちわりぃな……<%br>変な奴……",
 		"tr_text": "",
 		"fileID": 3
@@ -10746,7 +10746,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "うーん……そりゃあ、仲間が捕食されてるんだ。<%br>警戒もするだろうさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -10770,7 +10770,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "……どうしたんだよ、おっさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -10778,7 +10778,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "……はは。<%br>いや……おっさんでも、いいけど……",
 		"tr_text": "",
 		"fileID": 3
@@ -10794,7 +10794,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "Bruno",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -10810,7 +10810,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "たのしーね、ぶーの！<%br>ねぇー？",
 		"tr_text": "",
 		"fileID": 3
@@ -10818,7 +10818,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "ぶーの？　……あー、うん……たのしい？<%br>うんうん、楽しいねぇ。",
 		"tr_text": "",
 		"fileID": 3
@@ -10826,7 +10826,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "……ヘイドとやらは、捕食によって能力を<%br>強化する。彼にすれば、全ての生命体は……",
 		"tr_text": "",
 		"fileID": 3
@@ -10842,7 +10842,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Calamity",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10850,7 +10850,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -10858,7 +10858,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……「食べる。」<%br>それに理由がいるのか？",
 		"tr_text": "",
 		"fileID": 3
@@ -10882,7 +10882,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドは……食べることに「理由」がいるのかって<%br>そう言いました。",
 		"tr_text": "",
 		"fileID": 3
@@ -10890,7 +10890,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -10898,7 +10898,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "彼は、アークスに強い敵意をもっています。<%br>わたし達アークスを殺すためには……",
 		"tr_text": "",
 		"fileID": 3
@@ -10914,7 +10914,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "ヘイド……あいつが生まれた経緯が……<%br>アークスへの殺意に関係してるんだろうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -10922,7 +10922,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "リーダー、ジェネ。私たちはロードのアジトで<%br>ブルーノの上司……情報部の「次席」に会った。",
 		"tr_text": "",
 		"fileID": 3
@@ -10954,7 +10954,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "龍族を改造する……<%br>そんなことができるのかよ！？",
 		"tr_text": "",
 		"fileID": 3
@@ -10962,7 +10962,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "その組織って……",
 		"tr_text": "",
 		"fileID": 3
@@ -10970,7 +10970,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "「虚空機関」。<%br>今は解体された、巨大組織……",
 		"tr_text": "",
 		"fileID": 3
@@ -10978,7 +10978,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "……虚空機関。",
 		"tr_text": "",
 		"fileID": 3
@@ -10986,7 +10986,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ぼーいど？",
 		"tr_text": "",
 		"fileID": 3
@@ -10994,7 +10994,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "ヴォイド……って、いうのよ。<%br>そこではダーカー因子の研究が行われていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11010,7 +11010,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "虚空機関の研究で生まれた<%br>ヘイズ・ドラールは、空間転移の力を持っていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11034,7 +11034,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "そんで……トランスエネミーとして<%br>奴が生まれた……ってことかよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11042,7 +11042,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "そのうえ、ダーカー以外も捕食することで<%br>能力を強化できる。ほんと……厄介な力よね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11050,7 +11050,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "あいつ……だから、仲間のウェポノイドを……",
 		"tr_text": "",
 		"fileID": 3
@@ -11058,7 +11058,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "…………？",
 		"tr_text": "",
 		"fileID": 3
@@ -11066,7 +11066,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "だから、クシャネビュラを喰ったんだ。<%br>それにあいつは、造龍だっていっても……",
 		"tr_text": "",
 		"fileID": 3
@@ -11082,7 +11082,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……クシャネビュラ……を……食べた？",
 		"tr_text": "",
 		"fileID": 3
@@ -11090,7 +11090,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11098,7 +11098,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11106,7 +11106,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "あ、えっと……<%br>う……うん……",
 		"tr_text": "",
 		"fileID": 3
@@ -11114,7 +11114,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "そ……そっか。<%br>……アイツ……そっか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11122,7 +11122,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ……！<%br>んーっ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11130,7 +11130,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……どうしたの？",
 		"tr_text": "",
 		"fileID": 3
@@ -11138,7 +11138,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "いえ、いえいえ！<%br>なんでもない。そう……なんでもないっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11154,7 +11154,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Calamity",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、ウォルガーダ撃破<%br>おめでとうございます。",
 		"tr_text": "",
 		"fileID": 3
@@ -11170,7 +11170,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……急がないと、ですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11178,7 +11178,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "移動スピードが上がってるな。<%br>これも、捕食で能力が上がってるせいなのか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11186,7 +11186,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "Bruno",
+		"tr_name": "Seraphy",
 		"jp_text": "おそらく、そうだと。……龍祭壇エリアに進んだ<%br>生体反応は、フォトン量を増大させています。",
 		"tr_text": "",
 		"fileID": 3
@@ -11194,7 +11194,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "急ごうぜ、ヘイドのやつ<%br>どんどん強くなっちゃうんだろ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11202,7 +11202,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "急ぎましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 3
@@ -11210,7 +11210,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "りだ！　いしょぐよっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11218,7 +11218,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん……待ってください！<%br>これは……そんな、まさか……",
 		"tr_text": "",
 		"fileID": 3
@@ -11226,7 +11226,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Seraphy",
+		"tr_name": "Annette",
 		"jp_text": "……何かあったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -11234,7 +11234,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "……新たな捕食の報告が入りました。",
 		"tr_text": "",
 		"fileID": 3
@@ -11242,7 +11242,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "新たなって……それって……",
 		"tr_text": "",
 		"fileID": 3
@@ -11250,7 +11250,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "惑星ウォパルで、捕食事件の調査を始めた<%br>別部隊からの報告です……",
 		"tr_text": "",
 		"fileID": 3
@@ -11266,7 +11266,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "海王種……？　ウォパルは確か……<%br>カラミティさんが捕食を確認した惑星……",
 		"tr_text": "",
 		"fileID": 3
@@ -11274,7 +11274,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "んーっ！　やはり、あの惑星にいるんだ！<%br>まだ見ぬトランスエネミーが！",
 		"tr_text": "",
 		"fileID": 3
@@ -11298,7 +11298,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "…………<%br>お、オレも……オレもヘイドを追いたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -11306,7 +11306,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "とはいえ、ウォパルも放ってはおけないな。<%br>……そうだ、こうしたらどうだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11322,7 +11322,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "そして私たちが、惑星ウォパルへ行く……<%br>ということね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11330,7 +11330,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……それなら、俺たちでウォパルに向かう。<%br>アネット、カラミティ……それでいいよな？",
 		"tr_text": "",
 		"fileID": 3
@@ -11338,7 +11338,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ。<%br>そうね……カラミティ行きましょう。",
 		"tr_text": "",
 		"fileID": 3
@@ -11346,7 +11346,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "で、でもさ！　龍祭壇エリアにいるのは<%br>きっとヘイドのやつだけどさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11362,7 +11362,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ブルーノ",
-		"tr_name": "More",
+		"tr_name": "Bruno",
 		"jp_text": "なーに、おチビ。心配してくれてるわけ？<%br>あははは……大丈夫だって。",
 		"tr_text": "",
 		"fileID": 3
@@ -11370,7 +11370,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "そうよ。心配いらないわ。<%br>危ないと思えば、すぐに撤退する……",
 		"tr_text": "",
 		"fileID": 3
@@ -11378,7 +11378,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！<%br>それより君たちも、十分注意するように！",
 		"tr_text": "",
 		"fileID": 3
@@ -11386,7 +11386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Calamity",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん、ブルーノさん……<%br>カラミティさん、気を付けてくださいね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11394,7 +11394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "きおつけて、ね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11426,7 +11426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "えぇ。デュナも……リーダーやジェネの側から<%br>離れちゃダメよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11434,7 +11434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "ぶーの……ぶーのねぇ……<%br>アネットは呼べるようになってるのに……",
 		"tr_text": "",
 		"fileID": 3
@@ -11442,7 +11442,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "こ、子供……君は貴重なトランスエネミーの<%br>幼体だ。ケガに気を付けるように……",
 		"tr_text": "",
 		"fileID": 3
@@ -11450,7 +11450,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "はぁい！<%br>でゅな、ままといっしょ、いるねー。",
 		"tr_text": "",
 		"fileID": 3
@@ -11458,7 +11458,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "え……！<%br>は、はい……そうですね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11466,7 +11466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……ジェネ。<%br>ちょっと……",
 		"tr_text": "",
 		"fileID": 3
@@ -11482,7 +11482,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11490,7 +11490,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "貴方は……<%br>あの子の本当の母親にはなれないわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11514,7 +11514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "だって……わ……わたしは<%br>本当の母親……お母さんじゃないです……",
 		"tr_text": "",
 		"fileID": 3
@@ -11522,7 +11522,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ザッカードは貴方に……一時的ではあったけど<%br>両親から受けた愛情の記憶を与えた。",
 		"tr_text": "",
 		"fileID": 3
@@ -11538,7 +11538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "…………！",
 		"tr_text": "",
 		"fileID": 3
@@ -11554,7 +11554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "身を挺して、デュナを助けたんでしょう？<%br>モアから聞いたわ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11578,7 +11578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……アネットさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -11586,7 +11586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……そんな顔しないの。<%br>それじゃあ、もう行くわ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11594,7 +11594,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "あ、アネットさん……！<%br>ブルーノさん、カラミティさん、気を付けて。",
 		"tr_text": "",
 		"fileID": 3
@@ -11602,7 +11602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……えぇ。貴方たちもね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11610,7 +11610,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "惑星ウォパルッ！！<%br>んーっ！　やはりここに「捕食者」がいたんだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11626,7 +11626,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "そうだな。……ヘイドとは違う。<%br>目撃情報が正しければ、海王種ってことは……",
 		"tr_text": "",
 		"fileID": 3
@@ -11634,7 +11634,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "あらブルーノ……めずらしく<%br>緊張してるのかしら？　余裕がなさそうね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11642,7 +11642,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11658,7 +11658,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "モア",
-		"tr_name": "Bruno",
+		"tr_name": "More",
 		"jp_text": "でもさでもさ、捕食者がふたりいるってことは<%br>うーんっと、えっと……",
 		"tr_text": "",
 		"fileID": 3
@@ -11666,7 +11666,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "うんっとー……えっとぉ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11674,7 +11674,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドの……仲間でしょうか。",
 		"tr_text": "",
 		"fileID": 3
@@ -11682,7 +11682,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11690,7 +11690,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "喰らいつぶしてやりたいが、今は……<%br>早く食料をもって帰るのが先だ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11698,7 +11698,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "食料……？<%br>持って、帰る……？",
 		"tr_text": "",
 		"fileID": 3
@@ -11722,7 +11722,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "ヘイドみたいに<%br>すっごい強いかもしれないよな……？",
 		"tr_text": "",
 		"fileID": 3
@@ -11738,7 +11738,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "しんぱい……だね。",
 		"tr_text": "",
 		"fileID": 3
@@ -11746,7 +11746,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -11770,7 +11770,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……そうですね！<%br>急ぎましょう！",
 		"tr_text": "",
 		"fileID": 3
@@ -11786,7 +11786,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま、だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 3
@@ -11794,7 +11794,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11802,7 +11802,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -11810,7 +11810,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "身を挺して、デュナを助けたんでしょう？<%br>モアから聞いたわ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11826,7 +11826,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……はい、大丈夫です。<%br>デュナは優しい子ですね。ありがとう。",
 		"tr_text": "",
 		"fileID": 3
@@ -11834,7 +11834,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ふへへへへ～。<%br>ほめられたぁ！",
 		"tr_text": "",
 		"fileID": 3
@@ -11842,7 +11842,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "でもさ……凶暴化してない龍族たちも<%br>すごくピリピリしてるな……",
 		"tr_text": "",
 		"fileID": 3
@@ -11850,7 +11850,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "仕方ねーよ。ヘイド……ヘイズ・ドラールは<%br>龍族と見た目が似てる。",
 		"tr_text": "",
 		"fileID": 3
@@ -11874,7 +11874,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "そ、そうだよな……う、うん。<%br>オレも、そう思ってたってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -11882,7 +11882,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "モア……わかってんのか？　<%br>ウェポノイドはトランスエネミーと同じだぞ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11906,7 +11906,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……シュトラ。",
 		"tr_text": "",
 		"fileID": 3
@@ -11930,7 +11930,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "あ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -11938,7 +11938,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……リーダー。<%br>そう……そうですよ、シュトラさん。",
 		"tr_text": "",
 		"fileID": 3
@@ -11954,7 +11954,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "べ、べつに怖がってなんか……ねーよ。<%br>……そうなっても仕方ないって思ってる。",
 		"tr_text": "",
 		"fileID": 3
@@ -11962,7 +11962,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "仕方ない、なんてこと……ないです。",
 		"tr_text": "",
 		"fileID": 3
@@ -11986,7 +11986,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "どうして……アンタ……",
 		"tr_text": "",
 		"fileID": 3
@@ -11994,7 +11994,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……そのために<%br>一緒にがんばりましょう！　ね？",
 		"tr_text": "",
 		"fileID": 3
@@ -12002,7 +12002,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "……あぁ、そう……だな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12010,7 +12010,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……さ、みんなでヘイドを捕まえましょう。<%br>きっと解決できますよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12026,7 +12026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "これは……",
 		"tr_text": "",
 		"fileID": 3
@@ -12034,7 +12034,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "間違いない。ボクが発見して<%br>報告をあげてきた捕食跡と合致する。",
 		"tr_text": "",
 		"fileID": 3
@@ -12042,7 +12042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……私たちが今まで見てきた「喰い跡」とは<%br>どうやら、大分違うようね。",
 		"tr_text": "",
 		"fileID": 3
@@ -12050,7 +12050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "そうだね。ヘイドとは違う「捕食者」……<%br>おそらくそいつも、トランスエネミー……",
 		"tr_text": "",
 		"fileID": 3
@@ -12058,7 +12058,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12074,7 +12074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……アネットさん。わたし達も、もうすぐ<%br>ヘイド……捕食者の生体反応に追いつきます。",
 		"tr_text": "",
 		"fileID": 3
@@ -12082,7 +12082,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……そう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12090,7 +12090,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "あねっとぉ？<%br>どったの？",
 		"tr_text": "",
 		"fileID": 3
@@ -12098,7 +12098,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12114,7 +12114,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネット……さん。",
 		"tr_text": "",
 		"fileID": 3
@@ -12130,7 +12130,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "そ、そうだぞ！　だから、大丈夫だってば！<%br>それよりアネットこそ、気をつけろよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12138,7 +12138,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "More",
+		"tr_name": "Bruno",
 		"jp_text": "はーいはいはい。なーんかアネットが<%br>しんみりしちゃってるけど、大丈夫よ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12162,7 +12162,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "……セラフィさん<%br>捕食者の反応は近いんですよね？",
 		"tr_text": "",
 		"fileID": 3
@@ -12170,7 +12170,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "はい、すぐ近くです。",
 		"tr_text": "",
 		"fileID": 3
@@ -12178,7 +12178,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "Seraphy",
+		"tr_name": "Duna",
 		"jp_text": "いしょぎましょ！<%br>りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12186,7 +12186,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "グゥウオオオオオー！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12194,7 +12194,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "これ……は……",
 		"tr_text": "",
 		"fileID": 3
@@ -12202,7 +12202,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ひゅぅ……<%br>こわ、い……",
 		"tr_text": "",
 		"fileID": 3
@@ -12210,7 +12210,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ひどい……ってば……<%br>お前がっ……お前がやったのか！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12226,7 +12226,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "……また……お前らか。",
 		"tr_text": "",
 		"fileID": 3
@@ -12250,7 +12250,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ヘイズ・ドラールは……造龍なんですよね？<%br>なのに……どうして、龍族を……",
 		"tr_text": "",
 		"fileID": 3
@@ -12258,7 +12258,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "また、お前が納得する<%br>理由が欲しいのか……くだらない。",
 		"tr_text": "",
 		"fileID": 3
@@ -12266,7 +12266,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "あなたには……アークスへの殺意しか<%br>ないんじゃないかって……思っていた。",
 		"tr_text": "",
 		"fileID": 3
@@ -12282,7 +12282,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12290,7 +12290,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -12298,7 +12298,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "喰らいつぶしてやりたいが、今は……<%br>早く食料をもって帰るのが先だ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12306,7 +12306,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "でも、あなたには……アークスへの殺意よりも<%br>優先する……仲間がいる。",
 		"tr_text": "",
 		"fileID": 3
@@ -12322,7 +12322,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "オンナ……お前、何が言いたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -12330,7 +12330,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……あなたは、あなたの意思で……<%br>こんなことをしているんです？",
 		"tr_text": "",
 		"fileID": 3
@@ -12338,7 +12338,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12362,7 +12362,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "お……おい、ジェネ……！<%br>アンタ何してんだ、離れろ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12378,7 +12378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>デュナ……だいじょうぶ、です……？",
 		"tr_text": "",
 		"fileID": 3
@@ -12386,7 +12386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……まま、うぅ……<%br>でゅな、だいじょうぶよ……まま。",
 		"tr_text": "",
 		"fileID": 3
@@ -12394,7 +12394,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12402,7 +12402,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "ひゃっ！！",
 		"tr_text": "",
 		"fileID": 3
@@ -12410,7 +12410,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "デュナ……リーダーの後ろに<%br>かくれてろってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -12426,7 +12426,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "……この力……今までの粗雑なものとは……<%br>効果が違うな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12442,7 +12442,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12474,7 +12474,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12482,7 +12482,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12514,7 +12514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "お前が、この隊の将か。",
 		"tr_text": "",
 		"fileID": 3
@@ -12530,7 +12530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "まだ……まだ、食べる気ですか？",
 		"tr_text": "",
 		"fileID": 3
@@ -12538,7 +12538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "当たり前だ。お前らを殺せないようでは<%br>アークスを殺し尽くすことはできない……",
 		"tr_text": "",
 		"fileID": 3
@@ -12554,7 +12554,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "ま、まって……！",
 		"tr_text": "",
 		"fileID": 3
@@ -12570,7 +12570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ままっ！<%br>だめ、けが、してう……",
 		"tr_text": "",
 		"fileID": 3
@@ -12578,7 +12578,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>ヘイド……",
 		"tr_text": "",
 		"fileID": 3
@@ -12610,7 +12610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12626,7 +12626,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ブルーノ",
-		"tr_name": "Hade",
+		"tr_name": "Bruno",
 		"jp_text": "ふぅ……ふたりとも、大丈夫か？<%br>いったん報告を入れてから、追跡を続けよう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12634,7 +12634,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "クーナ",
-		"tr_name": "Bruno",
+		"tr_name": "Quna",
 		"jp_text": "……そうですか。捕食者は、２体。<%br>惑星アムドゥスキアの龍族を食らう者。",
 		"tr_text": "",
 		"fileID": 3
@@ -12658,7 +12658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "カラミティ",
-		"tr_name": "Quna",
+		"tr_name": "Calamity",
 		"jp_text": "んんっー！　そう！<%br>ボクが見つけたんだ！　このウォパルでっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12666,7 +12666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "ちょ、おま、今は黙ってろ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12682,7 +12682,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "クーナ",
-		"tr_name": "Bruno",
+		"tr_name": "Quna",
 		"jp_text": "分かりました。<%br>気を付けてください。どうぞ、ご武運を……",
 		"tr_text": "",
 		"fileID": 3
@@ -12690,7 +12690,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "Quna",
+		"tr_name": "Bruno",
 		"jp_text": "……っと！<%br>じゃあ、進むとするか……",
 		"tr_text": "",
 		"fileID": 3
@@ -12698,7 +12698,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの！　あねっと！",
 		"tr_text": "",
 		"fileID": 3
@@ -12706,7 +12706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "うお、今度はどうした？<%br>なんだ……デュナちゃんか……",
 		"tr_text": "",
 		"fileID": 3
@@ -12714,7 +12714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "でゅなもね、つーしん、する。<%br>もしもーし！",
 		"tr_text": "",
 		"fileID": 3
@@ -12722,7 +12722,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ちょっと、デュナってば……<%br>もう、もしもしいいだろ？　代われってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -12730,7 +12730,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "モア……何かあったの？<%br>大丈夫？",
 		"tr_text": "",
 		"fileID": 3
@@ -12738,7 +12738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "大丈夫だってば！<%br>えっとさ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12754,7 +12754,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドは、龍族を捕食して<%br>以前よりずっと……ずっと強くなっていました。",
 		"tr_text": "",
 		"fileID": 3
@@ -12762,7 +12762,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "Gene",
+		"tr_name": "Bruno",
 		"jp_text": "やっぱ、ヘイドだったか……<%br>強くなってるってのは、厄介だね。",
 		"tr_text": "",
 		"fileID": 3
@@ -12770,7 +12770,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ジェネ",
-		"tr_name": "Bruno",
+		"tr_name": "Gene",
 		"jp_text": "わたし達は、ヘイドを追って<%br>龍祭壇エリアのさらに奥に進みます。",
 		"tr_text": "",
 		"fileID": 3
@@ -12778,7 +12778,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "なぁなぁ、ブルーノ。",
 		"tr_text": "",
 		"fileID": 3
@@ -12802,7 +12802,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ブルーノ",
-		"tr_name": "More",
+		"tr_name": "Bruno",
 		"jp_text": "……うーん、いい線いってる気はするけど。<%br>オレは、捕食以外の能力を警戒してるかな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12810,7 +12810,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12818,7 +12818,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "捕食以外？",
 		"tr_text": "",
 		"fileID": 3
@@ -12826,7 +12826,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ブルーノ",
-		"tr_name": "Calamity",
+		"tr_name": "Bruno",
 		"jp_text": "まず、ヘイズ・ドラールには捕食能力がある。<%br>これは個体の能力値を上げる厄介な能力だが……",
 		"tr_text": "",
 		"fileID": 3
@@ -12850,7 +12850,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "Bruno",
+		"tr_name": "Stra",
 		"jp_text": "……それって、ヘイドは空間転移能力を<%br>悪用するために生まれた……ってことだよな。",
 		"tr_text": "",
 		"fileID": 3
@@ -12858,7 +12858,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "そう、つまり……俺たちが追う海王種の捕食者も<%br>捕食以外に能力があるってこと。",
 		"tr_text": "",
 		"fileID": 3
@@ -12866,7 +12866,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "んんっ！　……海王種で<%br>空間転移能力を持つエネミーはいないはずだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12874,7 +12874,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Calamity",
+		"tr_name": "Gene",
 		"jp_text": "じゃあ、ウォパルの捕食者は、空間転移能力<%br>ではない能力を持っている……ってことです？",
 		"tr_text": "",
 		"fileID": 3
@@ -12882,7 +12882,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "そう！　「利用価値の高い能力」をね。<%br>あー、実に楽しみだ！　早く会いたいっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12890,7 +12890,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……お前なっ！<%br>カラミティ！　てめーっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12898,7 +12898,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "からみてー、しゅとらー！<%br>あしょぶのー？",
 		"tr_text": "",
 		"fileID": 3
@@ -12906,7 +12906,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……えっ？<%br>いや……遊んでるわけじゃ……",
 		"tr_text": "",
 		"fileID": 3
@@ -12914,7 +12914,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "はーいはい、ストップストップ。<%br>どうどうどう、落ち着いて。",
 		"tr_text": "",
 		"fileID": 3
@@ -12938,7 +12938,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "またねー、ぶーの！",
 		"tr_text": "",
 		"fileID": 3
@@ -12946,7 +12946,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……くっそ！<%br>カラミティの奴……ホントむかつく。",
 		"tr_text": "",
 		"fileID": 3
@@ -12954,7 +12954,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "落ち着けってば。シュトラ……<%br>カラミティのこと、許してやれよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -12962,7 +12962,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "でゅなも<%br>ゆるしたらいいよーって、おもう。",
 		"tr_text": "",
 		"fileID": 3
@@ -12970,7 +12970,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -12986,7 +12986,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "うふふ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13002,7 +13002,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "……わかったよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13010,7 +13010,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "よっしゃ！　じゃあヘイドのやつ追うぞ！<%br>いっくぜー！",
 		"tr_text": "",
 		"fileID": 3
@@ -13018,7 +13018,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "いきましょー！<%br>りだ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13026,7 +13026,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "周辺エネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 3
@@ -13042,7 +13042,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "……おうっ！<%br>がんばるってば！",
 		"tr_text": "",
 		"fileID": 3
@@ -13050,7 +13050,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "がんばるよー！",
 		"tr_text": "",
 		"fileID": 3
@@ -13066,7 +13066,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……え？<%br>あ……いや、べつに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13074,7 +13074,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "Stra",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13082,7 +13082,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "じゃあ、ウォパルの捕食者は、空間転移能力<%br>ではない能力を持っている……ってことです？",
 		"tr_text": "",
 		"fileID": 3
@@ -13090,7 +13090,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13106,7 +13106,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "",
-		"tr_name": "Stra",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13114,7 +13114,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……だが……馬鹿ではない。<%br>だから……さっきの発言は、撤回する。",
 		"tr_text": "",
 		"fileID": 3
@@ -13122,7 +13122,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "……なんなんだよ、アイツ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13170,7 +13170,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "へぇ……シュトラ、なんだかんだ言っても<%br>カラミティのこと心配してんだなっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13178,7 +13178,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……あ、あのさ。<%br>リーダー、アンタが強いのは分かった。",
 		"tr_text": "",
 		"fileID": 3
@@ -13202,7 +13202,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "ぶーの！　つよーいよ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13210,7 +13210,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "そうそうっ！　でも、なんだかんだ言って<%br>カラミティのこと心配してんだなぁ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13218,7 +13218,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……っ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13226,7 +13226,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……シュトラ、さん？",
 		"tr_text": "",
 		"fileID": 3
@@ -13234,7 +13234,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "そ、そんなんじゃ……ねーよ。<%br>別に……",
 		"tr_text": "",
 		"fileID": 3
@@ -13258,7 +13258,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……へへへっ！<%br>シュトラのやつも、意外と優しいんだな。",
 		"tr_text": "",
 		"fileID": 3
@@ -13266,7 +13266,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "でゅな、しってるよ。<%br>しゅとら、いいこいいこっ！",
 		"tr_text": "",
 		"fileID": 3
@@ -13274,7 +13274,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "うんうんっ！<%br>素直じゃないのは、照れてるんだってば。",
 		"tr_text": "",
 		"fileID": 3
@@ -13282,7 +13282,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "てれれる？<%br>てれ、てる？？",
 		"tr_text": "",
 		"fileID": 3
@@ -13290,7 +13290,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "おう！　はずかしいって思って<%br>かっこつけてるんだ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13298,7 +13298,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……おい、モア。マジで恥ずかしいから<%br>そんなことデュナに説明すんなよ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13306,7 +13306,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "うふふふ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13338,7 +13338,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13354,7 +13354,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "ブルーノ",
-		"tr_name": "Stra",
+		"tr_name": "Bruno",
 		"jp_text": "……おいおい、嫌になっちゃうね。<%br>アネット……カラミティ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13370,7 +13370,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……マギサ・メデューナ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13378,7 +13378,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "？？？",
-		"tr_name": "Annette",
+		"tr_name": "???",
 		"jp_text": "グォゴォゴォゴォッ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13386,7 +13386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "???",
+		"tr_name": "Annette",
 		"jp_text": "あの女性……<%br>……これは……歌？",
 		"tr_text": "",
 		"fileID": 3
@@ -13394,7 +13394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "？？？",
-		"tr_name": "Annette",
+		"tr_name": "???",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 3
@@ -13426,7 +13426,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "???",
+		"tr_name": "Annette",
 		"jp_text": "彼女が……私たちが追っていたトランスエネミー。<%br>……でも……なにこれ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13450,7 +13450,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……あぁ。<%br>ふたりとも、下がってろ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13466,7 +13466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "話……<%br>あなたたちは、一体……",
 		"tr_text": "",
 		"fileID": 3
@@ -13474,7 +13474,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ブルーノ",
-		"tr_name": "???",
+		"tr_name": "Bruno",
 		"jp_text": "俺たちは、アークスだ。<%br>一緒にアークスシップに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13482,7 +13482,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "アークス……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13490,7 +13490,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "???",
+		"tr_name": "Stra",
 		"jp_text": "……いた。<%br>アイツまた、龍族を喰ったんだ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13498,7 +13498,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13506,7 +13506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "わたしは、あなたがどうして<%br>アークスを憎むのか……知りたい。",
 		"tr_text": "",
 		"fileID": 3
@@ -13538,7 +13538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13562,7 +13562,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "やく……そく……？",
 		"tr_text": "",
 		"fileID": 3
@@ -13570,7 +13570,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "貴様らアークスが生み出した。",
 		"tr_text": "",
 		"fileID": 3
@@ -13602,7 +13602,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "……まま。<%br>こわい、こわい……",
 		"tr_text": "",
 		"fileID": 3
@@ -13610,7 +13610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫です。デュナ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13642,7 +13642,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "くっ……<%br>ジェネ、モア……大丈夫か？",
 		"tr_text": "",
 		"fileID": 3
@@ -13650,7 +13650,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "う、うん……大丈夫ってば……",
 		"tr_text": "",
 		"fileID": 3
@@ -13658,7 +13658,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "くっそ！　前のヘイドとの戦いで、ふたりとも……<%br>どうすんだよ、アイツまた強くなってる……",
 		"tr_text": "",
 		"fileID": 3
@@ -13666,7 +13666,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイズ・ドラール",
-		"tr_name": "Stra",
+		"tr_name": "Haze Draal",
 		"jp_text": "グゥウオオオオオー！！",
 		"tr_text": "",
 		"fileID": 3
@@ -13674,7 +13674,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "Haze Draal",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 3
@@ -13690,7 +13690,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Hade",
+		"tr_name": "More",
 		"jp_text": "ど、どうしたんだ……アイツ？<%br>なんで人の姿に、急に戻ったんだ？",
 		"tr_text": "",
 		"fileID": 3
@@ -13698,7 +13698,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "……ティス……今、どこに……",
 		"tr_text": "",
 		"fileID": 3
@@ -13714,7 +13714,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 3
@@ -13722,7 +13722,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "お前が死んだら……俺は……<%br>くっ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13730,7 +13730,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13738,7 +13738,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "ま、まって……！<%br>くっ……うぅ……",
 		"tr_text": "",
 		"fileID": 3
@@ -13746,7 +13746,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……まま……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13754,7 +13754,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "だいじょうぶ……です。<%br>それより、ヘイドが……",
 		"tr_text": "",
 		"fileID": 3
@@ -13762,7 +13762,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "リーダーっ！<%br>ジェネ……！",
 		"tr_text": "",
 		"fileID": 3
@@ -13770,7 +13770,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……どうしました？",
 		"tr_text": "",
 		"fileID": 3
@@ -13778,7 +13778,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……ブルーノ、ブルーノが……っ！<%br>どうしてよ、馬鹿！",
 		"tr_text": "",
 		"fileID": 3
@@ -13786,7 +13786,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "な……は、はは……たしかに馬鹿、かも俺。<%br>まったく……嫌になるよ。",
 		"tr_text": "",
 		"fileID": 3
@@ -13810,7 +13810,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "",
-		"tr_name": "Bruno",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 3
@@ -13818,7 +13818,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "",
+		"tr_name": "Calamity",
 		"jp_text": "……コロス。アークス……コロス……",
 		"tr_text": "",
 		"fileID": 3
@@ -13826,7 +13826,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "貴方……カラミティを……<%br>いえ、シュトラもクシャネビュラも……",
 		"tr_text": "",
 		"fileID": 3
@@ -13842,7 +13842,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "？？？",
-		"tr_name": "Annette",
+		"tr_name": "???",
 		"jp_text": "カラミティ……この者たちは、アークス。<%br>宇宙に害を成す、危険な生命体。",
 		"tr_text": "",
 		"fileID": 3
@@ -13866,7 +13866,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "",
-		"tr_name": "???",
+		"tr_name": "",
 		"jp_text": "それぞれの「理由」",
 		"tr_text": "",
 		"fileID": 3
@@ -13874,7 +13874,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "リーダーっ！<%br>ジェネ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -13882,7 +13882,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……どうしました？",
 		"tr_text": "",
 		"fileID": 4
@@ -13890,7 +13890,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……ブルーノ、ブルーノが……っ！<%br>どうしてよ、馬鹿！",
 		"tr_text": "",
 		"fileID": 4
@@ -13898,7 +13898,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "わたし達が駆け付けたときには<%br>ブルーノさんは、重傷を負い<%br>アネットさんはその場に倒れて<%br>……意識を失っていました。",
 		"tr_text": "",
 		"fileID": 4
@@ -13922,7 +13922,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "……ここ……は？",
 		"tr_text": "",
 		"fileID": 4
@@ -13930,7 +13930,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "アネット……大丈夫かよ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -13938,7 +13938,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……モア、リーダー……<%br>ここは……アークスシップ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -13962,7 +13962,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……おい、無理して起きるなって。<%br>アンタ、意識失ってたんだ。怪我もひどい。",
 		"tr_text": "",
 		"fileID": 4
@@ -13970,7 +13970,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……！<%br>よかった……目が覚めたんですね。",
 		"tr_text": "",
 		"fileID": 4
@@ -13978,7 +13978,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ジェネ……",
 		"tr_text": "",
 		"fileID": 4
@@ -13986,7 +13986,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "今、ブルーノさんの容態について<%br>デュナと一緒に聞いてきたんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -14002,7 +14002,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……そう。よかった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14010,7 +14010,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……わたし達が到着するまでに<%br>何があったか、聞いても大丈夫ですか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14018,7 +14018,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "えぇ……リーダーたちが駆け付けてくれる<%br>までに、起きたことを話すわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14026,7 +14026,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "リーダーたちと離れて<%br>私、ブルーノ、カラミティの３名は<%br>惑星ウォパルへ向かった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14042,7 +14042,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "",
+		"tr_name": "Annette",
 		"jp_text": "（そして……マギサ・メデューナは<%br>　美しい……女性の姿に変わった）",
 		"tr_text": "",
 		"fileID": 4
@@ -14050,7 +14050,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "俺たちは、あんたに危害を加える気はない。<%br>話が聞きたい。",
 		"tr_text": "",
 		"fileID": 4
@@ -14058,7 +14058,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "話……<%br>あなたたちは、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -14066,7 +14066,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ブルーノ",
-		"tr_name": "???",
+		"tr_name": "Bruno",
 		"jp_text": "俺たちは、アークスだ。<%br>一緒にアークスシップに……",
 		"tr_text": "",
 		"fileID": 4
@@ -14074,7 +14074,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "アークス……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14090,7 +14090,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "ブルーノ",
-		"tr_name": "???",
+		"tr_name": "Bruno",
 		"jp_text": "……っ！<%br>アネット、カラミティ……構えろっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14098,7 +14098,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "？？？",
-		"tr_name": "Bruno",
+		"tr_name": "???",
 		"jp_text": "『－－－－－－－－』",
 		"tr_text": "",
 		"fileID": 4
@@ -14106,7 +14106,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "アネット",
-		"tr_name": "???",
+		"tr_name": "Annette",
 		"jp_text": "なに……この声……！？<%br>一体何をしようとしているの……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14114,7 +14114,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "アネット、危ない……っ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14122,7 +14122,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "カラミティ",
-		"tr_name": "Bruno",
+		"tr_name": "Calamity",
 		"jp_text": "コロス……アークス！",
 		"tr_text": "",
 		"fileID": 4
@@ -14130,7 +14130,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "カラミティのヤツ……<%br>くそっ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14138,7 +14138,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "そっか……アネット……<%br>それで……どうなったんだってば？",
 		"tr_text": "",
 		"fileID": 4
@@ -14146,7 +14146,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……それで……ヘイドが現れて<%br>海王種が……途中で……うっ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14154,7 +14154,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "あねっと、いたいの？<%br>だいじょーぶ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14162,7 +14162,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……無理しちゃダメです。<%br>ゆっくり休んでください……",
 		"tr_text": "",
 		"fileID": 4
@@ -14170,7 +14170,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "えぇ……<%br>そうさせて……もらうわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14186,7 +14186,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "惑星ウォパルで遭遇した<%br>新たなトランスエネミー……<%br>アナティスの能力によって<%br>カラミティが「洗脳」されてしまった。",
 		"tr_text": "",
 		"fileID": 4
@@ -14210,7 +14210,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "アナティス……<%br>なぜだ……なぜ、外に出た……",
 		"tr_text": "",
 		"fileID": 4
@@ -14218,7 +14218,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……<%br>お前ひとりを、戦わせるわけにはいかない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14242,7 +14242,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "ふたり、きり……<%br>アナティス……お前……",
 		"tr_text": "",
 		"fileID": 4
@@ -14250,7 +14250,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ブルーノ",
-		"tr_name": "Hade",
+		"tr_name": "Bruno",
 		"jp_text": "……ったく、最悪だな。<%br>アネット……、お前……まだ動けるな？",
 		"tr_text": "",
 		"fileID": 4
@@ -14258,7 +14258,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……え？<%br>えぇ……ブルーノ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14266,7 +14266,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "最悪……だけどね……<%br>お前、先逃げろ……",
 		"tr_text": "",
 		"fileID": 4
@@ -14274,7 +14274,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……っ！<%br>ふざけないで、そんなことできるわけ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14282,7 +14282,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "ジェネちゃんと、おチビに……死ぬなって<%br>言った……お前が、死んだら笑えねーの。",
 		"tr_text": "",
 		"fileID": 4
@@ -14298,7 +14298,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "（私だけじゃ……ヘイドひとりだって<%br>　相手にできない……それなのに……）",
 		"tr_text": "",
 		"fileID": 4
@@ -14314,7 +14314,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "？？？",
-		"tr_name": "Annette",
+		"tr_name": "???",
 		"jp_text": "ウオオオオオーー！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14322,7 +14322,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "???",
+		"tr_name": "Annette",
 		"jp_text": "え……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14330,7 +14330,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "？？？",
-		"tr_name": "Annette",
+		"tr_name": "???",
 		"jp_text": "『……アンタタチヲ助ケテヤル。<%br>　ソノ代ワリ……交換条件ダ』",
 		"tr_text": "",
 		"fileID": 4
@@ -14338,7 +14338,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "???",
+		"tr_name": "Hade",
 		"jp_text": "…………！！<%br>……ノワル・ドラール……なぜ、こんなところに？",
 		"tr_text": "",
 		"fileID": 4
@@ -14354,7 +14354,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 4
@@ -14362,7 +14362,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……腹の子を、危険に晒すな。",
 		"tr_text": "",
 		"fileID": 4
@@ -14378,7 +14378,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Hade",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、惑星ナベリウスの凍土エリアで<%br>新たな捕食の目撃情報が報告されました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14386,7 +14386,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "……どうすんだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14434,7 +14434,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさん……ブルーノさんに、わたし<%br>ずっと前に、言われたことがあるんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -14466,7 +14466,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "ブルーノのおっさんみたいに……<%br>カラミティみたいに、なるかもしれねーんだぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14474,7 +14474,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "それでも……行かなきゃいけないんです。<%br>リーダー、わたしも行きます。",
 		"tr_text": "",
 		"fileID": 4
@@ -14490,7 +14490,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "……カラミティ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14498,7 +14498,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "少し……いいかしら？<%br>リーダー、ジェネ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14506,7 +14506,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……！<%br>どうしました？　大丈夫です？",
 		"tr_text": "",
 		"fileID": 4
@@ -14514,7 +14514,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "大丈夫よ。ありがとう。<%br>それより……",
 		"tr_text": "",
 		"fileID": 4
@@ -14530,7 +14530,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "どういうことだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14538,7 +14538,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "ブルーノの負傷後……",
 		"tr_text": "",
 		"fileID": 4
@@ -14586,7 +14586,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -14594,7 +14594,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……ティス……今、どこに……",
 		"tr_text": "",
 		"fileID": 4
@@ -14610,7 +14610,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "もしかして……ヘイドが食料を持って帰るって<%br>話していたのって、そのアナティスのため……？",
 		"tr_text": "",
 		"fileID": 4
@@ -14618,7 +14618,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "確かにそれだと、アナティスが表に出られない今が<%br>捕まえやすい……ってことか。",
 		"tr_text": "",
 		"fileID": 4
@@ -14626,7 +14626,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "そうよ。アナティスが表に出てこられるように<%br>なったら……更に事態は厄介になる。",
 		"tr_text": "",
 		"fileID": 4
@@ -14634,7 +14634,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "わかった、オレも行くよ……<%br>やるなら……今しかない。",
 		"tr_text": "",
 		"fileID": 4
@@ -14642,7 +14642,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "シュトラ……うん、行こうぜ！<%br>大丈夫だってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -14650,7 +14650,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……う……うん。<%br>そう……だな。",
 		"tr_text": "",
 		"fileID": 4
@@ -14658,7 +14658,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……みんな、それでも十分に気を付けて。<%br>無事を願ってるわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14674,7 +14674,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "はい……行ってきます。<%br>みんなで頑張りましょうね！",
 		"tr_text": "",
 		"fileID": 4
@@ -14682,7 +14682,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "がんばるよー！<%br>りだ、いきましょ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14690,7 +14690,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、周囲のエネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 4
@@ -14698,7 +14698,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "デュナ",
-		"tr_name": "Seraphy",
+		"tr_name": "Duna",
 		"jp_text": "きゅしゅんっ！<%br>しゃ、しゃむい……ね！",
 		"tr_text": "",
 		"fileID": 4
@@ -14706,7 +14706,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……大丈夫です？",
 		"tr_text": "",
 		"fileID": 4
@@ -14714,7 +14714,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "だいじょーばないけど、けど……グズッ<%br>でゅな、だいじょーぶよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14722,7 +14722,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、捕食者の生体反応が<%br>凍土エリアから消えてしまったのですが……",
 		"tr_text": "",
 		"fileID": 4
@@ -14730,7 +14730,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "ええっ！　じゃ、じゃあ戻ろうぜ……<%br>……デュナも風邪ひいちゃうってば。",
 		"tr_text": "",
 		"fileID": 4
@@ -14738,7 +14738,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "ですが……その……<%br>カラミティさんの反応が、確認できました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14746,7 +14746,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -14762,7 +14762,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "セラフィ",
-		"tr_name": "Stra",
+		"tr_name": "Seraphy",
 		"jp_text": "……はい、カラミティさんと同じ反応が<%br>凍土エリア奥地に現れました。",
 		"tr_text": "",
 		"fileID": 4
@@ -14778,7 +14778,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "空間転移能力で、カラミティさんを呼び出して<%br>ヘイドは……帰ったということ、でしょうか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14786,7 +14786,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "……はい、その可能性が高いと思われます。",
 		"tr_text": "",
 		"fileID": 4
@@ -14794,7 +14794,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "……行こうぜ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14818,7 +14818,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "シュトラ……<%br>うん……そうだな！　そうだってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -14826,7 +14826,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさん……<%br>助けましょう、絶対……カラミティさんを！",
 		"tr_text": "",
 		"fileID": 4
@@ -14834,7 +14834,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "うんっ！<%br>いっしょに、たすけよーね。",
 		"tr_text": "",
 		"fileID": 4
@@ -14842,7 +14842,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……あぁ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14850,7 +14850,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……リーダー、ジェネ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14858,7 +14858,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……！<%br>もう、大丈夫なんですか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14866,7 +14866,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "えぇ。どうにか……",
 		"tr_text": "",
 		"fileID": 4
@@ -14882,7 +14882,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "調べものって……<%br>アネット、なに調べてるんだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14890,7 +14890,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "あねっと……しらべもの？",
 		"tr_text": "",
 		"fileID": 4
@@ -14898,7 +14898,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "カラミティを操った女性……アナティス。<%br>その元となったマギサ・メデューナについてよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -14914,7 +14914,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……じゃあ、なんでアナティスは<%br>洗脳なんて力……使えるんだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -14922,7 +14922,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "わからない……ただ、アナティスの元となった<%br>個体に能力が加えられた可能性は、あるわね。",
 		"tr_text": "",
 		"fileID": 4
@@ -14946,7 +14946,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "それってさ！　ぼいどってところと<%br>E.M.A.がいっしょに悪いことしたってことか？",
 		"tr_text": "",
 		"fileID": 4
@@ -14954,7 +14954,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "わるいことー？<%br>だめだよね。まま。",
 		"tr_text": "",
 		"fileID": 4
@@ -14962,7 +14962,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……そう、ですね。悪いことはダメです。<%br>でも、虚空機関は解体されてるんですよね？",
 		"tr_text": "",
 		"fileID": 4
@@ -14970,7 +14970,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "えぇ。E.M.A.が虚空機関の研究を<%br>引き継いだんじゃないか……そう思っている。",
 		"tr_text": "",
 		"fileID": 4
@@ -14986,7 +14986,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……必要って言っても。悪用するためだろ？<%br>カラミティは……そのせいでっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -14994,7 +14994,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "シュトラさん……",
 		"tr_text": "",
 		"fileID": 4
@@ -15002,7 +15002,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "なぁ！　アンタたち……<%br>ずっとE.M.A.のこと追ってたんだろ！？",
 		"tr_text": "",
 		"fileID": 4
@@ -15034,7 +15034,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……シュトラ。<%br>あのさ……えっと……",
 		"tr_text": "",
 		"fileID": 4
@@ -15042,7 +15042,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……っ！　ごめん。<%br>アンタたちが、悪いわけじゃないのに……",
 		"tr_text": "",
 		"fileID": 4
@@ -15058,7 +15058,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……シュトラさん、行きましょう。<%br>カラミティさんを助けに……ね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15066,7 +15066,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15090,7 +15090,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "はい……わたし達は、このままカラミティさんの<%br>反応を追って、凍土エリアを進みます。",
 		"tr_text": "",
 		"fileID": 4
@@ -15098,7 +15098,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "あねっと、またねー。",
 		"tr_text": "",
 		"fileID": 4
@@ -15106,7 +15106,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "？？？",
-		"tr_name": "Duna",
+		"tr_name": "???",
 		"jp_text": "……いいのかよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15114,7 +15114,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "アネット",
-		"tr_name": "???",
+		"tr_name": "Annette",
 		"jp_text": "……あら、何が？",
 		"tr_text": "",
 		"fileID": 4
@@ -15122,7 +15122,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "フェル",
-		"tr_name": "Annette",
+		"tr_name": "Fel",
 		"jp_text": "ジェネに……<%br>アイツらに、オレのこと話さなくて……",
 		"tr_text": "",
 		"fileID": 4
@@ -15130,7 +15130,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アネット",
-		"tr_name": "Fel",
+		"tr_name": "Annette",
 		"jp_text": "……そうね。<%br>今はまだ……話せないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15138,7 +15138,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "……みなさん、止まってください！",
 		"tr_text": "",
 		"fileID": 4
@@ -15154,7 +15154,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "どこだってば？<%br>なーんも周りにいないぞ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15162,7 +15162,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "いないよ？<%br>からみて、いないね、まま？",
 		"tr_text": "",
 		"fileID": 4
@@ -15170,7 +15170,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "お……おい、あれっ！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15178,7 +15178,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "あれは……ヘイドの……",
 		"tr_text": "",
 		"fileID": 4
@@ -15186,7 +15186,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "オ、オ、オ、マエラ……ガ、シタコトダ。<%br>アーアーアー、アークス……",
 		"tr_text": "",
 		"fileID": 4
@@ -15194,7 +15194,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Calamity",
+		"tr_name": "Gene",
 		"jp_text": "カラミティ……さん……",
 		"tr_text": "",
 		"fileID": 4
@@ -15202,7 +15202,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "……カラミティのやつ洗脳されちゃったんだな。<%br>あいつ、オレたちことわかんないのかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -15210,7 +15210,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "違う……洗脳されてても<%br>オレ達の声はカラミティに聞こえてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -15218,7 +15218,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -15226,7 +15226,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "カラミティ……助けてやるよ。<%br>お前を……絶対に……",
 		"tr_text": "",
 		"fileID": 4
@@ -15250,7 +15250,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "アークス……コロス。",
 		"tr_text": "",
 		"fileID": 4
@@ -15258,7 +15258,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "Calamity",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん……気を付けてください！<%br>ウォルガーダが現れました！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15266,7 +15266,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "リーダー、行きましょう！",
 		"tr_text": "",
 		"fileID": 4
@@ -15282,7 +15282,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "カラミティ",
-		"tr_name": "Gene",
+		"tr_name": "Calamity",
 		"jp_text": "コロス……コロス……アー、アークス……",
 		"tr_text": "",
 		"fileID": 4
@@ -15290,7 +15290,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "セラフィ",
-		"tr_name": "Calamity",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、ウォルガーダ撃破<%br>確認できました……",
 		"tr_text": "",
 		"fileID": 4
@@ -15306,7 +15306,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "カラミティ……<%br>痛い思いさせて……悪かったな……",
 		"tr_text": "",
 		"fileID": 4
@@ -15314,7 +15314,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "ア、アークス……利用、実験……ソノ結果ガ<%br>アークス……コロス……コロ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15322,7 +15322,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Calamity",
+		"tr_name": "Duna",
 		"jp_text": "あぶなーよ！<%br>しゅとら！",
 		"tr_text": "",
 		"fileID": 4
@@ -15330,7 +15330,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -15338,7 +15338,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "まだだ……まだ、働いてもらうぞ。<%br>カラミティ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15346,7 +15346,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "Hade",
+		"tr_name": "Calamity",
 		"jp_text": "ヘイドサマ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15354,7 +15354,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ヘイド",
-		"tr_name": "Calamity",
+		"tr_name": "Hade",
 		"jp_text": "戻るぞ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15362,7 +15362,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "おい……！<%br>カラミティ……行くなぁ！",
 		"tr_text": "",
 		"fileID": 4
@@ -15370,7 +15370,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "カラミティ",
-		"tr_name": "Stra",
+		"tr_name": "Calamity",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15378,7 +15378,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "カラ……ミティ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15386,7 +15386,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "あとちょっとのところでさ……<%br>カラミティ助けられたのに……！",
 		"tr_text": "",
 		"fileID": 4
@@ -15394,7 +15394,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……カラミティを、保護できなかったのは残念ね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15410,7 +15410,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "あねっと、もう、へいき！<%br>なのーっ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15418,7 +15418,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……あら、もうそんなにお喋りできるように<%br>なったのね、賢い子。",
 		"tr_text": "",
 		"fileID": 4
@@ -15450,7 +15450,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "そうですよ。アネットさん、無理はダメです。<%br>もう少し休んでた方が……",
 		"tr_text": "",
 		"fileID": 4
@@ -15458,7 +15458,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "あら？　ジェネに言われたくないわ。<%br>いつも無理ばっかりしてるじゃない……",
 		"tr_text": "",
 		"fileID": 4
@@ -15466,7 +15466,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……えっと、え……わ、わたしはそんな！",
 		"tr_text": "",
 		"fileID": 4
@@ -15474,7 +15474,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……ふふ。大丈夫よ、ほんとに。<%br>ありがとう。",
 		"tr_text": "",
 		"fileID": 4
@@ -15482,7 +15482,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "そうだってば！　アネットがいたら<%br>むずかしーことも、すぐわかるし！",
 		"tr_text": "",
 		"fileID": 4
@@ -15490,7 +15490,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "わかるー。あねっとすごーい！",
 		"tr_text": "",
 		"fileID": 4
@@ -15498,7 +15498,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……うふふ。<%br>ありがとう、ふたりとも。",
 		"tr_text": "",
 		"fileID": 4
@@ -15506,7 +15506,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん、ほんとに無理だけは<%br>しないでください。約束……ですよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15514,7 +15514,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ええ。そうするわ。……私を庇って<%br>重傷を負ったブルーノにも……悪いしね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15522,7 +15522,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……ブルーノのおっさん、大丈夫なのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -15530,7 +15530,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……さすがというか、致命傷になりそうな<%br>攻撃は、すべて避けていたみたい。",
 		"tr_text": "",
 		"fileID": 4
@@ -15546,7 +15546,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "ぶ……ブルーノがいなくっても<%br>オレの活躍で余裕だってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -15554,7 +15554,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "もあ、ぶーののぶんも、がんばるんだよねー。<%br>でゅなも、がんばるね。",
 		"tr_text": "",
 		"fileID": 4
@@ -15562,7 +15562,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……デュナ。<%br>貴方、がんばれる？",
 		"tr_text": "",
 		"fileID": 4
@@ -15570,7 +15570,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……ふゅ？<%br>がんばるよ？　でゅな、がんばるよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15578,7 +15578,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15586,7 +15586,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……？<%br>どうしたんです……何か、あったんです……？",
 		"tr_text": "",
 		"fileID": 4
@@ -15594,7 +15594,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、お話のところ<%br>すみません……",
 		"tr_text": "",
 		"fileID": 4
@@ -15610,7 +15610,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "Seraphy",
+		"tr_name": "Annette",
 		"jp_text": "ひとまず……リリーパへ向かいましょう。<%br>……話はそれからでも出来るわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15618,7 +15618,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……そうですね。<%br>惑星リリーパに行きましょう、リーダー！",
 		"tr_text": "",
 		"fileID": 4
@@ -15626,7 +15626,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Gene",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、周辺エネミーの撃破<%br>お疲れ様でした。",
 		"tr_text": "",
 		"fileID": 4
@@ -15634,7 +15634,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "……さっき、シップ内でした話だけど<%br>あの話の続き、してくれるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15642,7 +15642,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "えぇ。……人は、毒を作るときに……<%br>必ず合わせて薬も作るの。",
 		"tr_text": "",
 		"fileID": 4
@@ -15658,7 +15658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "むー？<%br>もあ、わかる？",
 		"tr_text": "",
 		"fileID": 4
@@ -15666,7 +15666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "わかん……わかるってば！<%br>でゅ、デュナには、まだ早いけどなっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -15674,7 +15674,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "つまり……",
 		"tr_text": "",
 		"fileID": 4
@@ -15690,7 +15690,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……アナティスの洗脳が毒なら<%br>それを解くための、薬がいるってことか？",
 		"tr_text": "",
 		"fileID": 4
@@ -15698,7 +15698,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "えぇ、おそらく。アナティスには「解除の能力」を<%br>持たせなかったはず。",
 		"tr_text": "",
 		"fileID": 4
@@ -15706,7 +15706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "……ま、待ってください。<%br>アネットさん……まさか、解除の能力って……",
 		"tr_text": "",
 		"fileID": 4
@@ -15714,7 +15714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……この子が持っているのよ。<%br>シュトラの洗脳を解除したのは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15722,7 +15722,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -15730,7 +15730,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "いいこ、いいこ。<%br>いちゃいの、ないない！",
 		"tr_text": "",
 		"fileID": 4
@@ -15738,7 +15738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "コロ……ころ……",
 		"tr_text": "",
 		"fileID": 4
@@ -15746,7 +15746,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "デュナ、貴方がウェポノイドの洗脳を解く鍵よ。<%br>がんばれる……わね？",
 		"tr_text": "",
 		"fileID": 4
@@ -15754,7 +15754,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "かーぎー？<%br>でゅなは、でゅなだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -15778,7 +15778,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15786,7 +15786,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま？",
 		"tr_text": "",
 		"fileID": 4
@@ -15794,7 +15794,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……あ、アネットさん。<%br>えっと……それって……",
 		"tr_text": "",
 		"fileID": 4
@@ -15802,7 +15802,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ジェネ……私、ずっと考えていたの。<%br>トランスエネミーがなんで生まれたのかって……",
 		"tr_text": "",
 		"fileID": 4
@@ -15834,7 +15834,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -15850,7 +15850,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……中には純粋な好奇心で、研究が進む場合も<%br>あるけれど……トランスエネミーは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15866,7 +15866,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "ヘイドやアナティスが<%br>生まれたって……ことですか。",
 		"tr_text": "",
 		"fileID": 4
@@ -15874,7 +15874,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……ままー？",
 		"tr_text": "",
 		"fileID": 4
@@ -15882,7 +15882,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナのこと、わたしが守ります。<%br>だから……大丈夫です。",
 		"tr_text": "",
 		"fileID": 4
@@ -15890,7 +15890,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……まま、どうしたの？<%br>かなしーの？　どこかいたい？",
 		"tr_text": "",
 		"fileID": 4
@@ -15898,7 +15898,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……だい、じょうぶです。",
 		"tr_text": "",
 		"fileID": 4
@@ -15906,7 +15906,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ジェネ……言いたくはないことだけど……<%br>でも……これからの戦いで、私たちは……",
 		"tr_text": "",
 		"fileID": 4
@@ -15914,7 +15914,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "きっと、アネットさんが言っている……<%br>その通りだと……思います。",
 		"tr_text": "",
 		"fileID": 4
@@ -15978,7 +15978,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま、りだ？<%br>むずかしーおはなしね。でゅなわかんないよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -15986,7 +15986,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "そうだよね……むずかしいこと<%br>わかんないよね……ただね……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16002,7 +16002,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……どう生まれてきたとしても……それだけで<%br>幸せか不幸かなんて、決まらないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16010,7 +16010,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネット……さん……<%br>そう……ですよね。",
 		"tr_text": "",
 		"fileID": 4
@@ -16034,7 +16034,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……まま。<%br>でゅな、ままに、ずっとあいたかったの。",
 		"tr_text": "",
 		"fileID": 4
@@ -16050,7 +16050,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "セラフィ",
-		"tr_name": "Duna",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、捕食者の場所が捕捉できました。<%br>急いでください！",
 		"tr_text": "",
 		"fileID": 4
@@ -16058,7 +16058,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "……はい！<%br>リーダー、みなさん、行きましょう！",
 		"tr_text": "",
 		"fileID": 4
@@ -16066,7 +16066,7 @@
 	{
 		"eventNo": "33",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "いきましょー！",
 		"tr_text": "",
 		"fileID": 4
@@ -16074,7 +16074,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……<%br>これは……",
 		"tr_text": "",
 		"fileID": 4
@@ -16082,7 +16082,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "ひどいな……ここら一帯のリリーパ族……<%br>もしかして……全部……",
 		"tr_text": "",
 		"fileID": 4
@@ -16090,7 +16090,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16098,7 +16098,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま、だいじょーぶ？<%br>どーしたの、かなしいの？　おこってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -16106,7 +16106,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。<%br>うん……悲しいし、怒ってます。",
 		"tr_text": "",
 		"fileID": 4
@@ -16122,7 +16122,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -16130,7 +16130,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "なぁ、アネット。あのさ、デュナがその……<%br>アナティスの能力解除のために……えっと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16146,7 +16146,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "ええ。……それも、アナティスのあとに<%br>デュナが生まれたんだと、私は考えてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -16154,7 +16154,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Annette",
+		"tr_name": "More",
 		"jp_text": "だったらさ、ダンテとか、フェルとかレヴィ<%br>みたいな……えっと……だからさ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16170,7 +16170,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "……そうね。でも<%br>それも目的の邪魔になるなら話は別。",
 		"tr_text": "",
 		"fileID": 4
@@ -16186,7 +16186,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……へいど……<%br>あなてぅ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16194,7 +16194,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "敵の名前だってば！<%br>覚えておいた方が、いいぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16202,7 +16202,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "はいっ！<%br>おぼえるよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16210,7 +16210,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "それってさ、えっと……ヘイドはアナティスの<%br>能力を利用、しよーとしてんのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -16218,7 +16218,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "私は……そうね……<%br>そうだと、思っているわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16226,7 +16226,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "わたしには……<%br>そうは見えませんでした。",
 		"tr_text": "",
 		"fileID": 4
@@ -16250,7 +16250,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "助けに……<%br>確かに……あの時……",
 		"tr_text": "",
 		"fileID": 4
@@ -16266,7 +16266,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16274,7 +16274,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "アナティス、下がれ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16282,7 +16282,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16290,7 +16290,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……腹の子を、危険に晒すな。",
 		"tr_text": "",
 		"fileID": 4
@@ -16298,7 +16298,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "Hade",
+		"tr_name": "Annette",
 		"jp_text": "……アナティスは……身ごもってる。<%br>なんで私、こんな大事なこと……",
 		"tr_text": "",
 		"fileID": 4
@@ -16306,7 +16306,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "子供……ヘイドは、アナティスを<%br>やっぱり守ろうと……している。",
 		"tr_text": "",
 		"fileID": 4
@@ -16314,7 +16314,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "……デュナが、もしアイツらの仲間でもさ<%br>優先順位があるんだろ……ヘイドにも。",
 		"tr_text": "",
 		"fileID": 4
@@ -16338,7 +16338,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……あら、随分大人びたことを言うのね。",
 		"tr_text": "",
 		"fileID": 4
@@ -16346,7 +16346,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……ふん、ガキ扱いすんな。<%br>オレは、モアとはちげーんだよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16354,7 +16354,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "なっ！　なんだってー！",
 		"tr_text": "",
 		"fileID": 4
@@ -16362,7 +16362,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "……！！<%br>デュナ……危ないっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16370,7 +16370,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "わぁっ……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16378,7 +16378,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "お前らを……<%br>このままにはしておけない……",
 		"tr_text": "",
 		"fileID": 4
@@ -16394,7 +16394,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "ひぅ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16402,7 +16402,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "カラミティ",
-		"tr_name": "Duna",
+		"tr_name": "Calamity",
 		"jp_text": "コロ、コロス……アークスハ<%br>宇宙ニ害ヲナス……",
 		"tr_text": "",
 		"fileID": 4
@@ -16410,7 +16410,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "カラミティ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16426,7 +16426,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "ふゅ？<%br>えっと……えっとぉ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16434,7 +16434,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "おい、シュトラ……<%br>そんな急にデュナに言ったって……",
 		"tr_text": "",
 		"fileID": 4
@@ -16442,7 +16442,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -16450,7 +16450,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "そいつの能力に気づいたか……<%br>やはり邪魔だな、デュナ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16466,7 +16466,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16474,7 +16474,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "く……うっ……アークス、アークスッ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16490,7 +16490,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "カラミティ",
-		"tr_name": "Hade",
+		"tr_name": "Calamity",
 		"jp_text": "アーク……ヘイド……サマ……<%br>アークス……コロ……",
 		"tr_text": "",
 		"fileID": 4
@@ -16498,7 +16498,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Calamity",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -16514,7 +16514,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "しゅとら？",
 		"tr_text": "",
 		"fileID": 4
@@ -16522,7 +16522,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "頼むよ……お前なら、カラミティの洗脳<%br>解けるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16530,7 +16530,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "シュトラ、落ち着きなさい。今は、それよりも<%br>ヘイドとカラミティを捕獲することを……",
 		"tr_text": "",
 		"fileID": 4
@@ -16538,7 +16538,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "アネットは、頭のいい研究者なんだよな？<%br>アンタの言ってたこと、当たってるんだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16554,7 +16554,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "……でゅな……わか……わかんない。",
 		"tr_text": "",
 		"fileID": 4
@@ -16562,7 +16562,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ヘイド",
-		"tr_name": "Duna",
+		"tr_name": "Hade",
 		"jp_text": "そうか、まだ……<%br>まだ力の使い方を覚えていない……か。",
 		"tr_text": "",
 		"fileID": 4
@@ -16586,7 +16586,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16602,7 +16602,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "ま、まて！",
 		"tr_text": "",
 		"fileID": 4
@@ -16618,7 +16618,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "……ごめんね。<%br>ごめんね、しゅとら……",
 		"tr_text": "",
 		"fileID": 4
@@ -16642,7 +16642,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16650,7 +16650,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "からみて……からみて……<%br>たすけるの、でゅな、できなかった……",
 		"tr_text": "",
 		"fileID": 4
@@ -16658,7 +16658,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ、大丈夫です。<%br>みんなで、カラミティさんを助けましょう？",
 		"tr_text": "",
 		"fileID": 4
@@ -16666,7 +16666,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "みんな？",
 		"tr_text": "",
 		"fileID": 4
@@ -16674,7 +16674,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "はい……<%br>みんなで、カラミティさんを助けましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -16706,7 +16706,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "しゅとら、ぶーの、よろこぶ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16714,7 +16714,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "もちろんです。<%br>だから、大丈夫ですよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16730,7 +16730,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま、ねえ、まま！<%br>おうたうたって……こもりうた？",
 		"tr_text": "",
 		"fileID": 4
@@ -16738,7 +16738,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "こもり……歌……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16746,7 +16746,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "いつもね、でゅなね<%br>ままのおなかのなかでね、きいてたの。",
 		"tr_text": "",
 		"fileID": 4
@@ -16786,7 +16786,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "え？　え……えっとぉ……<%br>げんきに、おーきく、なーあーれー？",
 		"tr_text": "",
 		"fileID": 4
@@ -16794,7 +16794,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……まま、ちがうよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -16802,7 +16802,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "いいわね……ほのぼのタイム。<%br>お邪魔しても、いいかしら？",
 		"tr_text": "",
 		"fileID": 4
@@ -16810,7 +16810,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……<%br>あの……シュトラさんは？",
 		"tr_text": "",
 		"fileID": 4
@@ -16818,7 +16818,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……少し落ち込んでいるみたいだけど<%br>本人だって、状況は理解してるわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16834,7 +16834,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アムドゥスキア……また、龍族を……<%br>ヘイドは……",
 		"tr_text": "",
 		"fileID": 4
@@ -16842,7 +16842,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "モアとシュトラも待ってるわ。<%br>行きましょう、アムドゥスキアに……！",
 		"tr_text": "",
 		"fileID": 4
@@ -16850,7 +16850,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Annette",
+		"tr_name": "Seraphy",
 		"jp_text": "周辺エネミーの撃破、お疲れ様です。捕食者の<%br>反応はエリアの奥地で確認できています。",
 		"tr_text": "",
 		"fileID": 4
@@ -16858,7 +16858,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "Seraphy",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……急がないと、ですね。<%br>それにしても、龍族の姿が、見えないです……",
 		"tr_text": "",
 		"fileID": 4
@@ -16866,7 +16866,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "ここら一帯の龍族……<%br>全部ヘイドが、食いつくしたんじゃねーの……",
 		"tr_text": "",
 		"fileID": 4
@@ -16874,7 +16874,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドのあの様子だと、焦っているのよ。<%br>だから、龍族を捕食して能力強化を急いでる。",
 		"tr_text": "",
 		"fileID": 4
@@ -16882,7 +16882,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "焦ってる……？",
 		"tr_text": "",
 		"fileID": 4
@@ -16890,7 +16890,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "デュナが、アナティスの洗脳解除できるって<%br>私たちが気づいた。それに危機感を覚えた……",
 		"tr_text": "",
 		"fileID": 4
@@ -16898,7 +16898,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アナティスの能力に、デュナが対抗できるから<%br>ヘイドはデュナを、狙ったんでしょうか……",
 		"tr_text": "",
 		"fileID": 4
@@ -16906,7 +16906,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "キィィィイイイイーーーー！！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -16914,7 +16914,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -16938,7 +16938,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "惑星ウォパルでのブルーノら襲撃後",
 		"tr_text": "",
 		"fileID": 4
@@ -16946,7 +16946,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……怒っている、のか？",
 		"tr_text": "",
 		"fileID": 4
@@ -16954,7 +16954,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "どうして、ひとりで出た……？<%br>ここから出るな……アークスは強い、危険だ。",
 		"tr_text": "",
 		"fileID": 4
@@ -16962,7 +16962,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "お前だけが戦うのが、嫌なんだ。<%br>アークスが強いなら、なおさら……",
 		"tr_text": "",
 		"fileID": 4
@@ -16978,7 +16978,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "Anatis",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -16986,7 +16986,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "『私は、お前を利用など<%br>　したくない……ヘイド』",
 		"tr_text": "",
 		"fileID": 4
@@ -16994,7 +16994,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……どうしてだ。<%br>どうして、そんな言葉を……言う？",
 		"tr_text": "",
 		"fileID": 4
@@ -17002,7 +17002,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "……ヘイド？",
 		"tr_text": "",
 		"fileID": 4
@@ -17010,7 +17010,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……好きにしろ。<%br>ただ、無理はするな……",
 		"tr_text": "",
 		"fileID": 4
@@ -17018,7 +17018,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "デュナ",
-		"tr_name": "Hade",
+		"tr_name": "Duna",
 		"jp_text": "らーらーらぁー♪<%br>むー？　……ちがうなぁ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -17026,7 +17026,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "何してんだ、デュナ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17034,7 +17034,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "おうたーうたったの。あのね、あんまりね<%br>おぼえてないの。でゅなも、ままも……",
 		"tr_text": "",
 		"fileID": 4
@@ -17042,7 +17042,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "あは……はは、忘れちゃって……",
 		"tr_text": "",
 		"fileID": 4
@@ -17050,7 +17050,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……子守歌。<%br>お腹には子供……解除する能力……",
 		"tr_text": "",
 		"fileID": 4
@@ -17122,7 +17122,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "あ、あのさ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17130,7 +17130,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "りだー！　あねっと！",
 		"tr_text": "",
 		"fileID": 4
@@ -17138,7 +17138,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "うわー、もう！<%br>先ひとりで走ったら危ないってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -17146,7 +17146,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "セラフィ",
-		"tr_name": "More",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、捕食者の生体反応が<%br>近くで確認できました。急いでください！",
 		"tr_text": "",
 		"fileID": 4
@@ -17154,7 +17154,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "Seraphy",
+		"tr_name": "Stra",
 		"jp_text": "……急ごうぜ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17162,7 +17162,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "……これ……これを……<%br>全部お前が食ったのか……ヘイド！",
 		"tr_text": "",
 		"fileID": 4
@@ -17170,7 +17170,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ヘイド",
-		"tr_name": "More",
+		"tr_name": "Hade",
 		"jp_text": "……お前たちか。",
 		"tr_text": "",
 		"fileID": 4
@@ -17178,7 +17178,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "シュトラ",
-		"tr_name": "Hade",
+		"tr_name": "Stra",
 		"jp_text": "カラミティは……アイツはどこだよ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17186,7 +17186,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "……く……はっ……は……はぁ……<%br>まだ……腹には入れてない……",
 		"tr_text": "",
 		"fileID": 4
@@ -17194,7 +17194,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "なんだか……様子がおかしいです。<%br>どうしたんでしょう……",
 		"tr_text": "",
 		"fileID": 4
@@ -17202,7 +17202,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ま、まま……こわい。",
 		"tr_text": "",
 		"fileID": 4
@@ -17210,7 +17210,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "……ヘイド、貴方やアナティスを生み出し<%br>利用しようとした組織は……人間は、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -17226,7 +17226,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ヘイド",
-		"tr_name": "Annette",
+		"tr_name": "Hade",
 		"jp_text": "……ふ……ふははは。",
 		"tr_text": "",
 		"fileID": 4
@@ -17242,7 +17242,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Hade",
+		"tr_name": "Annette",
 		"jp_text": "理由……そうね。貴方の行動や発言が<%br>私の中で結びつかないのよ、ごめんなさいね。",
 		"tr_text": "",
 		"fileID": 4
@@ -17250,7 +17250,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Annette",
+		"tr_name": "Hade",
 		"jp_text": "命令などない。俺を生み出した人間は……<%br>とっくに殺した。",
 		"tr_text": "",
 		"fileID": 4
@@ -17266,7 +17266,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17274,7 +17274,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "命令なんてものはない……<%br>俺はただ……約束を……守るだけだ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17282,7 +17282,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17290,7 +17290,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "",
+		"tr_name": "Gene",
 		"jp_text": "デュナ、離れたらダメですよ！<%br>リーダー、行きましょうっ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17298,7 +17298,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "グゥウオオオオオーー！！",
 		"tr_text": "",
 		"fileID": 4
@@ -17314,7 +17314,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "くっ……！<%br>はぁ……はぁ……ヘイド……",
 		"tr_text": "",
 		"fileID": 4
@@ -17346,7 +17346,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ヘイドを、ここで仕留めましょう。<%br>彼になんの理由があっても、危険よ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17354,7 +17354,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん、まってください……",
 		"tr_text": "",
 		"fileID": 4
@@ -17394,7 +17394,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……オンナ。<%br>お前は、知ってどうするんだ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17410,7 +17410,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……地獄。",
 		"tr_text": "",
 		"fileID": 4
@@ -17418,7 +17418,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "お前らは、なんの犠牲もなく<%br>俺や、アナティスが生まれたと思うのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17434,7 +17434,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "犠牲……<%br>……ヘイド、一体……",
 		"tr_text": "",
 		"fileID": 4
@@ -17442,7 +17442,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "いくら貴方が、被害者だとしても……<%br>私は貴方をここで捕まえる。",
 		"tr_text": "",
 		"fileID": 4
@@ -17458,7 +17458,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ヘイド",
-		"tr_name": "Annette",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -17466,7 +17466,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17474,7 +17474,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "『……死ぬな。』",
 		"tr_text": "",
 		"fileID": 4
@@ -17490,7 +17490,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "大事な人……か。",
 		"tr_text": "",
 		"fileID": 4
@@ -17498,7 +17498,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "あ、アネットさん……！<%br>リーダー……ダメです！",
 		"tr_text": "",
 		"fileID": 4
@@ -17514,7 +17514,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "……俺は死ねない。",
 		"tr_text": "",
 		"fileID": 4
@@ -17522,7 +17522,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17530,7 +17530,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "……俺がひとりになっても<%br>あいつをひとりには、できない。",
 		"tr_text": "",
 		"fileID": 4
@@ -17538,7 +17538,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -17570,7 +17570,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "……アナ……ティス……",
 		"tr_text": "",
 		"fileID": 4
@@ -17578,7 +17578,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "お前はここで休んでいろ。<%br>私が行ってくる……",
 		"tr_text": "",
 		"fileID": 4
@@ -17586,7 +17586,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "ふ……<%br>どうしてだ。どうして、同じことを言う……",
 		"tr_text": "",
 		"fileID": 4
@@ -17602,7 +17602,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "クーナ",
-		"tr_name": "Hade",
+		"tr_name": "Quna",
 		"jp_text": "……わたしです。<%br>貴方が話していた、例の件ですが……",
 		"tr_text": "",
 		"fileID": 4
@@ -17610,7 +17610,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "……会って、話をしていただけましたか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17618,7 +17618,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "はい……<%br>本人に会い、確認しました。",
 		"tr_text": "",
 		"fileID": 4
@@ -17634,7 +17634,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "フェル",
-		"tr_name": "Quna",
+		"tr_name": "Fel",
 		"jp_text": "ずいぶん……簡単に信じてくれるんだな。<%br>市街地で暴れまわった、トランスエネミーだろ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17642,7 +17642,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "クーナ",
-		"tr_name": "Fel",
+		"tr_name": "Quna",
 		"jp_text": "……別に、簡単に信じたわけではありません。",
 		"tr_text": "",
 		"fileID": 4
@@ -17666,7 +17666,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "フェル",
-		"tr_name": "Quna",
+		"tr_name": "Fel",
 		"jp_text": "……べ、べつに……交換条件だ。<%br>レヴィを……助けてくれるなら……",
 		"tr_text": "",
 		"fileID": 4
@@ -17674,7 +17674,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "クーナ",
-		"tr_name": "Fel",
+		"tr_name": "Quna",
 		"jp_text": "……アークスの持つ医療技術と<%br>アネットのフォトンと人体に関する知見があれば……",
 		"tr_text": "",
 		"fileID": 4
@@ -17690,7 +17690,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "フェル",
-		"tr_name": "Quna",
+		"tr_name": "Fel",
 		"jp_text": "ああ……",
 		"tr_text": "",
 		"fileID": 4
@@ -17706,7 +17706,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アネット",
-		"tr_name": "Fel",
+		"tr_name": "Annette",
 		"jp_text": "貴方……フェル！？<%br>……どうして……まさか、助けてくれるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17714,7 +17714,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "フェル",
-		"tr_name": "Annette",
+		"tr_name": "Fel",
 		"jp_text": "『……レヴィヲ……助ケラレルカ？』",
 		"tr_text": "",
 		"fileID": 4
@@ -17722,7 +17722,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "アネット",
-		"tr_name": "Fel",
+		"tr_name": "Annette",
 		"jp_text": "……！",
 		"tr_text": "",
 		"fileID": 4
@@ -17746,7 +17746,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "フェル",
-		"tr_name": "Annette",
+		"tr_name": "Fel",
 		"jp_text": "『……アリガトウ』",
 		"tr_text": "",
 		"fileID": 4
@@ -17754,7 +17754,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Fel",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、惑星ウォパルの「海底エリア」で<%br>再び、捕食者の生体反応が確認できました。",
 		"tr_text": "",
 		"fileID": 4
@@ -17762,7 +17762,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "よっしゃ！<%br>みんなで海底エリアにしゅっぱーつ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17770,7 +17770,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "うんっ！<%br>しゅっぱーつ！",
 		"tr_text": "",
 		"fileID": 4
@@ -17786,7 +17786,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "アネット",
-		"tr_name": "Duna",
+		"tr_name": "Annette",
 		"jp_text": "ふふ……ブルーノの代わりにね。<%br>彼の上司に、報告をしに行ってたのよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -17802,7 +17802,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "ヘイド……",
 		"tr_text": "",
 		"fileID": 4
@@ -17810,7 +17810,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……どうしたの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17818,7 +17818,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "みなさん……この任務を達成した先に<%br>何が待っているんでしょうか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17842,7 +17842,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ジェネ……貴方、ヘイドが言ってたこと<%br>気にしているのね。",
 		"tr_text": "",
 		"fileID": 4
@@ -17850,7 +17850,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -17858,7 +17858,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "",
+		"tr_name": "Hade",
 		"jp_text": "お前らは、なんの犠牲もなく<%br>俺や、アナティスが生まれたと思うのか？",
 		"tr_text": "",
 		"fileID": 4
@@ -17874,7 +17874,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "ジェネ",
-		"tr_name": "Hade",
+		"tr_name": "Gene",
 		"jp_text": "……わからないんです。ヘイドを倒せば<%br>彼がいなくなれば、平和になるのか……",
 		"tr_text": "",
 		"fileID": 4
@@ -17922,7 +17922,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "……うぬぼれすぎよ、ジェネ。<%br>そもそも貴方ひとりで、勝てると思ってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -17930,7 +17930,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "それは……そう、ですけど。ただ……みんなに<%br>悲しい気持ちになって欲しくないんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -17938,7 +17938,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……でゅなも、ままに……<%br>かなしい、なってほしくない。",
 		"tr_text": "",
 		"fileID": 4
@@ -17946,7 +17946,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 4
@@ -17954,7 +17954,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "そうね。貴方のいうように、誰かを倒して<%br>平和が訪れるなんて単純なものじゃないと思う。",
 		"tr_text": "",
 		"fileID": 4
@@ -17978,7 +17978,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……でゅなも、いっしょたたかう！<%br>みんなで、でしょっ？",
 		"tr_text": "",
 		"fileID": 4
@@ -17986,7 +17986,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……",
 		"tr_text": "",
 		"fileID": 4
@@ -17994,7 +17994,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……でゅなね、つぎはね。<%br>しゅとらのおねがい、する……の。",
 		"tr_text": "",
 		"fileID": 4
@@ -18002,7 +18002,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "オレの……お願い？",
 		"tr_text": "",
 		"fileID": 4
@@ -18010,7 +18010,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "",
-		"tr_name": "Stra",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18018,7 +18018,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あのね、でゅなは<%br>しゅとらのおねがい、できなかった……",
 		"tr_text": "",
 		"fileID": 4
@@ -18034,7 +18034,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナは、カラミティさんの<%br>洗脳を解除したいって、思ってるんです。",
 		"tr_text": "",
 		"fileID": 4
@@ -18050,7 +18050,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "……！<%br>……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18058,7 +18058,7 @@
 	{
 		"eventNo": "37",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "……えへへ。<%br>でゅなもね、からみて、たすけたいの！",
 		"tr_text": "",
 		"fileID": 4
@@ -18066,7 +18066,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "そう……ですね。<%br>みんなで、一緒に……戦いましょう。",
 		"tr_text": "",
 		"fileID": 4
@@ -18074,7 +18074,7 @@
 	{
 		"eventNo": "39",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "うんっ！<%br>……みんなで、うぉぱるいくよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18098,7 +18098,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "どうしたんだよ、デュナ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18106,7 +18106,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "なんかね、ここいいところだね。<%br>でゅな、すき。",
 		"tr_text": "",
 		"fileID": 4
@@ -18122,7 +18122,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "ここは、確かに不思議なところですよね。<%br>ふふ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18130,7 +18130,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "ねぇねぇ、もあ。<%br>ままちょっとだけ、げんきなったかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -18138,7 +18138,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ジェネか？<%br>そうだな……悩んで落ち込んでたもんな。",
 		"tr_text": "",
 		"fileID": 4
@@ -18146,7 +18146,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "ねぇねぇ、もあ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18154,7 +18154,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "うん？　どうしたんだよ、デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18162,7 +18162,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "あのね、しゅとらはどうしたら<%br>げんき……なるかな？",
 		"tr_text": "",
 		"fileID": 4
@@ -18178,7 +18178,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……デュナ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18186,7 +18186,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……べ、別にオレは……その……アイツが<%br>戻ってきたからって、うれしくなんかねーよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18194,7 +18194,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "うれしくないの？<%br>でゅなはままといると、うれしいよ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18202,7 +18202,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "オレは……うれしいとかじゃなくって<%br>ただ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18210,7 +18210,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18218,7 +18218,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18234,7 +18234,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "セラフィ",
-		"tr_name": "Stra",
+		"tr_name": "Seraphy",
 		"jp_text": "みなさん、周辺エネミーの撃破<%br>お疲れ様です。",
 		"tr_text": "",
 		"fileID": 4
@@ -18242,7 +18242,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "モア",
-		"tr_name": "Seraphy",
+		"tr_name": "More",
 		"jp_text": "ふぅー！<%br>このくらい、よっゆーだってば！",
 		"tr_text": "",
 		"fileID": 4
@@ -18250,7 +18250,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "もあ、すごいねー！",
 		"tr_text": "",
 		"fileID": 4
@@ -18258,7 +18258,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "へへへーん！<%br>だろー？　",
 		"tr_text": "",
 		"fileID": 4
@@ -18266,7 +18266,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18274,7 +18274,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "ん？　シュトラ、どうしたんだ？<%br>むすーっとしてると、変な顔になるぞ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18282,7 +18282,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "なるよー？",
 		"tr_text": "",
 		"fileID": 4
@@ -18290,7 +18290,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……変な顔って……考え事してたんだよ。<%br>アネット、アンタに聞きたいんだけど……",
 		"tr_text": "",
 		"fileID": 4
@@ -18306,7 +18306,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……いい質問ね。<%br>その解答は、「おそらく効かない」。",
 		"tr_text": "",
 		"fileID": 4
@@ -18322,7 +18322,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "……ねえ、ねえ、もあ。<%br>あねっと、なにいってるの？",
 		"tr_text": "",
 		"fileID": 4
@@ -18330,7 +18330,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "……こ、子供にはまだ、早いってば！<%br>お、オレはなんとなく、わかるけどさ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18338,7 +18338,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "More",
+		"tr_name": "Annette",
 		"jp_text": "アークスを洗脳できれば……単純に<%br>捕食で力を強める必要は、ないわ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18346,7 +18346,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "確かに……今まで洗脳されたのは<%br>全部ウェポノイド……だもんな。",
 		"tr_text": "",
 		"fileID": 4
@@ -18354,7 +18354,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "それに、もともと……",
 		"tr_text": "",
 		"fileID": 4
@@ -18362,7 +18362,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "イノセントブルーによって<%br>ザッカードが生み出したのが<%br>ウェポノイド。<%br>E.M.A.はウェポノイドを<%br>悪用しようとした。",
 		"tr_text": "",
 		"fileID": 4
@@ -18378,7 +18378,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "それってさ……アナティスの能力で<%br>E.M.A.がしたかったことじゃねーか。",
 		"tr_text": "",
 		"fileID": 4
@@ -18386,7 +18386,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "そう……ですね。<%br>アネットさん……それって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18394,7 +18394,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "えぇ、そのために、E.M.A.は<%br>虚空機関の研究を引き継いだ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18410,7 +18410,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "クーナ",
-		"tr_name": "Annette",
+		"tr_name": "Quna",
 		"jp_text": "アネット、貴方に伝えておくことがあります。<%br>虚空機関の研究についてです。",
 		"tr_text": "",
 		"fileID": 4
@@ -18450,7 +18450,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "アネット",
-		"tr_name": "Quna",
+		"tr_name": "Annette",
 		"jp_text": "ダークファルス【若人】の……魅了能力。<%br>その能力が、アナティスに移植されている。",
 		"tr_text": "",
 		"fileID": 4
@@ -18458,7 +18458,7 @@
 	{
 		"eventNo": "28",
 		"jp_name": "デュナ",
-		"tr_name": "Annette",
+		"tr_name": "Duna",
 		"jp_text": "あぷれん……てぃす？",
 		"tr_text": "",
 		"fileID": 4
@@ -18466,7 +18466,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "ダークファルスの能力とか……そんなの！<%br>そんなの使えるってヒキョーじゃんか！",
 		"tr_text": "",
 		"fileID": 4
@@ -18474,7 +18474,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "ダークファルスはわたし達の……<%br>宇宙の敵ですよね？",
 		"tr_text": "",
 		"fileID": 4
@@ -18490,7 +18490,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "モア",
-		"tr_name": "Gene",
+		"tr_name": "More",
 		"jp_text": "それにさ……なんか、ヘイドとかアナティスが<%br>ちょっとだけ、かわいそうだってば……",
 		"tr_text": "",
 		"fileID": 4
@@ -18498,7 +18498,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "More",
+		"tr_name": "Gene",
 		"jp_text": "モア……",
 		"tr_text": "",
 		"fileID": 4
@@ -18506,7 +18506,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "オレやカラミティは、そのダークファルスの力で<%br>洗脳されたのか……",
 		"tr_text": "",
 		"fileID": 4
@@ -18522,7 +18522,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……あの、場所？",
 		"tr_text": "",
 		"fileID": 4
@@ -18530,7 +18530,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "シュトラ……彼は隠し事をしている。<%br>恐らく……",
 		"tr_text": "",
 		"fileID": 4
@@ -18538,7 +18538,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "ねぇ、シュトラ。<%br>貴方に聞きたいことがあるの。",
 		"tr_text": "",
 		"fileID": 4
@@ -18546,7 +18546,7 @@
 	{
 		"eventNo": "11",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "え……？<%br>なんだよ……聞きたいことって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18554,7 +18554,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "シュトラ、貴方は<%br>私たちに隠していることがある。違う……？",
 		"tr_text": "",
 		"fileID": 4
@@ -18562,7 +18562,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……<%br>一体、何を言ってるんです？",
 		"tr_text": "",
 		"fileID": 4
@@ -18570,7 +18570,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18578,7 +18578,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "貴方を……追い詰めたいわけじゃないの。<%br>それは、カラミティが望んでいない。",
 		"tr_text": "",
 		"fileID": 4
@@ -18586,7 +18586,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……え？",
 		"tr_text": "",
 		"fileID": 4
@@ -18594,7 +18594,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "アネットさん……何を……",
 		"tr_text": "",
 		"fileID": 4
@@ -18602,7 +18602,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18610,7 +18610,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……話の続きは後にしましょう。<%br>囲まれてるわ……！",
 		"tr_text": "",
 		"fileID": 4
@@ -18618,7 +18618,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……",
 		"tr_text": "",
 		"fileID": 4
@@ -18626,7 +18626,7 @@
 	{
 		"eventNo": "1",
 		"jp_name": "シュトラ",
-		"tr_name": "Gene",
+		"tr_name": "Stra",
 		"jp_text": "どういうことだよ……カラミティが<%br>その……望んでいないって……",
 		"tr_text": "",
 		"fileID": 4
@@ -18634,7 +18634,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……シュトラ、貴方に聞いてほしい。<%br>カラミティがなんて言っていたか……",
 		"tr_text": "",
 		"fileID": 4
@@ -18642,7 +18642,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18658,7 +18658,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ブルーノ",
-		"tr_name": "",
+		"tr_name": "Bruno",
 		"jp_text": "それじゃあ、リーダー。<%br>あとでアークスシップで落ち合おう。またな。",
 		"tr_text": "",
 		"fileID": 4
@@ -18666,7 +18666,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "デュナ",
-		"tr_name": "Bruno",
+		"tr_name": "Duna",
 		"jp_text": "またねー、ぶーの！",
 		"tr_text": "",
 		"fileID": 4
@@ -18674,7 +18674,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "ブルーノ",
-		"tr_name": "Duna",
+		"tr_name": "Bruno",
 		"jp_text": "はぁーい。<%br>またねー。デュナちゃん。",
 		"tr_text": "",
 		"fileID": 4
@@ -18682,7 +18682,7 @@
 	{
 		"eventNo": "8",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18690,7 +18690,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……なんだよ、ふたりしてその目。",
 		"tr_text": "",
 		"fileID": 4
@@ -18698,7 +18698,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "それより、さっきリーダーたちに話していたこと<%br>だけど、これから会うトランスエネミーは……",
 		"tr_text": "",
 		"fileID": 4
@@ -18714,7 +18714,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "なーに？　アネット、怖いわけ？<%br>あらら～、意外だね。",
 		"tr_text": "",
 		"fileID": 4
@@ -18722,7 +18722,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "……逆よ。少しほっとしてるの。未確定な敵に<%br>対峙するのが、私たちでよかった……って。",
 		"tr_text": "",
 		"fileID": 4
@@ -18730,7 +18730,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "……あいかわらずの、過保護。",
 		"tr_text": "",
 		"fileID": 4
@@ -18746,7 +18746,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "あら……<%br>怖がってるのはブルーノ、貴方じゃない。",
 		"tr_text": "",
 		"fileID": 4
@@ -18754,7 +18754,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "ブルーノ",
-		"tr_name": "Annette",
+		"tr_name": "Bruno",
 		"jp_text": "ははは……俺はね、無駄死にとか<%br>リスク背負うのとか、基本は嫌なのよ。",
 		"tr_text": "",
 		"fileID": 4
@@ -18770,7 +18770,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "アネット",
-		"tr_name": "Bruno",
+		"tr_name": "Annette",
 		"jp_text": "いい心がけね。……カラミティ、貴方は<%br>これから会う、トランスエネミーの能力は何だと思う？",
 		"tr_text": "",
 		"fileID": 4
@@ -18778,7 +18778,7 @@
 	{
 		"eventNo": "20",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "そうっ！　そのとーり！<%br>敵に対峙するのがボクらでよかった……！",
 		"tr_text": "",
 		"fileID": 4
@@ -18794,7 +18794,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "カラミティ……それはさっきの話よ。今は<%br>能力の考察。貴方……どうしたの、さっきから変よ？",
 		"tr_text": "",
 		"fileID": 4
@@ -18802,7 +18802,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "あー……あの……あれだ。<%br>その……恐らくだけど……",
 		"tr_text": "",
 		"fileID": 4
@@ -18826,7 +18826,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "……？",
 		"tr_text": "",
 		"fileID": 4
@@ -18834,7 +18834,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "カラミティ",
-		"tr_name": "Annette",
+		"tr_name": "Calamity",
 		"jp_text": "シュトラ……彼は隠し事をしている。<%br>恐らく……",
 		"tr_text": "",
 		"fileID": 4
@@ -18866,7 +18866,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "Calamity",
+		"tr_name": "Annette",
 		"jp_text": "「だからシュトラ……彼はあそこまで真剣なんだ。<%br>　事の深刻さを一番理解している」",
 		"tr_text": "",
 		"fileID": 4
@@ -18890,7 +18890,7 @@
 	{
 		"eventNo": "34",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -18898,7 +18898,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アネット",
-		"tr_name": "Stra",
+		"tr_name": "Annette",
 		"jp_text": "……あの時、彼が何故そう結論付けたのかまで<%br>確認する時間がなかった。",
 		"tr_text": "",
 		"fileID": 4
@@ -18930,7 +18930,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "シュトラ",
-		"tr_name": "Annette",
+		"tr_name": "Stra",
 		"jp_text": "……っ！",
 		"tr_text": "",
 		"fileID": 4
@@ -18938,7 +18938,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "ジェネ",
-		"tr_name": "Stra",
+		"tr_name": "Gene",
 		"jp_text": "シュトラ……さん……",
 		"tr_text": "",
 		"fileID": 4
@@ -18946,7 +18946,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "",
-		"tr_name": "Gene",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -18954,7 +18954,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "シュトラ",
-		"tr_name": "",
+		"tr_name": "Stra",
 		"jp_text": "違う……洗脳されてても<%br>オレ達の声はカラミティに聞こえてる。",
 		"tr_text": "",
 		"fileID": 4
@@ -19002,7 +19002,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "モア",
-		"tr_name": "Stra",
+		"tr_name": "More",
 		"jp_text": "オレ、わかるってば。<%br>怖いよな……自分だけが見たこと……",
 		"tr_text": "",
 		"fileID": 4
@@ -19034,7 +19034,7 @@
 	{
 		"eventNo": "16",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "からみて、しゅとらの<%br>ともだちだもんねー。",
 		"tr_text": "",
 		"fileID": 4
@@ -19042,7 +19042,7 @@
 	{
 		"eventNo": "17",
 		"jp_name": "シュトラ",
-		"tr_name": "Duna",
+		"tr_name": "Stra",
 		"jp_text": "……オレ……ごめん……<%br>ごめ……ん……",
 		"tr_text": "",
 		"fileID": 4
@@ -19058,7 +19058,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "デュナ",
-		"tr_name": "Stra",
+		"tr_name": "Duna",
 		"jp_text": "うた？",
 		"tr_text": "",
 		"fileID": 4
@@ -19074,7 +19074,7 @@
 	{
 		"eventNo": "21",
 		"jp_name": "アナティス",
-		"tr_name": "Duna",
+		"tr_name": "Anatis",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -19098,7 +19098,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "ジェネ",
-		"tr_name": "Anatis",
+		"tr_name": "Gene",
 		"jp_text": "あなたが……アナティス！",
 		"tr_text": "",
 		"fileID": 4
@@ -19106,7 +19106,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "あ……あ……",
 		"tr_text": "",
 		"fileID": 4
@@ -19114,7 +19114,7 @@
 	{
 		"eventNo": "26",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "デュナ……？<%br>大丈夫か……どうしたんだってば……",
 		"tr_text": "",
 		"fileID": 4
@@ -19122,7 +19122,7 @@
 	{
 		"eventNo": "27",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "いつか……あなたは……<%br>おおきな……ゆめ……みつけるの……",
 		"tr_text": "",
 		"fileID": 4
@@ -19138,7 +19138,7 @@
 	{
 		"eventNo": "29",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "……デュナ。<%br>あなた……その歌……",
 		"tr_text": "",
 		"fileID": 4
@@ -19146,7 +19146,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "アナティス",
-		"tr_name": "Gene",
+		"tr_name": "Anatis",
 		"jp_text": "うわぁああああああああああ！！！！",
 		"tr_text": "",
 		"fileID": 4
@@ -19154,7 +19154,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アネット",
-		"tr_name": "Anatis",
+		"tr_name": "Annette",
 		"jp_text": "な……なんて声なの……！<%br>みんな、来るわ……構えて……！！",
 		"tr_text": "",
 		"fileID": 4
@@ -19162,7 +19162,7 @@
 	{
 		"eventNo": "32",
 		"jp_name": "",
-		"tr_name": "Annette",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19186,7 +19186,7 @@
 	{
 		"eventNo": "0",
 		"jp_name": "アナティス",
-		"tr_name": "",
+		"tr_name": "Anatis",
 		"jp_text": "あああ……ちがう！<%br>ああ、ちがう……アークス……",
 		"tr_text": "",
 		"fileID": 4
@@ -19202,7 +19202,7 @@
 	{
 		"eventNo": "2",
 		"jp_name": "ジェネ",
-		"tr_name": "Anatis",
+		"tr_name": "Gene",
 		"jp_text": "はぁ……はぁ……うっ……うぅ……",
 		"tr_text": "",
 		"fileID": 4
@@ -19210,7 +19210,7 @@
 	{
 		"eventNo": "3",
 		"jp_name": "アネット",
-		"tr_name": "Gene",
+		"tr_name": "Annette",
 		"jp_text": "ジェネ……しっかりして……！",
 		"tr_text": "",
 		"fileID": 4
@@ -19218,7 +19218,7 @@
 	{
 		"eventNo": "4",
 		"jp_name": "ジェネ",
-		"tr_name": "Annette",
+		"tr_name": "Gene",
 		"jp_text": "大丈夫……です……それより……<%br>デュナが……",
 		"tr_text": "",
 		"fileID": 4
@@ -19226,7 +19226,7 @@
 	{
 		"eventNo": "5",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "……まま、ま……ふぇ……<%br>まま……まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -19234,7 +19234,7 @@
 	{
 		"eventNo": "6",
 		"jp_name": "アナティス",
-		"tr_name": "Duna",
+		"tr_name": "Anatis",
 		"jp_text": "わ……私は、私の腹の子は……<%br>渡さない……！",
 		"tr_text": "",
 		"fileID": 4
@@ -19242,7 +19242,7 @@
 	{
 		"eventNo": "7",
 		"jp_name": "",
-		"tr_name": "Anatis",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19258,7 +19258,7 @@
 	{
 		"eventNo": "9",
 		"jp_name": "デュナ",
-		"tr_name": "",
+		"tr_name": "Duna",
 		"jp_text": "あ……",
 		"tr_text": "",
 		"fileID": 4
@@ -19266,7 +19266,7 @@
 	{
 		"eventNo": "10",
 		"jp_name": "モア",
-		"tr_name": "Duna",
+		"tr_name": "More",
 		"jp_text": "リーダー！<%br>あいつ、混乱して……おかしいって！",
 		"tr_text": "",
 		"fileID": 4
@@ -19282,7 +19282,7 @@
 	{
 		"eventNo": "12",
 		"jp_name": "シュトラ",
-		"tr_name": "More",
+		"tr_name": "Stra",
 		"jp_text": "……だ、ダメだ……あれは……",
 		"tr_text": "",
 		"fileID": 4
@@ -19290,7 +19290,7 @@
 	{
 		"eventNo": "13",
 		"jp_name": "ヘイド",
-		"tr_name": "Stra",
+		"tr_name": "Hade",
 		"jp_text": "アナティス……帰ろう……帰ろう……<%br>今は……何も考えるな……",
 		"tr_text": "",
 		"fileID": 4
@@ -19298,7 +19298,7 @@
 	{
 		"eventNo": "14",
 		"jp_name": "",
-		"tr_name": "Hade",
+		"tr_name": "",
 		"jp_text": "",
 		"tr_text": "",
 		"fileID": 4
@@ -19306,7 +19306,7 @@
 	{
 		"eventNo": "15",
 		"jp_name": "モア",
-		"tr_name": "",
+		"tr_name": "More",
 		"jp_text": "あー！<%br>まてってばーっ！！",
 		"tr_text": "",
 		"fileID": 4
@@ -19330,7 +19330,7 @@
 	{
 		"eventNo": "18",
 		"jp_name": "デュナ",
-		"tr_name": "More",
+		"tr_name": "Duna",
 		"jp_text": "ひぅ……ひゃう……まま……<%br>まま……",
 		"tr_text": "",
 		"fileID": 4
@@ -19338,7 +19338,7 @@
 	{
 		"eventNo": "19",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "デュナ……？",
 		"tr_text": "",
 		"fileID": 4
@@ -19362,7 +19362,7 @@
 	{
 		"eventNo": "22",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……？",
 		"tr_text": "",
 		"fileID": 4
@@ -19370,7 +19370,7 @@
 	{
 		"eventNo": "23",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "ううん……わたしは、デュナのママ……<%br>お母さんじゃない。",
 		"tr_text": "",
 		"fileID": 4
@@ -19378,7 +19378,7 @@
 	{
 		"eventNo": "24",
 		"jp_name": "デュナ",
-		"tr_name": "Gene",
+		"tr_name": "Duna",
 		"jp_text": "まま……まま、まま、まま……<%br>ちがうよ、ままが、ままだもん……",
 		"tr_text": "",
 		"fileID": 4
@@ -19386,7 +19386,7 @@
 	{
 		"eventNo": "25",
 		"jp_name": "ジェネ",
-		"tr_name": "Duna",
+		"tr_name": "Gene",
 		"jp_text": "聞いて、デュナ……わたしはあなたに<%br>幸せになってほしいから……",
 		"tr_text": "",
 		"fileID": 4
@@ -19426,7 +19426,7 @@
 	{
 		"eventNo": "30",
 		"jp_name": "ヘイド",
-		"tr_name": "Gene",
+		"tr_name": "Hade",
 		"jp_text": "…………",
 		"tr_text": "",
 		"fileID": 4
@@ -19434,7 +19434,7 @@
 	{
 		"eventNo": "31",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "その……小さな手と<%br>その　小さな瞳で",
 		"tr_text": "",
 		"fileID": 4
@@ -19466,7 +19466,7 @@
 	{
 		"eventNo": "35",
 		"jp_name": "ヘイド",
-		"tr_name": "Anatis",
+		"tr_name": "Hade",
 		"jp_text": "アナティス……お前……",
 		"tr_text": "",
 		"fileID": 4
@@ -19474,7 +19474,7 @@
 	{
 		"eventNo": "36",
 		"jp_name": "アナティス",
-		"tr_name": "Hade",
+		"tr_name": "Anatis",
 		"jp_text": "ヘイド……私の子は腹の中だ。<%br>アークスは、私の子を奪おうとする。",
 		"tr_text": "",
 		"fileID": 4
@@ -19490,7 +19490,7 @@
 	{
 		"eventNo": "38",
 		"jp_name": "",
-		"tr_name": "Anatis",
+		"tr_name": "",
 		"jp_text": "歌の続き",
 		"tr_text": "",
 		"fileID": 4

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -108,7 +108,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "『その……小さな手と<%br>　その　小さな瞳で』",
-		"tr_text": "\"With eyes so tiny,\n　and hands so tiny...\"",
+		"tr_text": "\"With eyes so tiny,\n  and hands so tiny...\"",
 		"fileID": 1
 	},
 	{

--- a/json/Season2_Title.txt
+++ b/json/Season2_Title.txt
@@ -7,7 +7,7 @@
 	{
 		"title_id": 1,
 		"jp_title": "第１話<%br>友からの依頼",
-		"tr_title": "Chapter 1\nFriendly Request"
+		"tr_title": "Chapter 1\nA Friendly Request"
 	},
 	{
 		"title_id": 1,

--- a/json/SeraphyRoom_TalkGreeting.txt
+++ b/json/SeraphyRoom_TalkGreeting.txt
@@ -2,22 +2,22 @@
 	{
 		"text_id": 60000,
 		"jp_text": "ぴんっ……ぴんっ……",
-		"tr_text": ""
+		"tr_text": "Pew... pew..."
 	},
 	{
 		"text_id": 60000,
 		"jp_text": "……はっ！\n<%CHARANAME>さん！\n来てらっしゃったんですか！",
-		"tr_text": ""
+		"tr_text": "Ah!\n<%CHARANAME>!\nWhat are you doing here?!"
 	},
 	{
 		"text_id": 60000,
 		"jp_text": "ちっ、違いますよ！\nチップをはじいて\n遊んでたわけじゃないですよ！\nその……研究の一環ですよ……",
-		"tr_text": ""
+		"tr_text": "No, no!\nOf course I wasn't playing around with\nthese chips!\nThis is... part of my research, yes..."
 	},
 	{
 		"text_id": 60001,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしてました。\nどうぞ、おあがりください！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting.\nPlease, come in!"
 	},
 	{
 		"text_id": 60002,
@@ -42,112 +42,112 @@
 	{
 		"text_id": 70000,
 		"jp_text": "<%CHARANAME>さん！\n来てくださって、うれしいです！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI'm glad to see you!"
 	},
 	{
 		"text_id": 70001,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしていました。\nさぁ、中へ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting.\nCome in!"
 	},
 	{
 		"text_id": 70002,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしてました。\nどうぞ、あがってください。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting.\nPlease, come in."
 	},
 	{
 		"text_id": 70003,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしてました！\nさぁ、奥へ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting!\nCome inside!"
 	},
 	{
 		"text_id": 70004,
 		"jp_text": "<%CHARANAME>さん！\nこんにちは！\n来てくださって\nありがとうございます。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nIt's good to see you!\nThank you for stopping by."
 	},
 	{
 		"text_id": 70005,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしてました。\nさぁ、奥へどうぞ。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting.\nPlease, do come inside."
 	},
 	{
 		"text_id": 80000,
 		"jp_text": "<%CHARANAME>さん！\n来てくださったんですね！\nどうぞ、おあがりください。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nYou came!\nPlease, come in."
 	},
 	{
 		"text_id": 80001,
 		"jp_text": "<%CHARANAME>さん！\nようこそ！\nごゆっくりどうぞ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nIt's nice to see you!\nTake your time!"
 	},
 	{
 		"text_id": 80002,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしていました！\nさぁ、中へどうぞ。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting!\nDo come in!"
 	},
 	{
 		"text_id": 80003,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしていました！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting!"
 	},
 	{
 		"text_id": 80004,
 		"jp_text": "<%CHARANAME>さん！\n来てくださったんですね！\nどうぞ、おあがりください。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nYou came!\nPlease, come in."
 	},
 	{
 		"text_id": 80005,
 		"jp_text": "<%CHARANAME>さん\nようこそ！\nゆっくりしていってくださいね。",
-		"tr_text": ""
+		"tr_text": "It's good to see you again,\n<%CHARANAME>!\nPlease, take your time."
 	},
 	{
 		"text_id": 80006,
 		"jp_text": "<%CHARANAME>さん！\nこんにちは。\nさぁ、奥へどうぞ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nHello again.\nDo come inside!"
 	},
 	{
 		"text_id": 80007,
 		"jp_text": "<%CHARANAME>さん！\nようこそ！\nお越しくださってうれしいです。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nIt's nice to see you!\nI'm glad you came."
 	},
 	{
 		"text_id": 80008,
 		"jp_text": "<%CHARANAME>さん！\nいらっしゃいませ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nWelcome!"
 	},
 	{
 		"text_id": 90000,
 		"jp_text": "<%CHARANAME>さん！\nお待ちしておりました！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nI was waiting!"
 	},
 	{
 		"text_id": 90001,
 		"jp_text": "<%CHARANAME>さん！\nようこそお越しくださいました！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nWelcome, thank you for coming!"
 	},
 	{
 		"text_id": 90002,
 		"jp_text": "<%CHARANAME>さん！\nお越しいただき\nありがとうございます。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThank you so much for coming by."
 	},
 	{
 		"text_id": 90003,
 		"jp_text": "<%CHARANAME>さん！\nこんにちは！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nHello again!"
 	},
 	{
 		"text_id": 90004,
 		"jp_text": "<%CHARANAME>さん！\nようこそ！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nIt's nice to see you!"
 	},
 	{
 		"text_id": 90005,
 		"jp_text": "<%CHARANAME>さん！\nきてくださったんですね。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nYou came."
 	},
 	{
 		"text_id": 90006,
 		"jp_text": "<%CHARANAME>さん！\nこんにちは！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nHello again!"
 	},
 	{
 		"text_id": 99700,
@@ -172,7 +172,7 @@
 	{
 		"text_id": 99700,
 		"jp_text": "……………………",
-		"tr_text": ""
+		"tr_text": "............"
 	},
 	{
 		"text_id": 99700,
@@ -217,7 +217,7 @@
 	{
 		"text_id": 99700,
 		"jp_text": "…………………！",
-		"tr_text": ""
+		"tr_text": ".........!"
 	},
 	{
 		"text_id": 99700,
@@ -252,7 +252,7 @@
 	{
 		"text_id": 99800,
 		"jp_text": "……………………",
-		"tr_text": ""
+		"tr_text": "............"
 	},
 	{
 		"text_id": 99800,
@@ -332,7 +332,7 @@
 	{
 		"text_id": 99900,
 		"jp_text": "……………………",
-		"tr_text": ""
+		"tr_text": "............"
 	},
 	{
 		"text_id": 99900,
@@ -372,7 +372,7 @@
 	{
 		"text_id": 99900,
 		"jp_text": "……………………！",
-		"tr_text": ""
+		"tr_text": "............!"
 	},
 	{
 		"text_id": 99900,
@@ -392,7 +392,7 @@
 	{
 		"text_id": 99900,
 		"jp_text": "…………",
-		"tr_text": ""
+		"tr_text": "......"
 	},
 	{
 		"text_id": 99900,

--- a/json/SeraphyRoom_TalkTouch2nd.txt
+++ b/json/SeraphyRoom_TalkTouch2nd.txt
@@ -92,17 +92,17 @@
 	{
 		"text_id": 570001,
 		"jp_text": "いつもありがとうございます。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 570002,
 		"jp_text": "いつもありがとうございます。\n無理はなさらないでくださいね。",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nBut please don't push yourself too hard."
 	},
 	{
 		"text_id": 570003,
 		"jp_text": "いつもお疲れ様です。\n<%CHARANAME>さんの\nご活躍を見て、私もがんばろう！\nって思います！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nSeeing you put in so much effort makes\nme want to try my hardest too!"
 	},
 	{
 		"text_id": 570004,
@@ -117,17 +117,17 @@
 	{
 		"text_id": 570001,
 		"jp_text": "いつもありがとうございます。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 570002,
 		"jp_text": "いつもありがとうございます。\n無理はなさらないでくださいね。",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nBut please don't push yourself too hard."
 	},
 	{
 		"text_id": 570003,
 		"jp_text": "いつもお疲れ様です。\n<%CHARANAME>さんの\nご活躍を見て、私もがんばろう！\nって思います！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nSeeing you put in so much effort makes\nme want to try my hardest too!"
 	},
 	{
 		"text_id": 570004,
@@ -142,17 +142,17 @@
 	{
 		"text_id": 570001,
 		"jp_text": "いつもありがとうございます。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 570002,
 		"jp_text": "いつもありがとうございます。\n無理はなさらないでくださいね。",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nBut please don't push yourself too hard."
 	},
 	{
 		"text_id": 570003,
 		"jp_text": "いつもお疲れ様です。\n<%CHARANAME>さんの\nご活躍を見て、私もがんばろう！\nって思います！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nSeeing you put in so much effort makes\nme want to try my hardest too!"
 	},
 	{
 		"text_id": 570004,
@@ -167,17 +167,17 @@
 	{
 		"text_id": 570001,
 		"jp_text": "いつもありがとうございます。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 570002,
 		"jp_text": "いつもありがとうございます。\n無理はなさらないでくださいね。",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nBut please don't push yourself too hard."
 	},
 	{
 		"text_id": 570003,
 		"jp_text": "いつもお疲れ様です。\n<%CHARANAME>さんの\nご活躍を見て、私もがんばろう！\nって思います！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nSeeing you put in so much effort makes\nme want to try my hardest too!"
 	},
 	{
 		"text_id": 570004,
@@ -192,17 +192,17 @@
 	{
 		"text_id": 570001,
 		"jp_text": "いつもありがとうございます。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 570002,
 		"jp_text": "いつもありがとうございます。\n無理はなさらないでくださいね。",
-		"tr_text": ""
+		"tr_text": "I'm always grateful for your help.\nBut please don't push yourself too hard."
 	},
 	{
 		"text_id": 570003,
 		"jp_text": "いつもお疲れ様です。\n<%CHARANAME>さんの\nご活躍を見て、私もがんばろう！\nって思います！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nSeeing you put in so much effort makes\nme want to try my hardest too!"
 	},
 	{
 		"text_id": 570004,
@@ -212,12 +212,12 @@
 	{
 		"text_id": 580000,
 		"jp_text": "クエストに行かれる際は\nしっかり準備してくださいね。\n無事を祈っています。",
-		"tr_text": ""
+		"tr_text": "Please make sure you're fully\nprepared before going on a quest.\nI'm praying for your safety."
 	},
 	{
 		"text_id": 580001,
 		"jp_text": "いつもお疲れ様です。\n今日もご活躍、期待しています！",
-		"tr_text": ""
+		"tr_text": "Thank you for all your hard work.\nI hope you find success today as well!"
 	},
 	{
 		"text_id": 580002,

--- a/json/SeraphyRoom_TalkTouch3rd.txt
+++ b/json/SeraphyRoom_TalkTouch3rd.txt
@@ -42,17 +42,17 @@
 	{
 		"text_id": 660000,
 		"jp_text": "父が無事見つかったら……",
-		"tr_text": ""
+		"tr_text": "If we ever find my father safe..."
 	},
 	{
 		"text_id": 660000,
 		"jp_text": "ぜひ\n<%CHARANAME>さんを\n紹介したいです！",
-		"tr_text": ""
+		"tr_text": "I'd love to introduce you to him,\n<%CHARANAME>!"
 	},
 	{
 		"text_id": 670000,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670000,
@@ -97,7 +97,7 @@
 	{
 		"text_id": 670003,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670003,
@@ -232,7 +232,7 @@
 	{
 		"text_id": 670000,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670000,
@@ -277,7 +277,7 @@
 	{
 		"text_id": 670003,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670003,
@@ -412,7 +412,7 @@
 	{
 		"text_id": 670000,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670000,
@@ -457,7 +457,7 @@
 	{
 		"text_id": 670003,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 670003,
@@ -597,7 +597,7 @@
 	{
 		"text_id": 680001,
 		"jp_text": "きゃっ！\n<%CHARANAME>さん！\nどこ触ってるんですか！",
-		"tr_text": "Kyaa!\n<%CHARANAME>!\nWhere do you think you're touching?!"
+		"tr_text": "Eek!\n<%CHARANAME>!\nWhere do you think you're touching?!"
 	},
 	{
 		"text_id": 680001,
@@ -847,21 +847,21 @@
 	{
 		"text_id": 590009,
 		"jp_text": "クエストで\nなかなか倒せないエネミーに\n出会ったことはありますか？",
-		"tr_text": ""
+		"tr_text": "Have you even encountered\nan enemy in a quest that\nyou couldn't defeat easily?"
 	},
 	{
 		"text_id": 590009,
 		"jp_text": "そんなときは、相手の攻撃体勢に\n注意してみてください。\n危ない！　と思ったら、無理せず\nスライドで避けてくださいね！",
-		"tr_text": ""
+		"tr_text": "In moments like that, pay attention to\nyour opponent's movements.\nIf you think they're about to strike,\nslide out of the way!"
 	},
 	{
 		"text_id": 590010,
 		"jp_text": "アークスシップの生活には\nもう慣れましたか？",
-		"tr_text": ""
+		"tr_text": "Have you got used to life\non the ARKS Ship yet?"
 	},
 	{
 		"text_id": 590010,
 		"jp_text": "お友達を\nたくさん作ってくださいね！",
-		"tr_text": ""
+		"tr_text": "Please make friends\nwith lots of people!"
 	}
 ]

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -16302,7 +16302,7 @@
 	{
 		"assign": "lookback_guide_1",
 		"jp_text": "<color=#f0df60>これまでに見たストーリーを回想できます。</color>",
-		"tr_text": "<color=#f0df60>You can recall the story events seen in the past.</color>"
+		"tr_text": "<color=#f0df60>You can rewatch previously viewed story events.</color>"
 	},
 	{
 		"assign": "lookback_category_title",

--- a/json/UI_Weaponoid_BallonName.txt
+++ b/json/UI_Weaponoid_BallonName.txt
@@ -587,7 +587,7 @@
 	{
 		"assign": "80011",
 		"jp_text": "アヴェンジャー",
-		"tr_text": ""
+		"tr_text": "Avenger"
 	},
 	{
 		"assign": "118",


### PR DESCRIPTION
Updates cosmetics, item sets, voices and bartering.
Translates remaining enemy chip names.
Translates a few support chip ability names.
Updates a load of active chips to new description format/corrects their effects.
Translates many of Seraphy's greetings and a couple of her other lines for being tapped on.
Translates all season 2 dialogue names.
Translates the season 2 episode 1 prologue and chapter 1.
Adds support chips to the normalization check blacklist - it was trying to 'correct' the circled numbers.