### PR TITLE
Cast parts, active chips, Seraphy notes + others

### DIFF
--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -35,7 +35,7 @@ for files in json_files:
             for rmid in djson:
                 for checkname in linenames:
                     checkjp = "jp_" + checkname
-                    if ((checkjp in rmid) and (rmid[checkjp] != "") and (rmid[checkjp] != "-")):
+                    if ((checkjp in rmid) and (rmid[checkjp] != "") and (rmid[checkjp] != "-") and (rmid[checkjp] != "---")):
                         countin += 1
                         checktr = "tr_" + checkname
                         

--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -30,10 +30,18 @@ for files in json_files:
             countin = 0
             countout = 0
             djson = json.load(json_file)
+            
+            linenames = ["text", "name", "title", "explain", "explainShort", "explainLong"]
             for rmid in djson:
-                countin += 1
-                if (("tr_text" in rmid) and (rmid["tr_text"] != "")):
-                    countout += 1
+                for checkname in linenames:
+                    checkjp = "jp_" + checkname
+                    if ((checkjp in rmid) and (rmid[checkjp] != "") and (rmid[checkjp] != "-")):
+                        countin += 1
+                        checktr = "tr_" + checkname
+                        
+                        if((checktr in rmid) and (rmid[checktr] != "") and (rmid[checktr] != rmid[checkjp])):
+                            countout += 1
+                        
             # print ("%s/%s" % (countin, countout))
             if (countin):
                 countper = "{:06.1%}".format(float(countout) / float(countin))

--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -31,7 +31,7 @@ for files in json_files:
             countout = 0
             djson = json.load(json_file)
             
-            linenames = ["text", "name", "title", "explain", "explainShort", "explainLong"]
+            linenames = ["text", "name", "title", "explain", "explainShort", "explainLong", "patterns"]
             for rmid in djson:
                 for checkname in linenames:
                     checkjp = "jp_" + checkname
@@ -47,7 +47,7 @@ for files in json_files:
                 countper = "{:06.1%}".format(float(countout) / float(countin))
                 bufout += '\n{0}\t{1}'.format(countper, files)
             else:
-                bufout += '\n{0}\t:{1}'.format("ERROR ", files)
+                bufout += '\n{0}\t:{1}'.format("No translatable lines found ", files)
         except ValueError as e:
             print("%s: %s") % (files, e)
             invalid_json_files.append(files)

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -2,86 +2,86 @@
 	{
 		"assign": "110",
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Element up + slight ATK boost",
+		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Fire Element up + slight ATK boost",
+		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Element up + slight ATK boost",
+		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Ice Element up + slight ATK boost",
+		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Element up + slight ATK boost",
+		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Lightning Element up + slight ATK boost",
+		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Element up + slight ATK boost",
+		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Wind Element up + slight ATK boost",
+		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Element up + slight ATK boost",
+		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Light Element up + slight ATK boost",
+		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Element up + slight ATK boost",
+		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
-		"tr_explainShort": "Dark Element up + slight ATK boost",
+		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically boosts Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "910",
@@ -100,70 +100,70 @@
 	{
 		"assign": "1110",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
-		"tr_explainShort": "ATK boost + DEF lowered",
+		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Reduces Defense.\n② Greatly increases ATK.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
-		"tr_explainShort": "ATK boost + DEF lowered",
+		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases ATK.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
-		"tr_explainShort": "Damage against element weaknesses up",
+		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases damage against\n    enemy element weaknesses.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
-		"tr_explainShort": "Damage against element weaknesses up",
+		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases damage against\n    enemy element weaknesses.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1510",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Light damage + ATK boost",
+		"tr_explainShort": "Immense Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Light damage + ATK boost",
+		"tr_explainShort": "Immense Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Light Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Ice damage + ATK boost",
+		"tr_explainShort": "Immense Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Ice Element damage.\n[Effect Duration] Long."
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Ice damage + ATK boost",
+		"tr_explainShort": "Immense Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Ice Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Wind damage + ATK boost",
+		"tr_explainShort": "Immense Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Wind damage + ATK boost",
+		"tr_explainShort": "Immense Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Wind Element damage.\n[Effect Duration] Long"
 	},
@@ -184,30 +184,30 @@
 	{
 		"assign": "1590",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Fire damage + ATK boost",
+		"tr_explainShort": "Immense Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
-		"tr_explainShort": "Immense Fire damage + ATK boost",
+		"tr_explainShort": "Immense Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Damage boost + HP recovery",
+		"tr_explainShort": "Power boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Large damage boost + HP recovery",
+		"tr_explainShort": "Power boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
@@ -226,14 +226,14 @@
 	{
 		"assign": "30001",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
-		"tr_explainShort": "Actions quickened + ATK boost",
+		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
-		"tr_explainShort": "Actions quickened + ATK boost",
+		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
@@ -310,226 +310,226 @@
 	{
 		"assign": "30017",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "ATK boost based on remaining CP",
+		"tr_explainShort": "ATK up based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
-		"tr_explainShort": "ATK boost based on remaining CP",
+		"tr_explainShort": "ATK up based on remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK,\n    increasing as remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Wind chips",
+		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Wind chips",
+		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Ice chips",
+		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Ice chips",
+		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Lightning chips",
+		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Lightning chips",
+		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30033",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
-		"tr_explainShort": "Normal attacks can [Panic] + ATK boost",
+		"tr_explainShort": "Normal attacks can [Panic] + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
-		"tr_explainShort": "Normal attacks can [Panic] + ATK boost",
+		"tr_explainShort": "Normal attacks can [Panic] + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1690",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
-		"tr_explainShort": "Fire damage + ATK boost inverse to HP",
+		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Boosts ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1700",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
-		"tr_explainShort": "Fire damage + ATK boost inverse to HP",
+		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Boosts ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional\n    to your HP on activation.② Deals immense Fire Element damage.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30043",
 		"jp_explainShort": "ダメージ軽減＋長槍の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly strengthens Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30044",
 		"jp_explainShort": "ダメージ大軽減＋長槍の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically strengthens Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30047",
 		"jp_explainShort": "ダメージ軽減＋長銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly strengthens Assault Rifle PA.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30048",
 		"jp_explainShort": "ダメージ大軽減＋長銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically strengthens Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30053",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
-		"tr_explainShort": "ATK boost + knockdown immunity",
+		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
-		"tr_explainShort": "ATK boost + knockdown immunity",
+		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30067",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost x # Elements equipped",
+		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number\n    of different chip elements equipped.\n② Increases DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
-		"tr_explainShort": "ATK & DEF boost x # Elements equipped",
+		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the number\n    of different chip elements equipped.\n② Boosts DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number\n    of different chip elements equipped.\n② Increases DEF based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30071",
 		"jp_explainShort": "定期的に攻撃力を上昇",
-		"tr_explainShort": "Regular ATK boosts",
+		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30072",
 		"jp_explainShort": "定期的に攻撃力を上昇",
-		"tr_explainShort": "Regular ATK boosts",
+		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30081",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Light chips",
+		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30082",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Light chips",
+		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30083",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Dark chips",
+		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30084",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Dark chips",
+		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30085",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Fire chips",
+		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30086",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
-		"tr_explainShort": "ATK boost x # of Fire chips",
+		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the\n    number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30089",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
-		"tr_explainShort": "ATK boost + HP recovery over time",
+		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Reduces current HP by 90%.\n② Dramatically boosts ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
-		"tr_explainShort": "ATK boost + HP recovery over time",
+		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Reduces current HP by 90%.\n② Dramatically boosts ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31009",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
-		"tr_explainShort": "Increased max CP + boosted CP regen",
+		"tr_explainShort": "Max CP boosted + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31010",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
-		"tr_explainShort": "Increased max CP + boosted CP regen",
+		"tr_explainShort": "Max CP boosted + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31011",
@@ -548,30 +548,30 @@
 	{
 		"assign": "31025",
 		"jp_explainShort": "ダメージ軽減＋飛翔剣の必殺技を大強化",
-		"tr_explainShort": "Damage reduced + Dual Blades PA boost",
+		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly strengthens Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31026",
 		"jp_explainShort": "ダメージ大軽減＋飛翔剣の必殺技を劇的強化",
-		"tr_explainShort": "Damage reduced + Dual Blades PA boost",
+		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically strengthens Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Dual Blade PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31029",
 		"jp_explainShort": "ダメージ軽減＋双機銃の必殺技を大強化",
-		"tr_explainShort": "Damage reduced + Machinegun PA boost",
+		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly strengthens Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31030",
 		"jp_explainShort": "ダメージ大軽減＋双機銃の必殺技を劇的強化",
-		"tr_explainShort": "Damage reduced + Machinegun PA boost",
+		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically strengthens Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31045",
@@ -632,114 +632,114 @@
 	{
 		"assign": "31061",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Wind Element",
+		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Wind Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Wind Element",
+		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Wind Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Ice Element",
+		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Ice Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Ice Element",
+		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Ice Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
-		"tr_explainShort": "ATK boost + status immunity",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK.\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
-		"tr_explainShort": "ATK boost + status immunity",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's Element weakness.\n[Effect Duration] Long"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31072",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's Element weakness.\n[Effect Duration] Long"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31085",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Dark Element",
+		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Dark Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Dark Element",
+		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Dark Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Fire Element",
+		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Fire Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
-		"tr_explainShort": "ATK boost proportional to Fire Element",
+		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK proportionately\n    to your Fire Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
-		"tr_explainShort": "Inflicts [Burn] + damage up vs [Burn]",
+		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts ATK against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
-		"tr_explainShort": "Inflicts [Burn] + damage up vs [Burn]",
+		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
-		"tr_explainShort": "ATK boosted + Katana ATK boosted",
+		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② If equipped with a Katana,\n   boosts attack power further.\n\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
-		"tr_explainShort": "ATK boosted + Katana ATK boosted",
+		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② If equipped with a Katana, boosts ATK further.\n\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② If equipped with a Katana,\n   boosts attack power further.\n\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31099",
@@ -786,42 +786,42 @@
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
-		"tr_explainShort": "ATK boost x # Elems + CP Recovery",
+		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK based on the number\n    of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
-		"tr_explainShort": "ATK boost x # Elems + CP Recovery",
+		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK based on the number\n    of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
-		"tr_explainShort": "ATK boost x # Elems + damage reduced",
+		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK based on the number\n    of different chip elements equipped.\n② Reduces damage taken based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
-		"tr_explainShort": "ATK boost x # Elems + damage reduced",
+		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK based on the number\n    of different chip elements equipped.\n② Reduces damage taken based on the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
-		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
+		"tr_explainShort": "[Freeze] + damage boost vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
-		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
+		"tr_explainShort": "[Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
 		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
 	},
@@ -870,114 +870,114 @@
 	{
 		"assign": "31175",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
-		"tr_explainShort": "All active chips activate + ATK boosted",
+		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Activates all active chips, excluding PAs &Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
-		"tr_explainShort": "All active chips activate + ATK boosted",
+		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Activates all active chips, excluding PAs &Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
-		"tr_explainShort": "ATK boosted + regular CP recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
-		"tr_explainShort": "ATK boosted + regular CP recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31189",
 		"jp_explainShort": "必殺技の威力大強化＋ダメージ軽減",
-		"tr_explainShort": "PA damage boosted + damage reduced",
+		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31190",
 		"jp_explainShort": "必殺技の威力劇的強化＋ダメージ軽減",
-		"tr_explainShort": "PA damage boosted + damage reduced",
+		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31197",
 		"jp_explainShort": "定期的に攻撃力が増加",
-		"tr_explainShort": "ATK boosted over time",
+		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
-		"tr_explainShort": "ATK boosted over time",
+		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "Active chips boost ATK & this effect",
+		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts ATK.\n② Each time you activate an active chip,\n    ATK is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts attack power.\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "Active chips boost ATK & this effect",
+		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK.\n② Each time you activate an active chip,\n    ATK is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "Active chips boost ATK & this effect",
+		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts ATK.\n② Each time you activate an active chip,\n    ATK is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly boosts attack power.\n② Each time you activate an active chip,\n    attack power is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "Active chips boost ATK & this effect",
+		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts ATK.\n② Each time you activate an active chip,\n    ATK is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n② Each time you activate an active chip,\n    attack power is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
-		"tr_explainShort": "ATK boosted + damage = HP recovery",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
-		"tr_explainShort": "ATK boosted + damage = HP recovery",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
-		"tr_explainShort": "ATK boosted + conditional Iron Will",
+		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
-		"tr_explainShort": "ATK boosted + conditional Iron Will",
+		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31227",
@@ -996,30 +996,30 @@
 	{
 		"assign": "31241",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
-		"tr_explainShort": "CP consumption reduced + ATK boosted",
+		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
-		"tr_explainShort": "CP consumption reduced + ATK boosted",
+		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
-		"tr_explainShort": "ATK boosted + Techs boosted",
+		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts ATK.\n② Slightly boosts the power of Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n② Slightly boosts the power of Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
-		"tr_explainShort": "ATK boosted + Techs boosted",
+		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts ATK.\n② Greatly boosts the power of Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n② Greatly boosts the power of Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31245",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -240,30 +240,30 @@
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Mechs",
+		"tr_explainShort": "Deals additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Mechs",
+		"tr_explainShort": "Deals additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Mechs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Darkers",
+		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Darkers",
+		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30007",
@@ -282,30 +282,30 @@
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Dragons",
+		"tr_explainShort": "Deals additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Dragons",
+		"tr_explainShort": "Deals additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Dragons.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Darkers",
+		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deal additional damage to Darkers",
+		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deal additional damage to Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30017",
@@ -760,14 +760,14 @@
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals large additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31131",
@@ -984,14 +984,14 @@
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals very large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals very large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31241",
@@ -1040,14 +1040,14 @@
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31255",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -116,14 +116,14 @@
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "1510",
@@ -200,14 +200,14 @@
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Power boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Power boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② Recovers HP based on damage done.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
@@ -396,28 +396,28 @@
 		"jp_explainShort": "ダメージ軽減＋長槍の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts the power of\n    Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30044",
 		"jp_explainShort": "ダメージ大軽減＋長槍の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of\n    Partizan PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30047",
 		"jp_explainShort": "ダメージ軽減＋長銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts the power of\n    Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30048",
 		"jp_explainShort": "ダメージ大軽減＋長銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of\n    Assault Rifle PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30053",
@@ -536,42 +536,42 @@
 		"jp_explainShort": "ダーカー以外にダメージ増加",
 		"tr_explainShort": "Damage boost against non-Darkers",
 		"jp_explainLong": "① 原生種、龍族、機甲種、海王種に\n　　 与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31012",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
 		"tr_explainShort": "Damage boost against non-Darkers",
 		"jp_explainLong": "① 原生種、龍族、機甲種、海王種に\n　　 与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31025",
 		"jp_explainShort": "ダメージ軽減＋飛翔剣の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts the power of\n    Dual Blades PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31026",
 		"jp_explainShort": "ダメージ大軽減＋飛翔剣の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of\n    Dual Blade PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Dual Blade PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31029",
 		"jp_explainShort": "ダメージ軽減＋双機銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts the power of\n    Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts the power of\n    Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31030",
 		"jp_explainShort": "ダメージ大軽減＋双機銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of\n    Twin Machinegun PAs.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of\n    Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31045",
@@ -634,42 +634,42 @@
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
@@ -690,56 +690,56 @@
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts ATK against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage against\n    enemies affected by [Burn].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② If equipped with a Katana,\n   boosts attack power further.\n\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts attack power further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② If equipped with a Katana,\n   boosts attack power further.\n\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts attack power further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31099",
@@ -774,56 +774,56 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK based on chip's ability level.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts ATK based on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK based on chip's ability level.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts ATK based on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
 		"tr_explainShort": "[Freeze] + damage boost vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
 		"tr_explainShort": "[Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31153",
@@ -872,112 +872,112 @@
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31189",
 		"jp_explainShort": "必殺技の威力大強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31190",
 		"jp_explainShort": "必殺技の威力劇的強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31197",
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n\n    <color=yellow>[G-Frame]</color>[Effect Duration] Long"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts attack power.\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts attack power.\n② Each time you activate an active chip,\n    attack power is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n② Each time you activate an active chip,\n    attack power is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31227",
@@ -998,84 +998,84 @@
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n② Slightly boosts the power of Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n② Greatly boosts the power of Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31249",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly boosts ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly boosts ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31255",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31259",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31260",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31269",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -200,14 +200,14 @@
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP based on damage done.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
@@ -662,14 +662,14 @@
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
@@ -984,14 +984,14 @@
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly raises the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically raises the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31241",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1038,16 +1038,16 @@
 	{
 		"assign": "31249",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
-		"tr_explainShort": "3 attacks = ATK up + additional damage",
+		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK.\n    (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
-		"tr_explainShort": "3 attacks = ATK up + additional damage",
+		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly increases ATK.\n    (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31255",
@@ -1080,86 +1080,86 @@
 	{
 		"assign": "31269",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
-		"tr_explainShort": "All Attribute. Boost + ATK Boost",
+		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "Greatly boosts all Attribute. and dramatically boosts\nATK for a period of time."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31270",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
-		"tr_explainShort": "All Attribute. Boost + ATK Boost",
+		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts all Attribute. and dramatically boosts\nATK for a period of time."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31271",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Boost ATK + Converts Damage into HP",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "-",
-		"tr_explainLong": "Enormously boosts ATK and converts part\nof damage done into recovery\nof HP for a long duration."
+		"tr_explainLong": ""
 	},
 	{
 		"assign": "31272",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Boost ATK + Converts Damage into HP",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "-",
-		"tr_explainLong": "Enormously boosts ATK and converts part\nof damage done into recovery\nof HP for a long duration."
+		"tr_explainLong": ""
 	},
 	{
 		"assign": "31277",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
-		"tr_explainShort": "CP Consumption for Techs and PA+Power Boost",
+		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "This chip increases CP consumption for PAs\n& Techs while boosting their power tremendously."
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31278",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
-		"tr_explainShort": "CP Consumption for Techs and PA+Power Boost",
+		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "This chip increases CP consumption for PAs\n& Techs while boosting their power tremendously."
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31291",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
-		"tr_explainShort": "Increased Weak Attribute. Damage + ATK Boost",
+		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically increase damage done to\nenemy's weak Attribute. and greatly increase ATK."
+		"tr_explainLong": "① Dramatically increases the target\n    enemy's weakness Element value.\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31292",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
-		"tr_explainShort": "Increased Weak Attribute. Damage + Boost ATK",
+		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically increase damage done to\nenemy's weak Attribute. and greatly increase ATK."
+		"tr_explainLong": "① Dramatically increases the target\n    enemy's weakness Element value.\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31311",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
-		"tr_explainShort": "",
+		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Excellent)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31312",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
-		"tr_explainShort": "",
+		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Excellent)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31315",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n②  Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31316",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n②  Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31319",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -746,14 +746,14 @@
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Decreases CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31100",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Decreases CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31119",
@@ -816,14 +816,14 @@
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
 		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
 		"tr_explainShort": "Inflicts [Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31153",
@@ -842,16 +842,16 @@
 	{
 		"assign": "31163",
 		"jp_explainShort": "定期的に劇的ダメージ",
-		"tr_explainShort": "Boost ATK over time",
+		"tr_explainShort": "Regular dramatic damage",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた劇的ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK against targeted\nenemy over time for a long duration."
+		"tr_explainLong": "① Deals regular dramatic damage to the\n    targeted enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "定期的に絶大ダメージ",
-		"tr_explainShort": "Boost ATK over time",
+		"tr_explainShort": "Regular immense damage",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた絶大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK against targeted\nenemy over time for a long duration."
+		"tr_explainLong": "① Deals regular immense damage to the\n    targeted enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31171",
@@ -870,156 +870,156 @@
 	{
 		"assign": "31175",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
-		"tr_explainShort": "All Active Chips Activation + ATK Boost",
+		"tr_explainShort": "All active chips activate + ATK boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "Activates all effects of active chips, excluding PA &\nTech and dramatically boosts ATK for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Activates all active chips, excluding PAs &Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
-		"tr_explainShort": "All Active Chips Activation + ATK Boost",
+		"tr_explainShort": "All active chips activate + ATK boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "Activates all effects of active chips, excluding PA &\nTech and dramatically boosts ATK for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Activates all active chips, excluding PAs &Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
-		"tr_explainShort": "ATK Boost + Periodic CP Recovery",
+		"tr_explainShort": "ATK boosted + regular CP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK and periodic\nCP recovery for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
-		"tr_explainShort": "ATK Boost + Periodic CP Recovery",
+		"tr_explainShort": "ATK boosted + regular CP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK and periodic\nCP recovery for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31189",
 		"jp_explainShort": "必殺技の威力大強化＋ダメージ軽減",
-		"tr_explainShort": "PA Damage Boost + Damage Mitigation",
+		"tr_explainShort": "PA damage boosted + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts PA Damage and reduces damage\ntaken for a long duration."
+		"tr_explainLong": "① Greatly boosts PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31190",
 		"jp_explainShort": "必殺技の威力劇的強化＋ダメージ軽減",
-		"tr_explainShort": "PA Damage Boost + Damage Mitigation",
+		"tr_explainShort": "PA damage boosted + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts PA damage and reduces damage\ntaken for a long duration."
+		"tr_explainLong": "① Dramatically boosts PA damage.\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31197",
 		"jp_explainShort": "定期的に攻撃力が増加",
-		"tr_explainShort": "Boost ATK over time",
+		"tr_explainShort": "ATK boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "Periodically boosts ATK (up to a\ndramatic boost) for a long duration."
+		"tr_explainLong": "① Boosts ATK slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
-		"tr_explainShort": "Boost ATK over time",
+		"tr_explainShort": "ATK boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "Periodically boosts ATK (up to an\nenormous boost) for a long duration."
+		"tr_explainLong": "① Boosts ATK slightly at regular intervals.\n    (Maximum boost: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "ATK Boost + Effect Time Extension",
+		"tr_explainShort": "Active chips boost ATK & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "Boost ATK. In addition, each activation of\nan active chip gives a slight ATK boost and\nextension of effect."
+		"tr_explainLong": "① Boosts ATK.\n② Each time you activate an active chip,\n    ATK is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "ATK Boost + Effect Time Extension",
+		"tr_explainShort": "Active chips boost ATK & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK. In addition, each activation\nof an active chip gives a slight ATK boost and\nextension of effect."
+		"tr_explainLong": "① Greatly boosts ATK.\n② Each time you activate an active chip,\n    ATK is slightly further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "ATK Boost + Effect Time Extension",
+		"tr_explainShort": "Active chips boost ATK & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK. In addition, each activation\nof an active chip gives a slight ATK boost and\nextension of effect."
+		"tr_explainLong": "① Slightly boosts ATK.\n② Each time you activate an active chip,\n    ATK is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
-		"tr_explainShort": "ATK Boost + Effect Time Extension",
+		"tr_explainShort": "Active chips boost ATK & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts ATK. In addition, each activation of\nan active chip gives a slight ATK boost and\nextension of effect."
+		"tr_explainLong": "① Boosts ATK.\n② Each time you activate an active chip,\n    ATK is further boosted.\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
-		"tr_explainShort": "ATK Boost + Converts Damage into HP",
+		"tr_explainShort": "ATK boosted + damage = HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK and converts part\nof damage done into recovery of HP for a\nlong duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
-		"tr_explainShort": "ATK Boost + Converts Damage into HP",
+		"tr_explainShort": "ATK boosted + damage = HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK and converts part\nof damage done into recovery of HP for a\nlong duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
-		"tr_explainShort": "Increases ATK power + iron will under conditions",
+		"tr_explainShort": "ATK boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically increases attack power\nfor a long while. Prevents a single\ninstance of incapacitation if the #\nof lightning chips equipped is 2 or less."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
-		"tr_explainShort": "",
+		"tr_explainShort": "ATK boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically increases attack power\nfor a long while. Prevents a single\ninstance of incapacitation if the #\nof lightning chips equipped is 2 or less."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Prevents a single incapacitation if the #\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31227",
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
-		"tr_explainShort": "Lightning Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boost ATK and increases\nLightning Attribute. for a long duration."
+		"tr_explainLong": "① Greatly raises the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
-		"tr_explainShort": "Lightning Attribute. Boosted + ATK Boost",
+		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "Greatly boosts ATK and dramatically\nincreases Lightning Attr for a long duration."
+		"tr_explainLong": "① Dramatically raises the Lightning Element.\n② Deals very large additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31241",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
-		"tr_explainShort": "CP Consumption Decreased + ATK Boost",
+		"tr_explainShort": "CP consumption reduced + ATK boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK while reducing\nconsumption of CP for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
-		"tr_explainShort": "CP Consumption Decreased + ATK Boost",
+		"tr_explainShort": "CP consumption reduced + ATK boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boosts ATK while reducing\nconsumption of CP for a long duration."
+		"tr_explainLong": "① Dramatically boosts ATK.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
-		"tr_explainShort": "ATK Boost + Boost Tech",
+		"tr_explainShort": "ATK boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boost ATK and slightly\nboost Techs for a long duration."
+		"tr_explainLong": "① Immensely boosts ATK.\n② Slightly boosts the power of Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
-		"tr_explainShort": "ATK Boost + Boost Tech",
+		"tr_explainShort": "ATK boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK and greatly\nboost Techs for a long duration."
+		"tr_explainLong": "① Immensely boosts ATK.\n② Greatly boosts the power of Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31245",
@@ -1556,16 +1556,16 @@
 	{
 		"assign": "31539",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
-		"tr_explainShort": "",
+		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種かダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "Decreases CP consumption and dramatically increases\ndamage towards Mechs. The decreased CP\nconsumption effect also applies to this Chip upon\nactivation.\n<color=yellow>[B-Frame]</color>"
+		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n<color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31540",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
-		"tr_explainShort": "",
+		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種かダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "Decreases CP consumption and dramatically increases\ndamage towards Mechs. The decreased CP\nconsumption effect also applies to this Chip upon\nactivation.\n<color=yellow>[B-Frame]</color>"
+		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n<color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31543",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -198,16 +198,16 @@
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Power boosted + damage HP recovery",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
-		"tr_explainShort": "Power boosted + damage HP recovery",
+		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n② Recovers HP based on damage done.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
@@ -634,42 +634,42 @@
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n② Grants immunity to status effects.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
@@ -690,28 +690,28 @@
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted based on Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",
@@ -732,14 +732,14 @@
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts attack power further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts damage further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts attack power further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② If equipped with a Katana,\n   boosts damage further.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31099",
@@ -788,28 +788,28 @@
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the\n    number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
@@ -872,28 +872,28 @@
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31189",
@@ -914,70 +914,70 @@
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage slightly at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power slightly at regular intervals.\n    (Maximum boost: Immense)\n\n    <color=yellow>[G-Frame]</color>[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage slightly at regular intervals.\n    (Maximum boost: Immense)\n\n    <color=yellow>[G-Frame]</color>[Effect Duration] Long"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間をわずかに延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    attack power is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is slightly extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31227",
@@ -998,42 +998,42 @@
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31249",
@@ -1054,14 +1054,14 @@
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31259",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1024,58 +1024,58 @@
 	{
 		"assign": "31245",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが微回復",
-		"tr_explainShort": "ATK Boost + Periodic CP Recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK and periodically\nrecovers CP for a long duration."
+		"tr_explainLong": "① Immensely boosts attack power.\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが回復",
-		"tr_explainShort": "Boost ATK + Periodic CP Recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Enormously boosts ATK and periodically\nrecovers CP for a long duration."
+		"tr_explainLong": "① Immensely boosts attack power.\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31249",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly boosts ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "3 attacks = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, greatly boosts ATK. (Maximum boost: Immense)\n② Deals small additional damage to enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31255",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
-		"tr_explainShort": "Boost ATK proportional to Chips equipped + Effect Time Extension",
+		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boost ATK proportional to the amount of\ndifferent element chips equipped, and gives addition\ntime to all other active chips on activation."
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
-		"tr_explainShort": "Boost ATK proportional to Chips equipped + Effect Time Extension",
+		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "Dramatically boost ATK proportional to the amount of\ndifferent element chips equipped, and gives addition\ntime to all other active chips on activation."
+		"tr_explainLong": "① Dramatically boosts attack power based on the\n    number of different equipped chip elements.\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31259",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
-		"tr_explainShort": "HP Recovery + Tech Boost Proportional to Ability Level",
+		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Recovers HP and boosts Tech damage proportional\nto chip ability level for a long duration."
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31260",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
-		"tr_explainShort": "HP Recovery + Tech Boost Proportional to Ability Level",
+		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Recovers HP and boosts Tech damage proportional\nto chip ability level for a long duration."
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31269",

--- a/json/Explain_Element_Special.txt
+++ b/json/Explain_Element_Special.txt
@@ -982,7 +982,7 @@
 	{
 		"assign": "140",
 		"jp_text": "エンペ・エンブレイス",
-		"tr_text": "Empe Embrace",
+		"tr_text": "Emper Embrace",
 		"jp_explain": "新世武器強化時の\n経験値が９０増加する",
 		"tr_explain": "Adds 90 EXP to\nNT weapon grinds."
 	},

--- a/json/Item_Parts_ArmFemale.txt
+++ b/json/Item_Parts_ArmFemale.txt
@@ -634,14 +634,14 @@
 		"jp_text": "デルマーチ・アーム",
 		"tr_text": "Delmarch Arms",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "64094",
 		"jp_text": "デルマーチ・アームＣＶ",
 		"tr_text": "Delmarch Arms CV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "64095",
@@ -942,7 +942,7 @@
 		"jp_text": "デルマーチ・アームＧＶ",
 		"tr_text": "Delmarch Arms GV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "640162",

--- a/json/Item_Parts_ArmFemale.txt
+++ b/json/Item_Parts_ArmFemale.txt
@@ -11,21 +11,21 @@
 		"jp_text": "ディール・アーム",
 		"tr_text": "Deal Arms",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "6402",
 		"jp_text": "ローズ・アーム",
 		"tr_text": "Rose Arms",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "6403",
 		"jp_text": "ファーネン・アーム",
 		"tr_text": "Fanen Arms",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "6404",
@@ -74,21 +74,21 @@
 		"jp_text": "ディール・アームＣＶ",
 		"tr_text": "Deal Arms CV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "64011",
 		"jp_text": "ローズ・アームＣＶ",
 		"tr_text": "Rose Arms CV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "64013",
 		"jp_text": "ファーネン・アームＣＶ",
 		"tr_text": "Fanen Arms CV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "64014",
@@ -438,21 +438,21 @@
 		"jp_text": "ディール・アームＧＶ",
 		"tr_text": "Deal Arms GV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "64064",
 		"jp_text": "ローズ・アームＧＶ",
 		"tr_text": "Rose Arms GV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "64065",
 		"jp_text": "ファーネン・アームＧＶ",
 		"tr_text": "Fanen Arms GV",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "64066",

--- a/json/Item_Parts_ArmFemale.txt
+++ b/json/Item_Parts_ArmFemale.txt
@@ -949,6 +949,6 @@
 		"jp_text": "マーヴ・アーム",
 		"tr_text": "Marv Arms",
 		"jp_explain": "女性キャスト向けの腕部パーツ。\n天然鉱をあしらった鮮やかなデザインに\n機動性と重厚さを兼ね備えたモデル。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for female Casts. A\nbeautiful design adorned with natural\nore, combining weight and mobility."
 	}
 ]

--- a/json/Item_Parts_ArmMale.txt
+++ b/json/Item_Parts_ArmMale.txt
@@ -4,21 +4,21 @@
 		"jp_text": "ディスタ・アーム",
 		"tr_text": "Dista Arms",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "6301",
 		"jp_text": "ロニア・アーム",
 		"tr_text": "Ronia Arms",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "6302",
 		"jp_text": "ファウマ・アーム",
 		"tr_text": "Fauma Arms",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "6303",
@@ -74,21 +74,21 @@
 		"jp_text": "ディスタ・アームＣＶ",
 		"tr_text": "Dista Arms CV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "63011",
 		"jp_text": "ロニア・アームＣＶ",
 		"tr_text": "Ronia Arms CV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "63013",
 		"jp_text": "ファウマ・アームＣＶ",
 		"tr_text": "Fauma Arms CV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "63014",
@@ -396,21 +396,21 @@
 		"jp_text": "ディスタ・アームＧＶ",
 		"tr_text": "Dista Arms GV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "63058",
 		"jp_text": "ロニア・アームＧＶ",
 		"tr_text": "Ronia Arms GV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "63059",
 		"jp_text": "ファウマ・アームＧＶ",
 		"tr_text": "Fauma Arms GV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "63060",

--- a/json/Item_Parts_ArmMale.txt
+++ b/json/Item_Parts_ArmMale.txt
@@ -592,14 +592,14 @@
 		"jp_text": "アコーディ・アーム",
 		"tr_text": "Accordi Arms",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "63088",
 		"jp_text": "アコーディ・アームＣＶ",
 		"tr_text": "Accordi Arms CV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "63089",
@@ -900,7 +900,7 @@
 		"jp_text": "アコーディ・アームＧＶ",
 		"tr_text": "Accordi Arms GV",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "630156",

--- a/json/Item_Parts_ArmMale.txt
+++ b/json/Item_Parts_ArmMale.txt
@@ -907,6 +907,6 @@
 		"jp_text": "クリスト・アーム",
 		"tr_text": "Crysto Arms",
 		"jp_explain": "男性キャスト向けの腕部パーツ。\n天然鉱をあしらった派手なデザインを\n採用しつつ、硬度と放熱性に優れる。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A flashy\ndesign adorned with natural ore, for\nhigh heat absorption and hardness."
 	}
 ]

--- a/json/Item_Parts_BodyFemale.txt
+++ b/json/Item_Parts_BodyFemale.txt
@@ -11,21 +11,21 @@
 		"jp_text": "ディール・ボディ",
 		"tr_text": "Deal Body",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "6202",
 		"jp_text": "ローズ・ボディ",
 		"tr_text": "Rose Body",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "6203",
 		"jp_text": "ファーネン・ボディ",
 		"tr_text": "Fanen Body",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "6204",
@@ -74,21 +74,21 @@
 		"jp_text": "ディール・ボディＣＶ",
 		"tr_text": "Deal Body CV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "62011",
 		"jp_text": "ローズ・ボディＣＶ",
 		"tr_text": "Rose Body CV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "62013",
 		"jp_text": "ファーネン・ボディＣＶ",
 		"tr_text": "Fanen Body CV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "62014",
@@ -438,21 +438,21 @@
 		"jp_text": "ディール・ボディＧＶ",
 		"tr_text": "Deal Body GV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "62064",
 		"jp_text": "ローズ・ボディＧＶ",
 		"tr_text": "Rose Body GV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "62065",
 		"jp_text": "ファーネン・ボディＧＶ",
 		"tr_text": "Fanen Body GV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "62066",

--- a/json/Item_Parts_BodyFemale.txt
+++ b/json/Item_Parts_BodyFemale.txt
@@ -942,6 +942,6 @@
 		"jp_text": "マーヴ・ボディ",
 		"tr_text": "Marv Body",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\n天然鉱をあしらった鮮やかなデザインに\n機動性と重厚さを兼ね備えたモデル。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts. A\nbeautiful design adorned with natural\nore, combining weight and mobility."
 	}
 ]

--- a/json/Item_Parts_BodyFemale.txt
+++ b/json/Item_Parts_BodyFemale.txt
@@ -627,14 +627,14 @@
 		"jp_text": "デルマーチ・ボディ",
 		"tr_text": "Delmarch Body",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "62093",
 		"jp_text": "デルマーチ・ボディＣＶ",
 		"tr_text": "Delmarch Body CV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "62094",
@@ -935,7 +935,7 @@
 		"jp_text": "デルマーチ・ボディＧＶ",
 		"tr_text": "Delmarch Body GV",
 		"jp_explain": "女性キャスト向けの基礎的なパーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "620161",

--- a/json/Item_Parts_BodyMale.txt
+++ b/json/Item_Parts_BodyMale.txt
@@ -900,6 +900,6 @@
 		"jp_text": "クリスト・ボディ",
 		"tr_text": "Crysto Body",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n天然鉱をあしらった派手なデザインを\n採用しつつ、硬度と放熱性に優れる。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. A flashy\ndesign adorned with natural ore, for\nhigh heat absorption and hardness."
 	}
 ]

--- a/json/Item_Parts_BodyMale.txt
+++ b/json/Item_Parts_BodyMale.txt
@@ -4,21 +4,21 @@
 		"jp_text": "ディスタ・ボディ",
 		"tr_text": "Dista Body",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "6101",
 		"jp_text": "ロニア・ボディ",
 		"tr_text": "Ronia Body",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "6102",
 		"jp_text": "ファウマ・ボディ",
 		"tr_text": "Fauma Body",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "6103",
@@ -74,21 +74,21 @@
 		"jp_text": "ディスタ・ボディＣＶ",
 		"tr_text": "Dista Body CV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "61011",
 		"jp_text": "ロニア・ボディＣＶ",
 		"tr_text": "Ronia Body CV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "61013",
 		"jp_text": "ファウマ・ボディＣＶ",
 		"tr_text": "Fauma Body CV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "61014",
@@ -396,21 +396,21 @@
 		"jp_text": "ディスタ・ボディＧＶ",
 		"tr_text": "Dista Body GV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "61058",
 		"jp_text": "ロニア・ボディＧＶ",
 		"tr_text": "Ronia Body GV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "61059",
 		"jp_text": "ファウマ・ボディＧＶ",
 		"tr_text": "Fauma Body GV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "61060",

--- a/json/Item_Parts_BodyMale.txt
+++ b/json/Item_Parts_BodyMale.txt
@@ -585,14 +585,14 @@
 		"jp_text": "アコーディ・ボディ",
 		"tr_text": "Accordi Body",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "61087",
 		"jp_text": "アコーディ・ボディＣＶ",
 		"tr_text": "Accordi Body CV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "61088",
@@ -893,7 +893,7 @@
 		"jp_text": "アコーディ・ボディＧＶ",
 		"tr_text": "Accordi Body GV",
 		"jp_explain": "男性キャスト向けの基礎的なパーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Core parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "610155",

--- a/json/Item_Parts_LegFemale.txt
+++ b/json/Item_Parts_LegFemale.txt
@@ -634,14 +634,14 @@
 		"jp_text": "デルマーチ・レッグ",
 		"tr_text": "Delmarch Legs",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "66094",
 		"jp_text": "デルマーチ・レッグＣＶ",
 		"tr_text": "Delmarch Legs CV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "66095",
@@ -942,7 +942,7 @@
 		"jp_text": "デルマーチ・レッグＧＶ",
 		"tr_text": "Delmarch Legs GV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\nマーチングバンド衣装をベースに設計。\n可愛らしさと機能性を兼ね備えている。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts.\nBased on a marching band costume.\nCute, yet functional."
 	},
 	{
 		"assign": "660162",

--- a/json/Item_Parts_LegFemale.txt
+++ b/json/Item_Parts_LegFemale.txt
@@ -11,21 +11,21 @@
 		"jp_text": "ディール・レッグ",
 		"tr_text": "Deal Legs",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "6602",
 		"jp_text": "ローズ・レッグ",
 		"tr_text": "Rose Legs",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "6603",
 		"jp_text": "ファーネン・レッグ",
 		"tr_text": "Fanen Legs",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "6604",
@@ -74,21 +74,21 @@
 		"jp_text": "ディール・レッグＣＶ",
 		"tr_text": "Deal Legs CV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "66011",
 		"jp_text": "ローズ・レッグＣＶ",
 		"tr_text": "Rose Legs CV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "66013",
 		"jp_text": "ファーネン・レッグＣＶ",
 		"tr_text": "Fanen Legs CV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "66014",
@@ -438,21 +438,21 @@
 		"jp_text": "ディール・レッグＧＶ",
 		"tr_text": "Deal Legs GV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n安定性が重視され、主にレンジャーが\n愛用するモデルで見た目の人気も高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. With a\nfocus on stability, they are popular\namong Rangers for their appearance."
 	},
 	{
 		"assign": "66064",
 		"jp_text": "ローズ・レッグＧＶ",
 		"tr_text": "Rose Legs GV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n機動力と軽量化に突出したモデルであり\nハンタークラスの愛用者が多い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A very\nlightweight, mobile model, which has\nmany followers among Hunters."
 	},
 	{
 		"assign": "66065",
 		"jp_text": "ファーネン・レッグＧＶ",
 		"tr_text": "Fanen Legs GV",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n大気中のフォトンと積極感応するための\nデザインで、フォースに人気が高い。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A\npopular design among Forces for its\nsensitivity to atmospheric Photons."
 	},
 	{
 		"assign": "66066",

--- a/json/Item_Parts_LegFemale.txt
+++ b/json/Item_Parts_LegFemale.txt
@@ -949,6 +949,6 @@
 		"jp_text": "マーヴ・レッグ",
 		"tr_text": "Marv Legs",
 		"jp_explain": "女性キャスト向けの脚部パーツ。\n天然鉱をあしらった鮮やかなデザインに\n機動性と重厚さを兼ね備えたモデル。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for female Casts. A\nbeautiful design adorned with natural\nore, combining weight and mobility."
 	}
 ]

--- a/json/Item_Parts_LegMale.txt
+++ b/json/Item_Parts_LegMale.txt
@@ -907,6 +907,6 @@
 		"jp_text": "クリスト・レッグ",
 		"tr_text": "Crysto Legs",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n天然鉱をあしらった派手なデザインを\n採用しつつ、硬度と放熱性に優れる。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. A flashy\ndesign adorned with natural ore, for\nhigh heat absorption and hardness."
 	}
 ]

--- a/json/Item_Parts_LegMale.txt
+++ b/json/Item_Parts_LegMale.txt
@@ -592,14 +592,14 @@
 		"jp_text": "アコーディ・レッグ",
 		"tr_text": "Accordi Legs",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "65088",
 		"jp_text": "アコーディ・レッグＣＶ",
 		"tr_text": "Accordi Legs CV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "65089",
@@ -900,7 +900,7 @@
 		"jp_text": "アコーディ・レッグＧＶ",
 		"tr_text": "Accordi Legs GV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n各部に搭載されたジェネレーターが\n安定したエネルギー供給を実現した。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Each part\nhas been fitted with generators to\nensure a steady energy supply."
 	},
 	{
 		"assign": "650156",

--- a/json/Item_Parts_LegMale.txt
+++ b/json/Item_Parts_LegMale.txt
@@ -4,21 +4,21 @@
 		"jp_text": "ディスタ・レッグ",
 		"tr_text": "Dista Legs",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "6501",
 		"jp_text": "ロニア・レッグ",
 		"tr_text": "Ronia Legs",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "6502",
 		"jp_text": "ファウマ・レッグ",
 		"tr_text": "Fauma Legs",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "6503",
@@ -74,21 +74,21 @@
 		"jp_text": "ディスタ・レッグＣＶ",
 		"tr_text": "Dista Legs CV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "65011",
 		"jp_text": "ロニア・レッグＣＶ",
 		"tr_text": "Ronia Legs CV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "65013",
 		"jp_text": "ファウマ・レッグＣＶ",
 		"tr_text": "Fauma Legs CV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "65014",
@@ -396,21 +396,21 @@
 		"jp_text": "ディスタ・レッグＧＶ",
 		"tr_text": "Dista Legs GV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\n安定性の高い箱形のフォルムがベースで\n主にレンジャークラスが愛用している。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts.\nA stable, boxy design mainly favored\nby Rangers."
 	},
 	{
 		"assign": "65058",
 		"jp_text": "ロニア・レッグＧＶ",
 		"tr_text": "Ronia Legs GV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nその機動性と、シャープなフォルムが\nハンタークラスに人気の理由。",
-		"tr_explain": ""
+		"tr_explain": "Leg parts for male Casts. Popular\nwith Hunters for their ease of\nmobility and their sharp appearance."
 	},
 	{
 		"assign": "65059",
 		"jp_text": "ファウマ・レッグＧＶ",
 		"tr_text": "Fauma Legs GV",
 		"jp_explain": "男性キャスト向けの脚部パーツ。\nゆったりとした布のようなフォルムは\nフォトンへの感応性を高めるという。",
-		"tr_explain": ""
+		"tr_explain": "Arm parts for male Casts. A loose,\ncloth-like design said to increase\nsensitivity to Photons."
 	},
 	{
 		"assign": "65060",

--- a/json/Item_Stack_Boost.txt
+++ b/json/Item_Stack_Boost.txt
@@ -200,7 +200,7 @@
 		"jp_text": "獲得経験値＋１５０％",
 		"tr_text": "Experience Gained +150%",
 		"jp_explain": "獲得経験値上昇のブーストアイテム。\n使用してから【６０分】の間だけ\n獲得経験値を１５０％アップさせる。",
-		"tr_explain": "Boosts Meseta dropped by 150%.\nDuration lasts for 60 minutes\non the field."
+		"tr_explain": "Boosts EXP gained by 150%.\nDuration lasts for 60 minutes\non the field."
 	},
 	{
 		"assign": "32050",

--- a/json/Item_Stack_PaidTicket.txt
+++ b/json/Item_Stack_PaidTicket.txt
@@ -900,56 +900,56 @@
 		"jp_text": "１スタージェム",
 		"tr_text": "1 Star Gem",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１】獲得する。",
-		"tr_explain": "Use to immediately receive\n1 SG."
+		"tr_explain": "When received, immediately awards\n1 SG."
 	},
 	{
 		"assign": "3200138",
 		"jp_text": "２スタージェム",
 		"tr_text": "2 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２】獲得する。",
-		"tr_explain": "Use to immediately receive\n2 SG."
+		"tr_explain": "When received, immediately awards\n2 SG."
 	},
 	{
 		"assign": "3200139",
 		"jp_text": "５スタージェム",
 		"tr_text": "5 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【５】獲得する。",
-		"tr_explain": "Use to immediately receive\n5 SG."
+		"tr_explain": "When received, immediately awards\n5 SG."
 	},
 	{
 		"assign": "3200140",
 		"jp_text": "１０スタージェム",
 		"tr_text": "10 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１０】獲得する。",
-		"tr_explain": "Use to immediately receive\n10 SG."
+		"tr_explain": "When received, immediately awards\n10 SG."
 	},
 	{
 		"assign": "3200141",
 		"jp_text": "５０スタージェム",
 		"tr_text": "50 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【５０】獲得する。",
-		"tr_explain": "Use to immediately receive\n50 SG."
+		"tr_explain": "When received, immediately awards\n50 SG."
 	},
 	{
 		"assign": "3200142",
 		"jp_text": "１００スタージェム",
 		"tr_text": "100 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１００】獲得する。",
-		"tr_explain": "Use to immediately receive\n100 SG."
+		"tr_explain": "When received, immediately awards\n100 SG."
 	},
 	{
 		"assign": "3200143",
 		"jp_text": "２００スタージェム",
 		"tr_text": "200 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２００】獲得する。",
-		"tr_explain": "Use to immediately receive\n200 SG."
+		"tr_explain": "When received, immediately awards\n200 SG."
 	},
 	{
 		"assign": "3200144",
 		"jp_text": "１０００スタージェム",
 		"tr_text": "1000 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１０００】獲得する。",
-		"tr_explain": "Use to immediately receive\n1000 SG."
+		"tr_explain": "When received, immediately awards\n1000 SG."
 	},
 	{
 		"assign": "3200146",
@@ -1075,7 +1075,7 @@
 		"jp_text": "２０スタージェム",
 		"tr_text": "20 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２０】獲得する。",
-		"tr_explain": "Use to immediately receive\n20 SG."
+		"tr_explain": "When received, immediately awards\n20 SG."
 	},
 	{
 		"assign": "3200165",
@@ -1117,14 +1117,14 @@
 		"jp_text": "３０スタージェム",
 		"tr_text": "30 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【３０】獲得する。",
-		"tr_explain": "Use to immediately receive\n30 SG."
+		"tr_explain": "When received, immediately awards\n30 SG."
 	},
 	{
 		"assign": "3200171",
 		"jp_text": "４０スタージェム",
 		"tr_text": "40 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【４０】獲得する。",
-		"tr_explain": "Use to immediately receive\n40 SG."
+		"tr_explain": "When received, immediately awards\n40 SG."
 	},
 	{
 		"assign": "3200172",

--- a/json/Item_Stack_PaidTicket.txt
+++ b/json/Item_Stack_PaidTicket.txt
@@ -137,21 +137,21 @@
 		"jp_text": "ＦＵＮ１００獲得チケット",
 		"tr_text": "FUN 100 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 FUN."
 	},
 	{
 		"assign": "320021",
 		"jp_text": "ＦＵＮ５００獲得チケット",
 		"tr_text": "FUN 500 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【５００】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"500\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n500 FUN."
 	},
 	{
 		"assign": "320022",
 		"jp_text": "ＦＵＮ１０００獲得チケット",
 		"tr_text": "FUN 1000 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 FUN."
 	},
 	{
 		"assign": "320023",
@@ -172,7 +172,7 @@
 		"jp_text": "ＦＵＮ５０獲得チケット",
 		"tr_text": "FUN 50 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【５０】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"50\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n50 FUN."
 	},
 	{
 		"assign": "320026",
@@ -214,77 +214,77 @@
 		"jp_text": "ＡＣ１００獲得チケット",
 		"tr_text": "AC 100 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 ARKS Cash."
 	},
 	{
 		"assign": "320032",
 		"jp_text": "ＡＣ２００獲得チケット",
 		"tr_text": "AC 200 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【２００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"200\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n200 ARKS Cash."
 	},
 	{
 		"assign": "320033",
 		"jp_text": "ＡＣ５００獲得チケット",
 		"tr_text": "AC 500 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【５００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"500\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n500 ARKS Cash."
 	},
 	{
 		"assign": "320034",
 		"jp_text": "ＡＣ１０００獲得チケット",
 		"tr_text": "AC 1000 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 ARKS Cash."
 	},
 	{
 		"assign": "320035",
 		"jp_text": "ＡＣ３０００獲得チケット",
 		"tr_text": "AC 3000 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【３０００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"3000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n3000 ARKS Cash."
 	},
 	{
 		"assign": "320036",
 		"jp_text": "ＡＣ５０００獲得チケット",
 		"tr_text": "AC 5000 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【５０００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"5000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n5000 ARKS Cash."
 	},
 	{
 		"assign": "320037",
 		"jp_text": "ＡＣ１００００獲得チケット",
 		"tr_text": "AC 10000 Ticket",
 		"jp_explain": "ＡＣの授与申請チケット。\nチケットを使用すると\nＡＣを【１００００】獲得可能。",
-		"tr_explain": "This ticket, awards ARKS Cash\nwhen used.\nAC \"10000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n10000 ARKS Cash."
 	},
 	{
 		"assign": "320040",
 		"jp_text": "ＣＰ１００獲得チケット",
 		"tr_text": "CP 100 Ticket",
 		"jp_explain": "ＣＰ（カフェポイント）の授与申請チケット。\nチケットを使用すると\nＣＰを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards Cafe Points\nwhen used.\nCP \"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 Cafe Points."
 	},
 	{
 		"assign": "320041",
 		"jp_text": "ＣＰ２００獲得チケット",
 		"tr_text": "CP 200 Ticket",
 		"jp_explain": "ＣＰ（カフェポイント）の授与申請チケット。\nチケットを使用すると\nＣＰを【２００】獲得可能。",
-		"tr_explain": "This ticket, awards Cafe Points\nwhen used.\nCP \"200\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n200 Cafe Points."
 	},
 	{
 		"assign": "320042",
 		"jp_text": "ＣＰ５００獲得チケット",
 		"tr_text": "CP 500 Ticket",
 		"jp_explain": "ＣＰ（カフェポイント）の授与申請チケット。\nチケットを使用すると\nＣＰを【５００】獲得可能。",
-		"tr_explain": "This ticket, awards Cafe Points\nwhen used.\nCP \"500\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n500 Cafe Points."
 	},
 	{
 		"assign": "320043",
 		"jp_text": "ＣＰ１０００獲得チケット",
 		"tr_text": "CP 1000 Ticket",
 		"jp_explain": "ＣＰ（カフェポイント）の授与申請チケット。\nチケットを使用すると\nＣＰを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards Cafe Points\nwhen used.\nCP \"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 Cafe Points."
 	},
 	{
 		"assign": "320044",
@@ -298,7 +298,7 @@
 		"jp_text": "ＦＵＮ５５５獲得チケット",
 		"tr_text": "FUN 555 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【５５５】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"555\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n555 FUN."
 	},
 	{
 		"assign": "320047",
@@ -571,14 +571,14 @@
 		"jp_text": "ＦＵＮ２０１４獲得チケット",
 		"tr_text": "FUN 2014 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【２０１４】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"2014\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2014 FUN."
 	},
 	{
 		"assign": "320086",
 		"jp_text": "ＦＵＮ７１１獲得チケット",
 		"tr_text": "FUN 711 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【７１１】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"711\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n711 FUN."
 	},
 	{
 		"assign": "320087",
@@ -676,28 +676,28 @@
 		"jp_text": "ＣＣ１００獲得チケット",
 		"tr_text": "CC 100 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 Casino Coins."
 	},
 	{
 		"assign": "3200104",
 		"jp_text": "ＣＣ１０００獲得チケット",
 		"tr_text": "CC 1000 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 Casino Coins."
 	},
 	{
 		"assign": "3200105",
 		"jp_text": "ＣＣ５０００獲得チケット",
 		"tr_text": "CC 5000 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【５０００】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"5000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n5000 Casino Coins."
 	},
 	{
 		"assign": "3200106",
 		"jp_text": "ＣＣ１００００獲得チケット",
 		"tr_text": "CC 10000 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【１００００】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"10000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n10000 Casino Coins."
 	},
 	{
 		"assign": "3200107",
@@ -718,63 +718,63 @@
 		"jp_text": "ＦＵＮ７７７獲得チケット",
 		"tr_text": "FUN 777 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【７７７】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN \"777\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n777 FUN."
 	},
 	{
 		"assign": "3200110",
 		"jp_text": "ＣＣ５０獲得チケット",
 		"tr_text": "CC 50 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【５０】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"50\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n50 Casino Coins."
 	},
 	{
 		"assign": "3200111",
 		"jp_text": "ＣＣ４５０獲得チケット",
 		"tr_text": "CC 450 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【４５０】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"450\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n450 Casino Coins."
 	},
 	{
 		"assign": "3200112",
 		"jp_text": "ＦＵＮ２０１５獲得チケット",
 		"tr_text": "FUN 2015 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【２０１５】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"2015\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2015 FUN."
 	},
 	{
 		"assign": "3200113",
 		"jp_text": "ＣＭ１００獲得チケット",
 		"tr_text": "CM 100 Ticket",
 		"jp_explain": "チャレンジマイルの授与申請チケット。\nチケットを使用すると\nＣＭを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards Challenge Miles\nwhen used.\nCM \"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 Challenge Miles."
 	},
 	{
 		"assign": "3200114",
 		"jp_text": "経験値獲得３０００",
 		"tr_text": "3000 EXP Ticket",
 		"jp_explain": "経験値の授与申請チケット。\n使用したクラスの経験値を\n【３０００】獲得可能。",
-		"tr_explain": "This ticket, awards Experience\nwhen used.\nEXP \"3000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n3000 EXP."
 	},
 	{
 		"assign": "3200115",
 		"jp_text": "経験値獲得１５０００",
 		"tr_text": "15000 EXP Ticket",
 		"jp_explain": "経験値の授与申請チケット。\n使用したクラスの経験値を\n【１５０００】獲得可能。",
-		"tr_explain": "This ticket, awards Experience\nwhen used.\nEXP \"15000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n15000 EXP."
 	},
 	{
 		"assign": "3200116",
 		"jp_text": "経験値獲得１０００００",
 		"tr_text": "100000 EXP Ticket",
 		"jp_explain": "経験値の授与申請チケット。\n使用したクラスの経験値を\n【１０００００】獲得可能。",
-		"tr_explain": "This ticket, awards Experience\nwhen used.\nEXP \"100000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100000 EXP."
 	},
 	{
 		"assign": "3200117",
 		"jp_text": "ＣＣ７１１獲得チケット",
 		"tr_text": "CC 711 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【７１１】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"711\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n711 Casino Coins."
 	},
 	{
 		"assign": "3200119",
@@ -865,28 +865,28 @@
 		"jp_text": "ＣＭ１０００獲得チケット",
 		"tr_text": "CM 1000 Ticket",
 		"jp_explain": "チャレンジマイルの授与申請チケット。\nチケットを使用すると\nＣＭを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards Challenge Miles\nwhen used.\nCM \"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 Challenge Miles."
 	},
 	{
 		"assign": "3200132",
 		"jp_text": "ＣＭ５０００獲得チケット",
 		"tr_text": "CM 5000 Ticket",
 		"jp_explain": "チャレンジマイルの授与申請チケット。\nチケットを使用すると\nＣＭを【５０００】獲得可能。",
-		"tr_explain": "This ticket, awards Challenge Miles\nwhen used.\nCM \"5000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n5000 Challenge Miles."
 	},
 	{
 		"assign": "3200133",
 		"jp_text": "ＣＭ１００００獲得チケット",
 		"tr_text": "CM 10000 Ticket",
 		"jp_explain": "チャレンジマイルの授与申請チケット。\nチケットを使用すると\nＣＭを【１００００】獲得可能。",
-		"tr_explain": "This ticket, awards Challenge Miles\nwhen used.\nCM \"100000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100000 Challenge Miles."
 	},
 	{
 		"assign": "3200134",
 		"jp_text": "ＦＵＮ２０１６獲得チケット",
 		"tr_text": "FUN 2016 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【２０１６】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"2016\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2016 FUN."
 	},
 	{
 		"assign": "3200136",
@@ -900,126 +900,126 @@
 		"jp_text": "１スタージェム",
 		"tr_text": "1 Star Gem",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"1\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n1 SG."
 	},
 	{
 		"assign": "3200138",
 		"jp_text": "２スタージェム",
 		"tr_text": "2 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"2\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n2 SG."
 	},
 	{
 		"assign": "3200139",
 		"jp_text": "５スタージェム",
 		"tr_text": "5 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【５】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"5\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n5 SG."
 	},
 	{
 		"assign": "3200140",
 		"jp_text": "１０スタージェム",
 		"tr_text": "10 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１０】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"10\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n10 SG."
 	},
 	{
 		"assign": "3200141",
 		"jp_text": "５０スタージェム",
 		"tr_text": "50 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【５０】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"50\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n50 SG."
 	},
 	{
 		"assign": "3200142",
 		"jp_text": "１００スタージェム",
 		"tr_text": "100 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１００】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"100\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n100 SG."
 	},
 	{
 		"assign": "3200143",
 		"jp_text": "２００スタージェム",
 		"tr_text": "200 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２００】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"200\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n200 SG."
 	},
 	{
 		"assign": "3200144",
 		"jp_text": "１０００スタージェム",
 		"tr_text": "1000 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【１０００】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"1000\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 SG."
 	},
 	{
 		"assign": "3200146",
 		"jp_text": "採取スタミナドリンク５０",
-		"tr_text": "Collect Stam. Drink 50",
+		"tr_text": "Harvesting Stam. Drink 50",
 		"jp_explain": "ギャザリング用に開発された栄養剤。\n使用すると採取スタミナが５０回復する。",
-		"tr_explain": "Nutritional Supplement that\nwas developed for Gathering.\nRecovers 50 Harvesting\nstamina when used."
+		"tr_explain": "Nutritional supplement that\nwas developed for Gathering.\nRecovers 50 Harvesting\nStamina when used."
 	},
 	{
 		"assign": "3200148",
 		"jp_text": "釣りスタミナドリンク５０",
 		"tr_text": "Fishing Stam. Drink 50",
 		"jp_explain": "ギャザリング用に開発された栄養剤。\n使用すると釣りスタミナが５０回復する。",
-		"tr_explain": "Nutritional Supplement that\nwas developed for Gathering.\nRecovers 50 Fishing\nstamina when used."
+		"tr_explain": "Nutritional supplement that\nwas developed for Gathering.\nRecovers 50 Fishing\nStamina when used."
 	},
 	{
 		"assign": "3200149",
 		"jp_text": "ＳＧ１獲得チケット",
 		"tr_text": "SG 1 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【１】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"1\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1 Star Gem."
 	},
 	{
 		"assign": "3200150",
 		"jp_text": "ＳＧ２獲得チケット",
 		"tr_text": "SG 2 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【２】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"2\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2 Star Gems."
 	},
 	{
 		"assign": "3200151",
 		"jp_text": "ＳＧ５獲得チケット",
 		"tr_text": "SG 5 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【５】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"5\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n5 Star Gems."
 	},
 	{
 		"assign": "3200152",
 		"jp_text": "ＳＧ１０獲得チケット",
 		"tr_text": "SG 10 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【１０】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"10\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n10 Star Gems."
 	},
 	{
 		"assign": "3200153",
 		"jp_text": "ＳＧ５０獲得チケット",
 		"tr_text": "SG 50 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【５０】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"50\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n50 Star Gems."
 	},
 	{
 		"assign": "3200154",
 		"jp_text": "ＳＧ１００獲得チケット",
 		"tr_text": "SG 100 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【１００】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"100\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n100 Star Gems."
 	},
 	{
 		"assign": "3200155",
 		"jp_text": "ＳＧ２００獲得チケット",
 		"tr_text": "SG 200 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【２００】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"200\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n200 Star Gems."
 	},
 	{
 		"assign": "3200156",
 		"jp_text": "ＳＧ１０００獲得チケット",
 		"tr_text": "SG 1000 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【１０００】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"1000\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n1000 Star Gems."
 	},
 	{
 		"assign": "3200157",
@@ -1052,30 +1052,30 @@
 	{
 		"assign": "3200161",
 		"jp_text": "採取スタミナドリンク２０",
-		"tr_text": "Collecting Stam. Drink 20",
+		"tr_text": "Harvesting Stam. Drink 20",
 		"jp_explain": "ギャザリング用に開発された栄養剤。\n使用すると採取スタミナが２０回復する。",
-		"tr_explain": "Nutritional Supplement that\nwas developed for Gathering.\nRecovers 20 Harvesting\nstamina when used."
+		"tr_explain": "Nutritional supplement that\nwas developed for Gathering.\nRecovers 20 Harvesting\nStamina when used."
 	},
 	{
 		"assign": "3200162",
 		"jp_text": "釣りスタミナドリンク２０",
 		"tr_text": "Fishing Stam. Drink 20",
 		"jp_explain": "ギャザリング用に開発された栄養剤。\n使用すると釣りスタミナが２０回復する。",
-		"tr_explain": "Nutritional Supplement that\nwas developed for Gathering.\nRecovers 20 Fishing\nstamina when used."
+		"tr_explain": "Nutritional supplement that\nwas developed for Gathering.\nRecovers 20 Fishing\nStamina when used."
 	},
 	{
 		"assign": "3200163",
 		"jp_text": "ＣＣ１２０獲得チケット",
 		"tr_text": "CC 120 Ticket",
 		"jp_explain": "ＣＣ（カジノコイン）の授与申請チケット。\nチケットを使用すると\nＣＣを【１２０】獲得可能。",
-		"tr_explain": "This ticket, awards Casino Coins\nwhen used.\nCC \"120\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n120 Casino Coins."
 	},
 	{
 		"assign": "3200164",
 		"jp_text": "２０スタージェム",
 		"tr_text": "20 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【２０】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"20\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n20 SG."
 	},
 	{
 		"assign": "3200165",
@@ -1117,49 +1117,49 @@
 		"jp_text": "３０スタージェム",
 		"tr_text": "30 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【３０】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"30\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n30 SG."
 	},
 	{
 		"assign": "3200171",
 		"jp_text": "４０スタージェム",
 		"tr_text": "40 Star Gems",
 		"jp_explain": "スタージェムの授与。\n条件を満たすことで\nＳＧを【４０】獲得する。",
-		"tr_explain": "Instantly awards Star Gems\nwhen received.\nSG \"40\" will be redeemed."
+		"tr_explain": "Use to immediately receive\n40 SG."
 	},
 	{
 		"assign": "3200172",
 		"jp_text": "ＳＧ２０獲得チケット",
 		"tr_text": "SG 20 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【２０】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"20\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n20 Star Gems."
 	},
 	{
 		"assign": "3200173",
 		"jp_text": "ＳＧ３０獲得チケット",
 		"tr_text": "SG 30 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【３０】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"30\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n30 Star Gems."
 	},
 	{
 		"assign": "3200174",
 		"jp_text": "ＳＧ４０獲得チケット",
 		"tr_text": "SG 40 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【４０】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"40\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n40 Star Gems."
 	},
 	{
 		"assign": "3200175",
 		"jp_text": "ＳＧ８３２獲得チケット",
 		"tr_text": "SG 832 Ticket",
 		"jp_explain": "スタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【８３２】獲得可能。",
-		"tr_explain": "This ticket, awards Star Gems\nwhen used.\nSG \"832\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n832 Star Gems."
 	},
 	{
 		"assign": "3200176",
 		"jp_text": "ＦＵＮ２０１７獲得チケット",
 		"tr_text": "FUN 2017 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【２０１７】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"2017\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2017 FUN."
 	},
 	{
 		"assign": "3200177",
@@ -1215,7 +1215,7 @@
 		"jp_text": "ＳＧ２２獲得チケット",
 		"tr_text": "SG 22 Ticket",
 		"jp_explain": "<yellow>【ＰＳＯ２の日】<c>にもらえる\nスタージェムの授与申請チケット。\nチケットを使用すると\nＳＧを【２２】獲得可能。",
-		"tr_explain": "<yellow>[PSO2 Day]<c> Reward. This ticket,\nawards Star Gems when used.\nSG \"22\" can be redeemed."
+		"tr_explain": "<yellow>[PSO2 Day]<c> Reward.\nUse to immediately receive\n22 Star Gems."
 	},
 	{
 		"assign": "3200186",
@@ -1236,6 +1236,6 @@
 		"jp_text": "ＦＵＮ２０１８獲得チケット",
 		"tr_text": "FUN 2018 Ticket",
 		"jp_explain": "ＦＵＮの授与申請チケット。\nチケットを使用すると\nＦＵＮを【２０１８】獲得可能。",
-		"tr_explain": "This ticket, awards FUN Points\nwhen used.\nFUN\"2018\" can be redeemed."
+		"tr_explain": "Use to immediately receive\n2018 FUN."
 	}
 ]

--- a/json/Item_Weapon_Launcher.txt
+++ b/json/Item_Weapon_Launcher.txt
@@ -445,7 +445,7 @@
 		"jp_text": "ファイナルインパクト",
 		"tr_text": "Final Impact",
 		"jp_explain": "その衝撃の激しさは群を抜くといわれる\n伝説の大砲。その分反動もすさまじく\n制御には卓越した技術が必要となる。",
-		"tr_explain": ""
+		"tr_explain": "A launcher legendary for the force\nof its shots' impact. Its recoil can\nonly be contained by top-end tech."
 	},
 	{
 		"assign": "19075",
@@ -1061,7 +1061,7 @@
 		"jp_text": "ファイナルインパクト-NT",
 		"tr_text": "Final Impact-NT",
 		"jp_explain": "その衝撃の激しさは群を抜くといわれる\n伝説の大砲。その分反動もすさまじく\n制御には卓越した技術が必要となる。",
-		"tr_explain": ""
+		"tr_explain": "A launcher legendary for the force\nof its shots' impact. Its recoil can\nonly be contained by top-end tech."
 	},
 	{
 		"assign": "190272",

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -4,7 +4,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "E.M.A.研究所の爆破事件……<%br>唯一の生存者　ザッカードの保護が<%br>わたしのアークスとしての<%br>初めての任務でした。",
-		"tr_text": "The E.M.A. Lab Bombing Incident...\nMy first duty as an ARKS was the\nprotection of the sole survivor, Zackard.",
+		"tr_text": "The E.M.A. Lab Bombing Incident...<%br>My first duty as an ARKS was the<%br>protection of the sole survivor, Zackard.",
 		"fileID": 1
 	},
 	{
@@ -12,7 +12,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "あなたと同じチームだったから<%br>わたしは、あの戦いを……任務を<%br>アークスとして全うできました。",
-		"tr_text": "Because I was in the same team\nas you, I was able to...\nI was able to fight in that\nmission as ARKS.",
+		"tr_text": "Because I was in the same team<%br>as you, I was able to...<%br>I was able to fight in that<%br>mission as ARKS.",
 		"fileID": 1
 	},
 	{
@@ -20,7 +20,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "「イノセントブルー」によって<%br>生まれたウェポノイド<%br>そして……敵として現れた<%br>ロード達との闘い……",
-		"tr_text": "From \"Innocent Blue\",\nI was born as a Weaponoid...\nAs was Lord, who fought\nas our adversary.",
+		"tr_text": "From \"Innocent Blue\",<%br>I was born as a Weaponoid...<%br>As was Lord, who fought<%br>as our adversary.",
 		"fileID": 1
 	},
 	{
@@ -28,7 +28,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "すべては、終わったんだって<%br>そう……思っていました。",
-		"tr_text": "Everything was over...\nOr so I thought.",
+		"tr_text": "Everything was over...<%br>Or so I thought.",
 		"fileID": 1
 	},
 	{
@@ -68,7 +68,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "人間こそが、宇宙を蝕む存在だ……<%br>俺たちは……自由だ、そうだろう？",
-		"tr_text": "The humans are a blight on this universe...\nWe... We are free, are we not?",
+		"tr_text": "The humans are a blight on this universe...<%br>We... We are free, are we not?",
 		"fileID": 1
 	},
 	{
@@ -84,7 +84,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "誰も知らない悪意は<%br>深い深いその場所で<%br>すでに始まっていました。",
-		"tr_text": "Nobody could have known,\nbut in that deep, dark place,\nevil had begun to return to the world.",
+		"tr_text": "Nobody could have known,<%br>but in that deep, dark place,<%br>evil had begun to return to the world.",
 		"fileID": 1
 	},
 	{
@@ -92,7 +92,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "誰かが思いついたことは<%br>すでにどこかで<%br>それは実現している。",
-		"tr_text": "By the time anyone realised.\nit was too late.\nIt was already taking shape.",
+		"tr_text": "By the time anyone realised.<%br>it was too late.<%br>It was already taking shape.",
 		"fileID": 1
 	},
 	{
@@ -100,7 +100,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "わたし達が防いだと思った悪意は<%br>別の場所で、別の誰かが<%br>すでに実現していました……",
-		"tr_text": "The evil that we thought we had stopped\nwas manifesting in another place,\nthrough another person.",
+		"tr_text": "The evil that we thought we had stopped<%br>was manifesting in another place,<%br>through another person.",
 		"fileID": 1
 	},
 	{
@@ -108,7 +108,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "『その……小さな手と<%br>　その　小さな瞳で』",
-		"tr_text": "\"With eyes so tiny,\n  and hands so tiny...\"",
+		"tr_text": "\"With eyes so tiny,<%br>  and hands so tiny...\"",
 		"fileID": 1
 	},
 	{
@@ -116,7 +116,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "腹が減った……<%br>この子に栄養を与えねば……",
-		"tr_text": "I am hungry...\nIf this child goes without sustenance...",
+		"tr_text": "I am hungry...<%br>If this child goes without sustenance...",
 		"fileID": 1
 	},
 	{
@@ -124,7 +124,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "腹の子が育たぬ。<%br>ヘイド……頼む。",
-		"tr_text": "The child within me is not growing.\nHade... please.",
+		"tr_text": "The child within me is not growing.<%br>Hade... please.",
 		"fileID": 1
 	},
 	{
@@ -140,7 +140,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "<%name>さん……<%br>今日は来てくれてありがとうございます。",
-		"tr_text": "<%name>...\nThank you for coming today.",
+		"tr_text": "<%name>...<%br>Thank you for coming today.",
 		"fileID": 1
 	},
 	{
@@ -148,7 +148,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "実は今回の任務は<%br>ブルーノさんからの協力要請です。",
-		"tr_text": "Actually, this mission is\na request from Bruno.",
+		"tr_text": "Actually, this mission is<%br>a request from Bruno.",
 		"fileID": 1
 	},
 	{
@@ -156,7 +156,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "よ！　久しぶりだな<%br><%name>！",
-		"tr_text": "Yo! Long time no see,\n<%name>!",
+		"tr_text": "Yo! Long time no see,<%br><%name>!",
 		"fileID": 1
 	},
 	{
@@ -172,7 +172,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "<%name>さん、まずは……<%br>ブルーノさんの現在の調査任務……いえ。",
-		"tr_text": "Firstly, <%name>...\nBruno's current mision is... No.",
+		"tr_text": "Firstly, <%name>...<%br>Bruno's current mision is... No.",
 		"fileID": 1
 	},
 	{
@@ -180,7 +180,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "……おふたりが解決した事件の経緯から<%br>一度整理させてください。",
-		"tr_text": "Let me explain what has been happening\nsince the incident that we resolved.",
+		"tr_text": "Let me explain what has been happening<%br>since the incident that we resolved.",
 		"fileID": 1
 	},
 	{
@@ -196,7 +196,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "E.M.A.研究所が極秘に開発した<%br>「イノセントブルー」。",
-		"tr_text": "The E.M.A. Lab had been secretly\nworking on \"Innocent Blue\".",
+		"tr_text": "The E.M.A. Lab had been secretly<%br>working on \"Innocent Blue\".",
 		"fileID": 1
 	},
 	{
@@ -204,7 +204,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "それによって生み出されたのが、武器を<%br>元にして作られたウェポノイドたち……",
-		"tr_text": "From that research, Weaponoids\nwere created, based on weapons.",
+		"tr_text": "From that research, Weaponoids<%br>were created, based on weapons.",
 		"fileID": 1
 	},
 	{
@@ -212,7 +212,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "その有用性を認めたアークスはウェポノイドを<%br>共に戦う仲間として迎え入れた。",
-		"tr_text": "ARKS recognized the Weaponoids' value on the\nbattlefield, welcoming them as comrades in arms.",
+		"tr_text": "ARKS recognized the Weaponoids' value on the<%br>battlefield, welcoming them as comrades in arms.",
 		"fileID": 1
 	},
 	{
@@ -220,7 +220,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "そしてアンタ……、リーダーもウェポノイドを<%br>加えたチームを率いて任務に出た。",
-		"tr_text": "And you... The leader of a team who\nundertook missions alongside Weaponoids.",
+		"tr_text": "And you... The leader of a team who<%br>undertook missions alongside Weaponoids.",
 		"fileID": 1
 	},
 	{
@@ -228,7 +228,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "その任務を進めるうちに、ウェポノイドと同じ<%br>原理で、エネミーを元に作られた「ダンテ」達……",
-		"tr_text": "As that mission progressed, \"Dante\" was created,\nsimilar to a Weaponoid, but based on an enemy.",
+		"tr_text": "As that mission progressed, \"Dante\" was created,<%br>similar to a Weaponoid, but based on an enemy.",
 		"fileID": 1
 	},
 	{
@@ -244,7 +244,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "そして、奴ら「トランスエネミー」は<%br>俺たちアークスの敵となった。",
-		"tr_text": "And those \"Trans Enemies\"\nbecame the enemies of us in ARKS.",
+		"tr_text": "And those \"Trans Enemies\"<%br>became the enemies of us in ARKS.",
 		"fileID": 1
 	},
 	{
@@ -252,7 +252,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "それによって、「ウェポノイド」まで<%br>危険なんじゃねーかって話が持ち上がった。",
-		"tr_text": "Because of that, word got around that\nWeaponoids were somehow dangerous.",
+		"tr_text": "Because of that, word got around that<%br>Weaponoids were somehow dangerous.",
 		"fileID": 1
 	},
 	{
@@ -260,7 +260,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "ですが、トランスエネミーを指揮する<%br>ロードを倒したことで、事件は解決しました。",
-		"tr_text": "However, when we defeated Lord, commander\nof the Trans Enemies, that issue was settled.",
+		"tr_text": "However, when we defeated Lord, commander<%br>of the Trans Enemies, that issue was settled.",
 		"fileID": 1
 	},
 	{
@@ -268,7 +268,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "リーダーのお陰で、今ではウェポノイドを<%br>危険視する声はなくなりました。",
-		"tr_text": "Thanks to you, Leader, nobody thinks\nWeaponoids are dangerous any more.",
+		"tr_text": "Thanks to you, Leader, nobody thinks<%br>Weaponoids are dangerous any more.",
 		"fileID": 1
 	},
 	{
@@ -276,7 +276,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ははは！<%br>俺も結構頑張ったんだけどねぇ？",
-		"tr_text": "Hahaha!\nDidn't I have something to do with it, too?",
+		"tr_text": "Hahaha!<%br>Didn't I have something to do with it, too?",
 		"fileID": 1
 	},
 	{
@@ -284,7 +284,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "す、すみません……<%br>つい……",
-		"tr_text": "I-I'm sorry...\nI didn't mean...",
+		"tr_text": "I-I'm sorry...<%br>I didn't mean...",
 		"fileID": 1
 	},
 	{
@@ -292,7 +292,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ま！　そんな感じで事件を解決してあのチーム<%br>……ダーカーバスターズは解散した。",
-		"tr_text": "But! With that situation defused, our team,\nthe Darker Busters, was dissolved.",
+		"tr_text": "But! With that situation defused, our team,<%br>the Darker Busters, was dissolved.",
 		"fileID": 1
 	},
 	{
@@ -300,7 +300,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "俺はチームが解散してから半年……ダンテたち<%br>「トランスエネミー」の追跡調査をしていた。",
-		"tr_text": "Ever since the team split up six months ago,\nI've been tracking Dante and the Trans Enemies.",
+		"tr_text": "Ever since the team split up six months ago,<%br>I've been tracking Dante and the Trans Enemies.",
 		"fileID": 1
 	},
 	{
@@ -308,7 +308,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ようやく、ダンテたちの尻尾が掴めた<%br>ってことで、アンタに協力して欲しいんだ。",
-		"tr_text": "And now I finally think I have a lead on\nDante, so I want your help to catch him.",
+		"tr_text": "And now I finally think I have a lead on<%br>Dante, so I want your help to catch him.",
 		"fileID": 1
 	},
 	{
@@ -316,7 +316,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "……ダンテたちを追うなら<%br>ジェネちゃんたちを呼ばなくていいんですか？",
-		"tr_text": "If you're pursuing Dante,\ndon't you want to call Gene?",
+		"tr_text": "If you're pursuing Dante,<%br>don't you want to call Gene?",
 		"fileID": 1
 	},
 	{
@@ -324,7 +324,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ジェネちゃんとアネットは……<%br>ダンテたちに情みたいなもんがあるからね……",
-		"tr_text": "The thing is, Gene and Annette...\nDante and his people are emotionally unstable.",
+		"tr_text": "The thing is, Gene and Annette...<%br>Dante and his people are emotionally unstable.",
 		"fileID": 1
 	},
 	{
@@ -332,7 +332,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ハッピーエンドになる保証がないわけだし……<%br>呼ばない方が俺は、いいと思ってるよ。",
-		"tr_text": "I can't say for sure that this will end well.\nBest to keep them out of it.",
+		"tr_text": "I can't say for sure that this will end well.<%br>Best to keep them out of it.",
 		"fileID": 1
 	},
 	{
@@ -340,7 +340,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "俺も、この任務はできるだけ早く片を付けたい。<%br>それにはアンタ……リーダーの力が必要なんだ。",
-		"tr_text": "I want to get this wrapped up as soon as possible.\nTo do that... I need the power of the Leader.",
+		"tr_text": "I want to get this wrapped up as soon as possible.<%br>To do that... I need the power of the Leader.",
 		"fileID": 1
 	},
 	{
@@ -372,7 +372,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "さっすが、リーダー！<%br>そう言ってくれると、思ってたぜ……",
-		"tr_text": "That's the spirit, Leader!\nI had a feeling you'd say that...",
+		"tr_text": "That's the spirit, Leader!<%br>I had a feeling you'd say that...",
 		"fileID": 1
 	},
 	{
@@ -380,7 +380,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "…………なに、俺とふたりはごめんってか？<%br>つれないこと言うなよなぁー。",
-		"tr_text": "What's wrong, aren't we friends?\nThere's no need to be so cold.",
+		"tr_text": "What's wrong, aren't we friends?<%br>There's no need to be so cold.",
 		"fileID": 1
 	},
 	{
@@ -388,7 +388,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ってことでセラフィさん。<%br>サポート頼むぜ？",
-		"tr_text": "How about you, Seraphy?\nWill you be our support?",
+		"tr_text": "How about you, Seraphy?<%br>Will you be our support?",
 		"fileID": 1
 	},
 	{
@@ -396,7 +396,7 @@
 		"jp_name": "セラフィ",
 		"tr_name": "Seraphy",
 		"jp_text": "はい。それでは早速ですが<%br>惑星ナベリウスへ向かってください。",
-		"tr_text": "Okay. Well then, head to\nplanet Naberius right away.",
+		"tr_text": "Okay. Well then, head to<%br>planet Naberius right away.",
 		"fileID": 1
 	},
 	{

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -22,7 +22,7 @@
 	{
 		"text_id": 1001200,
 		"jp_text": "炎属性で装備を固めれば\nさらに効果大です！\nぜひ、活用してみてくださいね！",
-		"tr_text": "It's even more effective if you\nequip Fire-element equipment!\nPlease make use of that fact!"
+		"tr_text": "It's even more effective if you\nequip Fire-element equipment!\nUse that to your advantage!"
 	},
 	{
 		"text_id": 1001200,
@@ -67,7 +67,7 @@
 	{
 		"text_id": 1002200,
 		"jp_text": "なんだか、うらやましい！",
-		"tr_text": "I'm a little envious!"
+		"tr_text": "I'm a little jealous!"
 	},
 	{
 		"text_id": 1003000,
@@ -82,27 +82,27 @@
 	{
 		"text_id": 1003200,
 		"jp_text": "先輩アークス\nエコーさんのチップです。\nいつも後輩のみなさんを\n優しく見守ってくれている\nとっても素敵な方なんですよ！",
-		"tr_text": ""
+		"tr_text": "This is a chip of your senior in ARKS, Echo.\nShe's a lovely person who always\nlooks after her juniors!"
 	},
 	{
 		"text_id": 1003200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、氷属性値を\n強化してくれます！",
-		"tr_text": ""
+		"tr_text": "Her ability is called\n\"<%abi>\".\nIt boosts your ATK and your Ice Element!"
 	},
 	{
 		"text_id": 1003200,
 		"jp_text": "氷属性で揃えた装備なら\nより良い性能を引き出せるでしょう。\nぜひ、活用してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "It's even more effective if you\nequip Ice-element equipment!\nUse that to your advantage!"
 	},
 	{
 		"text_id": 1003200,
 		"jp_text": "そうそう、エコーさんは\nおとなりのゼノさんと\n幼なじみなんですよ。",
-		"tr_text": ""
+		"tr_text": "Oh, that's right, the chip next to\Echo's is her childhood friend, Zeno."
 	},
 	{
 		"text_id": 1003200,
 		"jp_text": "チップの性能も\nなんだかペアになってる感じがして……\nとっても仲良しさんなのですね！\nうふふ！",
-		"tr_text": ""
+		"tr_text": "Their chips seem to be quite similar...\nThey must be very good friends!\nEhehe!"
 	},
 	{
 		"text_id": 1004000,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -51182,17 +51182,17 @@
 	{
 		"text_id": 8231200,
 		"jp_text": "このチップは、大剣の\n「クレイモア」が\n元になっています。\nベーシックな大剣であり\n多くの新人アークスが使ってきました。",
-		"tr_text": ""
+		"tr_text": "This chip is based on the\nsword \"Claymore\".\nIt is a basic sword, used by\ncountless new ARKS through\nthe years."
 	},
 	{
 		"text_id": 8231200,
 		"jp_text": "アビリティは\n「<%abi>」。\nジャストアタック時\n定期的にＨＰが回復し\nさらに威力が増加されます！",
-		"tr_text": ""
+		"tr_text": "Its ability is called \n\"<%abi>\".\nWhen you perform a Just Attack, it\nstarts periodically recovering your HP,\nand even boosts your attack power too!"
 	},
 	{
 		"text_id": 8231200,
 		"jp_text": "もちろんご存知ですよね。\nダーカーバスターズの一員\nモアくんです！\n初めて会った時よりも\nずっと頼もしくなりましたね！",
-		"tr_text": ""
+		"tr_text": "Of course, you know More well.\nHe's a member of Darker Busters!\nHe's become a lot more reliable\nthan when you first met."
 	},
 	{
 		"text_id": 8232000,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -97,7 +97,7 @@
 	{
 		"text_id": 1003200,
 		"jp_text": "そうそう、エコーさんは\nおとなりのゼノさんと\n幼なじみなんですよ。",
-		"tr_text": "Oh, that's right, the chip next to\Echo's is her childhood friend, Zeno."
+		"tr_text": "Oh, that's right, the chip next to\nEcho's is her childhood friend, Zeno."
 	},
 	{
 		"text_id": 1003200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -18312,7 +18312,7 @@
 	{
 		"text_id": 1171200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1171200,
@@ -18387,7 +18387,7 @@
 	{
 		"text_id": 1173200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1173200,
@@ -21357,7 +21357,7 @@
 	{
 		"text_id": 1177200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1177200,
@@ -21412,7 +21412,7 @@
 	{
 		"text_id": 1179200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1179200,
@@ -21467,7 +21467,7 @@
 	{
 		"text_id": 1181200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1181200,
@@ -21527,7 +21527,7 @@
 	{
 		"text_id": 1183200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1183200,
@@ -21687,7 +21687,7 @@
 	{
 		"text_id": 1189200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1189200,
@@ -21742,7 +21742,7 @@
 	{
 		"text_id": 1191200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1191200,
@@ -21797,7 +21797,7 @@
 	{
 		"text_id": 1193200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1193200,
@@ -21852,7 +21852,7 @@
 	{
 		"text_id": 1195200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1195200,
@@ -21907,7 +21907,7 @@
 	{
 		"text_id": 1197001,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197001,
@@ -23612,7 +23612,7 @@
 	{
 		"text_id": 1197141,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197141,
@@ -23677,7 +23677,7 @@
 	{
 		"text_id": 1197145,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197145,
@@ -25227,7 +25227,7 @@
 	{
 		"text_id": 1519200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1519200,
@@ -25307,7 +25307,7 @@
 	{
 		"text_id": 1521200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1521200,
@@ -25372,7 +25372,7 @@
 	{
 		"text_id": 1523200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1523200,
@@ -25447,7 +25447,7 @@
 	{
 		"text_id": 1525200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1525200,
@@ -25517,7 +25517,7 @@
 	{
 		"text_id": 1527200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1527200,
@@ -25592,7 +25592,7 @@
 	{
 		"text_id": 1529200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1529200,
@@ -25657,7 +25657,7 @@
 	{
 		"text_id": 1531200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1531200,
@@ -27192,7 +27192,7 @@
 	{
 		"text_id": 1511200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1511200,
@@ -27247,7 +27247,7 @@
 	{
 		"text_id": 1553200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1553200,
@@ -27302,7 +27302,7 @@
 	{
 		"text_id": 1555200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1555200,
@@ -27357,7 +27357,7 @@
 	{
 		"text_id": 1557200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1557200,
@@ -27412,7 +27412,7 @@
 	{
 		"text_id": 1559200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1559200,
@@ -27467,7 +27467,7 @@
 	{
 		"text_id": 1561200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1561200,
@@ -28882,7 +28882,7 @@
 	{
 		"text_id": 1571200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1571200,
@@ -28947,7 +28947,7 @@
 	{
 		"text_id": 1573200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1573200,
@@ -29017,7 +29017,7 @@
 	{
 		"text_id": 1575200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1575200,
@@ -29072,7 +29072,7 @@
 	{
 		"text_id": 1577200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1577200,
@@ -29127,7 +29127,7 @@
 	{
 		"text_id": 1579200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1579200,
@@ -29187,7 +29187,7 @@
 	{
 		"text_id": 1581200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1581200,
@@ -30547,7 +30547,7 @@
 	{
 		"text_id": 1605200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1605200,
@@ -30602,7 +30602,7 @@
 	{
 		"text_id": 1607200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1607200,
@@ -30657,7 +30657,7 @@
 	{
 		"text_id": 1609200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1609200,
@@ -30712,7 +30712,7 @@
 	{
 		"text_id": 1611200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1611200,
@@ -30767,7 +30767,7 @@
 	{
 		"text_id": 1613200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1613200,
@@ -30822,7 +30822,7 @@
 	{
 		"text_id": 1615200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1615200,
@@ -31702,7 +31702,7 @@
 	{
 		"text_id": 1617200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1617200,
@@ -31757,7 +31757,7 @@
 	{
 		"text_id": 1619200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1619200,
@@ -31817,7 +31817,7 @@
 	{
 		"text_id": 1621200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1621200,
@@ -31872,7 +31872,7 @@
 	{
 		"text_id": 1623200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1623200,
@@ -31927,7 +31927,7 @@
 	{
 		"text_id": 1625200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1625200,
@@ -31982,7 +31982,7 @@
 	{
 		"text_id": 1627200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1627200,
@@ -32322,7 +32322,7 @@
 	{
 		"text_id": 1629200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1629200,
@@ -32377,7 +32377,7 @@
 	{
 		"text_id": 1631200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1631200,
@@ -32432,7 +32432,7 @@
 	{
 		"text_id": 1633200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1633200,
@@ -32487,7 +32487,7 @@
 	{
 		"text_id": 1635200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1635200,
@@ -32652,7 +32652,7 @@
 	{
 		"text_id": 1641200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1641200,
@@ -32707,7 +32707,7 @@
 	{
 		"text_id": 1643200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1643200,
@@ -33407,7 +33407,7 @@
 	{
 		"text_id": 1655200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1655200,
@@ -33462,7 +33462,7 @@
 	{
 		"text_id": 1657200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1657200,
@@ -33522,7 +33522,7 @@
 	{
 		"text_id": 1659200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1659200,
@@ -33582,7 +33582,7 @@
 	{
 		"text_id": 1661200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1661200,
@@ -33637,7 +33637,7 @@
 	{
 		"text_id": 1663200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1663200,
@@ -33747,7 +33747,7 @@
 	{
 		"text_id": 1677200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1677200,
@@ -34282,7 +34282,7 @@
 	{
 		"text_id": 1671200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1671200,
@@ -34337,7 +34337,7 @@
 	{
 		"text_id": 1673200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1673200,
@@ -34392,7 +34392,7 @@
 	{
 		"text_id": 1675200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1675200,
@@ -34447,7 +34447,7 @@
 	{
 		"text_id": 1679200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1679200,
@@ -34502,7 +34502,7 @@
 	{
 		"text_id": 1681200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1681200,
@@ -35127,7 +35127,7 @@
 	{
 		"text_id": 1683200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1683200,
@@ -35182,7 +35182,7 @@
 	{
 		"text_id": 1687200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1687200,
@@ -35292,7 +35292,7 @@
 	{
 		"text_id": 1691200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1691200,
@@ -35807,7 +35807,7 @@
 	{
 		"text_id": 1697200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1697200,
@@ -35972,7 +35972,7 @@
 	{
 		"text_id": 1703200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1703200,
@@ -36027,7 +36027,7 @@
 	{
 		"text_id": 1707200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1707200,
@@ -36087,7 +36087,7 @@
 	{
 		"text_id": 1709200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1709200,
@@ -36142,7 +36142,7 @@
 	{
 		"text_id": 1711200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1711200,
@@ -36202,7 +36202,7 @@
 	{
 		"text_id": 1713200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1713200,
@@ -36612,7 +36612,7 @@
 	{
 		"text_id": 1715200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1715200,
@@ -36667,7 +36667,7 @@
 	{
 		"text_id": 1717200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1717200,
@@ -36722,7 +36722,7 @@
 	{
 		"text_id": 1719200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1719200,
@@ -36777,7 +36777,7 @@
 	{
 		"text_id": 1721200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1721200,
@@ -37107,7 +37107,7 @@
 	{
 		"text_id": 1733200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1733200,
@@ -37612,7 +37612,7 @@
 	{
 		"text_id": 1751200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1751200,
@@ -37672,7 +37672,7 @@
 	{
 		"text_id": 1753200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1753200,
@@ -37727,7 +37727,7 @@
 	{
 		"text_id": 1755200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1755200,
@@ -37782,7 +37782,7 @@
 	{
 		"text_id": 1757200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1757200,
@@ -37837,7 +37837,7 @@
 	{
 		"text_id": 1759200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1759200,
@@ -37892,7 +37892,7 @@
 	{
 		"text_id": 1761200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1761200,
@@ -38007,7 +38007,7 @@
 	{
 		"text_id": 1765200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1765200,
@@ -38062,7 +38062,7 @@
 	{
 		"text_id": 1767200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1767200,
@@ -38122,7 +38122,7 @@
 	{
 		"text_id": 1769200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1769200,
@@ -38992,7 +38992,7 @@
 	{
 		"text_id": 1771200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1771200,
@@ -39047,7 +39047,7 @@
 	{
 		"text_id": 1773200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1773200,
@@ -39437,7 +39437,7 @@
 	{
 		"text_id": 1787200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1787200,
@@ -39497,7 +39497,7 @@
 	{
 		"text_id": 1789200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1789200,
@@ -40477,7 +40477,7 @@
 	{
 		"text_id": 1059200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1059200,
@@ -40532,7 +40532,7 @@
 	{
 		"text_id": 1061200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1061200,
@@ -40587,7 +40587,7 @@
 	{
 		"text_id": 1065200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1065200,
@@ -40642,7 +40642,7 @@
 	{
 		"text_id": 1071200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1071200,
@@ -40697,7 +40697,7 @@
 	{
 		"text_id": 1073200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1073200,
@@ -41172,7 +41172,7 @@
 	{
 		"text_id": 1299200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1299200,
@@ -41227,7 +41227,7 @@
 	{
 		"text_id": 1301200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1301200,
@@ -41282,7 +41282,7 @@
 	{
 		"text_id": 1303200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1303200,
@@ -41337,7 +41337,7 @@
 	{
 		"text_id": 1305200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1305200,
@@ -41512,7 +41512,7 @@
 	{
 		"text_id": 1549200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1549200,
@@ -41627,7 +41627,7 @@
 	{
 		"text_id": 1651200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1651200,
@@ -41742,7 +41742,7 @@
 	{
 		"text_id": 1669200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1669200,
@@ -42107,7 +42107,7 @@
 	{
 		"text_id": 1685200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1685200,
@@ -42222,7 +42222,7 @@
 	{
 		"text_id": 1705200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1705200,
@@ -42277,7 +42277,7 @@
 	{
 		"text_id": 8001200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8001200,
@@ -42332,7 +42332,7 @@
 	{
 		"text_id": 8003200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8003200,
@@ -42392,7 +42392,7 @@
 	{
 		"text_id": 8005200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8005200,
@@ -42447,7 +42447,7 @@
 	{
 		"text_id": 8007200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8007200,
@@ -42562,7 +42562,7 @@
 	{
 		"text_id": 8011200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8011200,
@@ -42622,7 +42622,7 @@
 	{
 		"text_id": 8013200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8013200,
@@ -42677,7 +42677,7 @@
 	{
 		"text_id": 8015200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8015200,
@@ -42737,7 +42737,7 @@
 	{
 		"text_id": 8017200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8017200,
@@ -42797,7 +42797,7 @@
 	{
 		"text_id": 8019200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8019200,
@@ -42857,7 +42857,7 @@
 	{
 		"text_id": 8021200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8021200,
@@ -43552,7 +43552,7 @@
 	{
 		"text_id": 8033200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8033200,
@@ -43612,7 +43612,7 @@
 	{
 		"text_id": 8035200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8035200,
@@ -43672,7 +43672,7 @@
 	{
 		"text_id": 8037200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8037200,
@@ -43732,7 +43732,7 @@
 	{
 		"text_id": 8039200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8039200,
@@ -43787,7 +43787,7 @@
 	{
 		"text_id": 8041200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8041200,
@@ -44007,7 +44007,7 @@
 	{
 		"text_id": 8045200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8045200,
@@ -44062,7 +44062,7 @@
 	{
 		"text_id": 8047200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8047200,
@@ -44292,7 +44292,7 @@
 	{
 		"text_id": 8055200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8055200,
@@ -44347,7 +44347,7 @@
 	{
 		"text_id": 8057200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8057200,
@@ -44712,7 +44712,7 @@
 	{
 		"text_id": 8059200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8059200,
@@ -44822,7 +44822,7 @@
 	{
 		"text_id": 8063200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8063200,
@@ -45087,7 +45087,7 @@
 	{
 		"text_id": 8065200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8065200,
@@ -45202,7 +45202,7 @@
 	{
 		"text_id": 8071200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8071200,
@@ -45257,7 +45257,7 @@
 	{
 		"text_id": 8073200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8073200,
@@ -45312,7 +45312,7 @@
 	{
 		"text_id": 8075200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8075200,
@@ -45367,7 +45367,7 @@
 	{
 		"text_id": 8077200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8077200,
@@ -45727,7 +45727,7 @@
 	{
 		"text_id": 8081200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8081200,
@@ -45787,7 +45787,7 @@
 	{
 		"text_id": 8083200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8083200,
@@ -45847,7 +45847,7 @@
 	{
 		"text_id": 8085200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8085200,
@@ -45962,7 +45962,7 @@
 	{
 		"text_id": 8089200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8089200,
@@ -46017,7 +46017,7 @@
 	{
 		"text_id": 8091200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8091200,
@@ -46072,7 +46072,7 @@
 	{
 		"text_id": 8093200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8093200,
@@ -46132,7 +46132,7 @@
 	{
 		"text_id": 8095200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8095200,
@@ -46252,7 +46252,7 @@
 	{
 		"text_id": 8097200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8097200,
@@ -46352,7 +46352,7 @@
 	{
 		"text_id": 8099200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8099200,
@@ -46642,7 +46642,7 @@
 	{
 		"text_id": 8105200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8105200,
@@ -46752,7 +46752,7 @@
 	{
 		"text_id": 8109200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8109200,
@@ -46807,7 +46807,7 @@
 	{
 		"text_id": 8111200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8111200,
@@ -46902,7 +46902,7 @@
 	{
 		"text_id": 8114200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8114200,
@@ -47422,7 +47422,7 @@
 	{
 		"text_id": 8118200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8118200,
@@ -47477,7 +47477,7 @@
 	{
 		"text_id": 8120200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8120200,
@@ -47537,7 +47537,7 @@
 	{
 		"text_id": 8155200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8155200,
@@ -47592,7 +47592,7 @@
 	{
 		"text_id": 8124200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8124200,
@@ -47692,7 +47692,7 @@
 	{
 		"text_id": 8126200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8126200,
@@ -47747,7 +47747,7 @@
 	{
 		"text_id": 8128200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8128200,
@@ -47842,7 +47842,7 @@
 	{
 		"text_id": 8131200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8131200,
@@ -47902,7 +47902,7 @@
 	{
 		"text_id": 8135200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8135200,
@@ -48257,7 +48257,7 @@
 	{
 		"text_id": 8133200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8133200,
@@ -48542,7 +48542,7 @@
 	{
 		"text_id": 8147200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8147200,
@@ -48597,7 +48597,7 @@
 	{
 		"text_id": 8149200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8149200,
@@ -48652,7 +48652,7 @@
 	{
 		"text_id": 8151200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8151200,
@@ -48712,7 +48712,7 @@
 	{
 		"text_id": 8153200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8153200,
@@ -48772,7 +48772,7 @@
 	{
 		"text_id": 8157200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8157200,
@@ -48827,7 +48827,7 @@
 	{
 		"text_id": 8159200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8159200,
@@ -49042,7 +49042,7 @@
 	{
 		"text_id": 8161200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8161200,
@@ -49102,7 +49102,7 @@
 	{
 		"text_id": 8163200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8163200,
@@ -49157,7 +49157,7 @@
 	{
 		"text_id": 8165200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8165200,
@@ -49217,7 +49217,7 @@
 	{
 		"text_id": 8167200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8167200,
@@ -49337,7 +49337,7 @@
 	{
 		"text_id": 8171200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8171200,
@@ -49392,7 +49392,7 @@
 	{
 		"text_id": 8173200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8173200,
@@ -49492,7 +49492,7 @@
 	{
 		"text_id": 8176200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8176200,
@@ -49657,7 +49657,7 @@
 	{
 		"text_id": 8178200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8178200,
@@ -49712,7 +49712,7 @@
 	{
 		"text_id": 8180200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8180200,
@@ -49772,7 +49772,7 @@
 	{
 		"text_id": 8182200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8182200,
@@ -49867,7 +49867,7 @@
 	{
 		"text_id": 8185200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8185200,
@@ -49962,7 +49962,7 @@
 	{
 		"text_id": 8188200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8188200,
@@ -50017,7 +50017,7 @@
 	{
 		"text_id": 8190200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8190200,
@@ -50272,7 +50272,7 @@
 	{
 		"text_id": 8194200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8194200,
@@ -50332,7 +50332,7 @@
 	{
 		"text_id": 8196200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8196200,
@@ -50392,7 +50392,7 @@
 	{
 		"text_id": 8198200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8198200,
@@ -50452,7 +50452,7 @@
 	{
 		"text_id": 8200200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8200200,
@@ -50672,7 +50672,7 @@
 	{
 		"text_id": 8202200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8202200,
@@ -50727,7 +50727,7 @@
 	{
 		"text_id": 8204200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8204200,
@@ -50782,7 +50782,7 @@
 	{
 		"text_id": 8206200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8206200,
@@ -50837,7 +50837,7 @@
 	{
 		"text_id": 8208200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8208200,
@@ -51122,7 +51122,7 @@
 	{
 		"text_id": 8229200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8229200,
@@ -51177,7 +51177,7 @@
 	{
 		"text_id": 8231200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
+		"tr_text": "This is one of the next-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8231200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -12,27 +12,27 @@
 	{
 		"text_id": 1001200,
 		"jp_text": "<%CHARANAME>さんの\n先輩アークス\nゼノさんのチップです。\nどなたにも面倒見のよい\nとっても頼りになる方です！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>, this is\na chip of your senior in ARKS, Zeno.\nHe's a reliable, dependable person!"
 	},
 	{
 		"text_id": 1001200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、炎属性値を\n強化してくれます！",
-		"tr_text": ""
+		"tr_text": "His ability is called\n\"<%abi>\".\nIt boosts your ATK and your Fire Element!"
 	},
 	{
 		"text_id": 1001200,
 		"jp_text": "炎属性で装備を固めれば\nさらに効果大です！\nぜひ、活用してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "It's even more effective if you\nequip Fire-element equipment!\nPlease make use of that fact!"
 	},
 	{
 		"text_id": 1001200,
 		"jp_text": "そうそう、ゼノさんは\nおとなりのエコーさんと\n幼なじみなんです。",
-		"tr_text": ""
+		"tr_text": "Oh, that's right, the chip next to\nZeno's is his childhood friend, Echo."
 	},
 	{
 		"text_id": 1001200,
 		"jp_text": "いつも一緒にいるのを\n見かけるんですよ。\nとっても仲良しさんなんですね！\nうふふ！",
-		"tr_text": ""
+		"tr_text": "I see those two together a lot.\nThey must be very good friends!\nEhehe!"
 	},
 	{
 		"text_id": 1002000,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -18312,7 +18312,7 @@
 	{
 		"text_id": 1171200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1171200,
@@ -18387,7 +18387,7 @@
 	{
 		"text_id": 1173200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1173200,
@@ -21357,7 +21357,7 @@
 	{
 		"text_id": 1177200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1177200,
@@ -21412,7 +21412,7 @@
 	{
 		"text_id": 1179200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1179200,
@@ -21467,7 +21467,7 @@
 	{
 		"text_id": 1181200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1181200,
@@ -21527,7 +21527,7 @@
 	{
 		"text_id": 1183200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1183200,
@@ -21687,7 +21687,7 @@
 	{
 		"text_id": 1189200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1189200,
@@ -21742,7 +21742,7 @@
 	{
 		"text_id": 1191200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1191200,
@@ -21797,7 +21797,7 @@
 	{
 		"text_id": 1193200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1193200,
@@ -21852,7 +21852,7 @@
 	{
 		"text_id": 1195200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1195200,
@@ -21907,7 +21907,7 @@
 	{
 		"text_id": 1197001,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197001,
@@ -23612,7 +23612,7 @@
 	{
 		"text_id": 1197141,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197141,
@@ -23677,7 +23677,7 @@
 	{
 		"text_id": 1197145,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1197145,
@@ -25307,7 +25307,7 @@
 	{
 		"text_id": 1521200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1521200,
@@ -25372,7 +25372,7 @@
 	{
 		"text_id": 1523200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1523200,
@@ -25447,7 +25447,7 @@
 	{
 		"text_id": 1525200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1525200,
@@ -25517,7 +25517,7 @@
 	{
 		"text_id": 1527200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1527200,
@@ -25592,7 +25592,7 @@
 	{
 		"text_id": 1529200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1529200,
@@ -25657,7 +25657,7 @@
 	{
 		"text_id": 1531200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1531200,
@@ -27192,7 +27192,7 @@
 	{
 		"text_id": 1511200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1511200,
@@ -27247,7 +27247,7 @@
 	{
 		"text_id": 1553200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1553200,
@@ -27302,7 +27302,7 @@
 	{
 		"text_id": 1555200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1555200,
@@ -27357,7 +27357,7 @@
 	{
 		"text_id": 1557200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1557200,
@@ -27412,7 +27412,7 @@
 	{
 		"text_id": 1559200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1559200,
@@ -27467,7 +27467,7 @@
 	{
 		"text_id": 1561200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1561200,
@@ -28882,7 +28882,7 @@
 	{
 		"text_id": 1571200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1571200,
@@ -28947,7 +28947,7 @@
 	{
 		"text_id": 1573200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1573200,
@@ -29017,7 +29017,7 @@
 	{
 		"text_id": 1575200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1575200,
@@ -29072,7 +29072,7 @@
 	{
 		"text_id": 1577200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1577200,
@@ -29127,7 +29127,7 @@
 	{
 		"text_id": 1579200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1579200,
@@ -29187,7 +29187,7 @@
 	{
 		"text_id": 1581200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1581200,
@@ -30547,7 +30547,7 @@
 	{
 		"text_id": 1605200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1605200,
@@ -30602,7 +30602,7 @@
 	{
 		"text_id": 1607200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1607200,
@@ -30657,7 +30657,7 @@
 	{
 		"text_id": 1609200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1609200,
@@ -30712,7 +30712,7 @@
 	{
 		"text_id": 1611200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1611200,
@@ -30767,7 +30767,7 @@
 	{
 		"text_id": 1613200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1613200,
@@ -30822,7 +30822,7 @@
 	{
 		"text_id": 1615200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1615200,
@@ -31702,7 +31702,7 @@
 	{
 		"text_id": 1617200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1617200,
@@ -31757,7 +31757,7 @@
 	{
 		"text_id": 1619200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1619200,
@@ -31817,7 +31817,7 @@
 	{
 		"text_id": 1621200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1621200,
@@ -31872,7 +31872,7 @@
 	{
 		"text_id": 1623200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1623200,
@@ -31927,7 +31927,7 @@
 	{
 		"text_id": 1625200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1625200,
@@ -31982,7 +31982,7 @@
 	{
 		"text_id": 1627200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1627200,
@@ -32322,7 +32322,7 @@
 	{
 		"text_id": 1629200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1629200,
@@ -32377,7 +32377,7 @@
 	{
 		"text_id": 1631200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1631200,
@@ -32432,7 +32432,7 @@
 	{
 		"text_id": 1633200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1633200,
@@ -32487,7 +32487,7 @@
 	{
 		"text_id": 1635200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1635200,
@@ -32652,7 +32652,7 @@
 	{
 		"text_id": 1641200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1641200,
@@ -32707,7 +32707,7 @@
 	{
 		"text_id": 1643200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1643200,
@@ -33407,7 +33407,7 @@
 	{
 		"text_id": 1655200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1655200,
@@ -33462,7 +33462,7 @@
 	{
 		"text_id": 1657200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1657200,
@@ -33522,7 +33522,7 @@
 	{
 		"text_id": 1659200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1659200,
@@ -33582,7 +33582,7 @@
 	{
 		"text_id": 1661200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1661200,
@@ -33637,7 +33637,7 @@
 	{
 		"text_id": 1663200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1663200,
@@ -33747,7 +33747,7 @@
 	{
 		"text_id": 1677200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1677200,
@@ -34282,7 +34282,7 @@
 	{
 		"text_id": 1671200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1671200,
@@ -34337,7 +34337,7 @@
 	{
 		"text_id": 1673200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1673200,
@@ -34392,7 +34392,7 @@
 	{
 		"text_id": 1675200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1675200,
@@ -34447,7 +34447,7 @@
 	{
 		"text_id": 1679200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1679200,
@@ -34502,7 +34502,7 @@
 	{
 		"text_id": 1681200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1681200,
@@ -35127,7 +35127,7 @@
 	{
 		"text_id": 1683200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1683200,
@@ -35182,7 +35182,7 @@
 	{
 		"text_id": 1687200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1687200,
@@ -35292,7 +35292,7 @@
 	{
 		"text_id": 1691200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1691200,
@@ -35807,7 +35807,7 @@
 	{
 		"text_id": 1697200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1697200,
@@ -35972,7 +35972,7 @@
 	{
 		"text_id": 1703200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1703200,
@@ -36027,7 +36027,7 @@
 	{
 		"text_id": 1707200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1707200,
@@ -36087,7 +36087,7 @@
 	{
 		"text_id": 1709200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1709200,
@@ -36142,7 +36142,7 @@
 	{
 		"text_id": 1711200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1711200,
@@ -36202,7 +36202,7 @@
 	{
 		"text_id": 1713200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1713200,
@@ -36612,7 +36612,7 @@
 	{
 		"text_id": 1715200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1715200,
@@ -36667,7 +36667,7 @@
 	{
 		"text_id": 1717200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1717200,
@@ -36722,7 +36722,7 @@
 	{
 		"text_id": 1719200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1719200,
@@ -36777,7 +36777,7 @@
 	{
 		"text_id": 1721200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1721200,
@@ -37107,7 +37107,7 @@
 	{
 		"text_id": 1733200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1733200,
@@ -37612,7 +37612,7 @@
 	{
 		"text_id": 1751200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1751200,
@@ -37672,7 +37672,7 @@
 	{
 		"text_id": 1753200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1753200,
@@ -37727,7 +37727,7 @@
 	{
 		"text_id": 1755200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1755200,
@@ -37782,7 +37782,7 @@
 	{
 		"text_id": 1757200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1757200,
@@ -37837,7 +37837,7 @@
 	{
 		"text_id": 1759200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1759200,
@@ -37892,7 +37892,7 @@
 	{
 		"text_id": 1761200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1761200,
@@ -38007,7 +38007,7 @@
 	{
 		"text_id": 1765200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1765200,
@@ -38062,7 +38062,7 @@
 	{
 		"text_id": 1767200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1767200,
@@ -38122,7 +38122,7 @@
 	{
 		"text_id": 1769200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1769200,
@@ -38992,7 +38992,7 @@
 	{
 		"text_id": 1771200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1771200,
@@ -39047,7 +39047,7 @@
 	{
 		"text_id": 1773200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1773200,
@@ -39437,7 +39437,7 @@
 	{
 		"text_id": 1787200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1787200,
@@ -39497,7 +39497,7 @@
 	{
 		"text_id": 1789200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1789200,
@@ -40477,7 +40477,7 @@
 	{
 		"text_id": 1059200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1059200,
@@ -40532,7 +40532,7 @@
 	{
 		"text_id": 1061200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1061200,
@@ -40587,7 +40587,7 @@
 	{
 		"text_id": 1065200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1065200,
@@ -40642,7 +40642,7 @@
 	{
 		"text_id": 1071200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1071200,
@@ -40697,7 +40697,7 @@
 	{
 		"text_id": 1073200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1073200,
@@ -41172,7 +41172,7 @@
 	{
 		"text_id": 1299200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1299200,
@@ -41227,7 +41227,7 @@
 	{
 		"text_id": 1301200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1301200,
@@ -41282,7 +41282,7 @@
 	{
 		"text_id": 1303200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1303200,
@@ -41337,7 +41337,7 @@
 	{
 		"text_id": 1305200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1305200,
@@ -41512,7 +41512,7 @@
 	{
 		"text_id": 1549200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1549200,
@@ -41627,7 +41627,7 @@
 	{
 		"text_id": 1651200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1651200,
@@ -41742,7 +41742,7 @@
 	{
 		"text_id": 1669200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1669200,
@@ -42107,7 +42107,7 @@
 	{
 		"text_id": 1685200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1685200,
@@ -42222,7 +42222,7 @@
 	{
 		"text_id": 1705200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 1705200,
@@ -42277,7 +42277,7 @@
 	{
 		"text_id": 8001200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8001200,
@@ -42332,7 +42332,7 @@
 	{
 		"text_id": 8003200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8003200,
@@ -42392,7 +42392,7 @@
 	{
 		"text_id": 8005200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8005200,
@@ -42447,7 +42447,7 @@
 	{
 		"text_id": 8007200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8007200,
@@ -42562,7 +42562,7 @@
 	{
 		"text_id": 8011200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8011200,
@@ -42622,7 +42622,7 @@
 	{
 		"text_id": 8013200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8013200,
@@ -42677,7 +42677,7 @@
 	{
 		"text_id": 8015200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8015200,
@@ -42737,7 +42737,7 @@
 	{
 		"text_id": 8017200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8017200,
@@ -42797,7 +42797,7 @@
 	{
 		"text_id": 8019200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8019200,
@@ -42857,7 +42857,7 @@
 	{
 		"text_id": 8021200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8021200,
@@ -43552,7 +43552,7 @@
 	{
 		"text_id": 8033200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8033200,
@@ -43612,7 +43612,7 @@
 	{
 		"text_id": 8035200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8035200,
@@ -43672,7 +43672,7 @@
 	{
 		"text_id": 8037200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8037200,
@@ -43732,7 +43732,7 @@
 	{
 		"text_id": 8039200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8039200,
@@ -43787,7 +43787,7 @@
 	{
 		"text_id": 8041200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8041200,
@@ -44007,7 +44007,7 @@
 	{
 		"text_id": 8045200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8045200,
@@ -44062,7 +44062,7 @@
 	{
 		"text_id": 8047200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8047200,
@@ -44292,7 +44292,7 @@
 	{
 		"text_id": 8055200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8055200,
@@ -44347,7 +44347,7 @@
 	{
 		"text_id": 8057200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8057200,
@@ -44712,7 +44712,7 @@
 	{
 		"text_id": 8059200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8059200,
@@ -44822,7 +44822,7 @@
 	{
 		"text_id": 8063200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8063200,
@@ -45087,7 +45087,7 @@
 	{
 		"text_id": 8065200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8065200,
@@ -45202,7 +45202,7 @@
 	{
 		"text_id": 8071200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8071200,
@@ -45257,7 +45257,7 @@
 	{
 		"text_id": 8073200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8073200,
@@ -45312,7 +45312,7 @@
 	{
 		"text_id": 8075200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8075200,
@@ -45367,7 +45367,7 @@
 	{
 		"text_id": 8077200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8077200,
@@ -45727,7 +45727,7 @@
 	{
 		"text_id": 8081200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8081200,
@@ -45787,7 +45787,7 @@
 	{
 		"text_id": 8083200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8083200,
@@ -45847,7 +45847,7 @@
 	{
 		"text_id": 8085200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8085200,
@@ -45962,7 +45962,7 @@
 	{
 		"text_id": 8089200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8089200,
@@ -46017,7 +46017,7 @@
 	{
 		"text_id": 8091200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8091200,
@@ -46072,7 +46072,7 @@
 	{
 		"text_id": 8093200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8093200,
@@ -46132,7 +46132,7 @@
 	{
 		"text_id": 8095200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8095200,
@@ -46252,7 +46252,7 @@
 	{
 		"text_id": 8097200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8097200,
@@ -46352,7 +46352,7 @@
 	{
 		"text_id": 8099200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8099200,
@@ -46642,7 +46642,7 @@
 	{
 		"text_id": 8105200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8105200,
@@ -46752,7 +46752,7 @@
 	{
 		"text_id": 8109200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8109200,
@@ -46807,7 +46807,7 @@
 	{
 		"text_id": 8111200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8111200,
@@ -46902,7 +46902,7 @@
 	{
 		"text_id": 8114200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8114200,
@@ -47422,7 +47422,7 @@
 	{
 		"text_id": 8118200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8118200,
@@ -47477,7 +47477,7 @@
 	{
 		"text_id": 8120200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8120200,
@@ -47537,7 +47537,7 @@
 	{
 		"text_id": 8155200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8155200,
@@ -47592,7 +47592,7 @@
 	{
 		"text_id": 8124200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8124200,
@@ -47692,7 +47692,7 @@
 	{
 		"text_id": 8126200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8126200,
@@ -47747,7 +47747,7 @@
 	{
 		"text_id": 8128200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8128200,
@@ -47842,7 +47842,7 @@
 	{
 		"text_id": 8131200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8131200,
@@ -47902,7 +47902,7 @@
 	{
 		"text_id": 8135200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8135200,
@@ -48257,7 +48257,7 @@
 	{
 		"text_id": 8133200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8133200,
@@ -48542,7 +48542,7 @@
 	{
 		"text_id": 8147200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8147200,
@@ -48597,7 +48597,7 @@
 	{
 		"text_id": 8149200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8149200,
@@ -48652,7 +48652,7 @@
 	{
 		"text_id": 8151200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8151200,
@@ -48712,7 +48712,7 @@
 	{
 		"text_id": 8153200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8153200,
@@ -48772,7 +48772,7 @@
 	{
 		"text_id": 8157200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8157200,
@@ -48827,7 +48827,7 @@
 	{
 		"text_id": 8159200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8159200,
@@ -49042,7 +49042,7 @@
 	{
 		"text_id": 8161200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8161200,
@@ -49102,7 +49102,7 @@
 	{
 		"text_id": 8163200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8163200,
@@ -49157,7 +49157,7 @@
 	{
 		"text_id": 8165200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8165200,
@@ -49217,7 +49217,7 @@
 	{
 		"text_id": 8167200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8167200,
@@ -49337,7 +49337,7 @@
 	{
 		"text_id": 8171200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8171200,
@@ -49392,7 +49392,7 @@
 	{
 		"text_id": 8173200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8173200,
@@ -49492,7 +49492,7 @@
 	{
 		"text_id": 8176200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8176200,
@@ -49657,7 +49657,7 @@
 	{
 		"text_id": 8178200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8178200,
@@ -49712,7 +49712,7 @@
 	{
 		"text_id": 8180200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8180200,
@@ -49772,7 +49772,7 @@
 	{
 		"text_id": 8182200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8182200,
@@ -49867,7 +49867,7 @@
 	{
 		"text_id": 8185200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8185200,
@@ -49962,7 +49962,7 @@
 	{
 		"text_id": 8188200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8188200,
@@ -50017,7 +50017,7 @@
 	{
 		"text_id": 8190200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8190200,
@@ -50272,7 +50272,7 @@
 	{
 		"text_id": 8194200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8194200,
@@ -50332,7 +50332,7 @@
 	{
 		"text_id": 8196200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8196200,
@@ -50392,7 +50392,7 @@
 	{
 		"text_id": 8198200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8198200,
@@ -50452,7 +50452,7 @@
 	{
 		"text_id": 8200200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8200200,
@@ -50672,7 +50672,7 @@
 	{
 		"text_id": 8202200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8202200,
@@ -50727,7 +50727,7 @@
 	{
 		"text_id": 8204200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8204200,
@@ -50782,7 +50782,7 @@
 	{
 		"text_id": 8206200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8206200,
@@ -50837,7 +50837,7 @@
 	{
 		"text_id": 8208200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8208200,
@@ -51122,7 +51122,7 @@
 	{
 		"text_id": 8229200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8229200,
@@ -51177,7 +51177,7 @@
 	{
 		"text_id": 8231200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the new-generation\n\"Weaponoid Chips\" created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8231200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -25232,7 +25232,7 @@
 	{
 		"text_id": 1519200,
 		"jp_text": "このチップは、大剣の\n「クレイモア」が元になっています。\nとっても元気な男の子で\n私は「モア」くんと呼んでいますよ！",
-		"tr_text": "He might be easily frightened, but he\nalways tries his hardest and puts his\nfriends first. He never lets his size\nstop him from completing missions,\ngoing on adventures, meeting all\nkinds of people... Little More's really\ngrown up!"
+		"tr_text": "This chip is based on the\nsword \"Claymore\".\nIt takes the form of an energetic little\nboy, who I've nicknamed \"More\"!."
 	},
 	{
 		"text_id": 1519200,

--- a/json/SideStoryEvent_Text.txt
+++ b/json/SideStoryEvent_Text.txt
@@ -6276,7 +6276,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "ウェポノイドに、なぜ性格があるのか。<%br>いまだに答えが出ない、わたしの疑問。",
-		"tr_text": "",
+		"tr_text": "Why do Weaponoids have personalities?<%br>I still have no answers, only more questions.",
 		"fileID": 7
 	},
 	{
@@ -6284,7 +6284,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "でも、モアと話していたら<%br>それでいいのかもしれないと、思った。",
-		"tr_text": "",
+		"tr_text": "However, from my conversations with More,<%br>I believe there is much left for me to learn.",
 		"fileID": 7
 	},
 	{
@@ -6292,7 +6292,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "武器の性能だけではない。気持ちや性格が<%br>わたしたちウェポノイドの特徴になっている。",
-		"tr_text": "",
+		"tr_text": "We Weaponoids are more than our weapons. Our<%br>feelings and personalities are unique to each of us.",
 		"fileID": 7
 	},
 	{
@@ -6300,7 +6300,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "今は、それがとても大切なものだと<%br>思えるようになった。",
-		"tr_text": "",
+		"tr_text": "I have come to think of them<%br>as something to be treasured.",
 		"fileID": 7
 	},
 	{
@@ -6308,7 +6308,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "それにしても……<%br>モアというウェポノイド……",
-		"tr_text": "",
+		"tr_text": "Even so...<%br>That Weaponoid named More...",
 		"fileID": 7
 	},
 	{
@@ -6316,7 +6316,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "他のウェポノイドとは違う、何かを……<%br>持っているような気がする。",
-		"tr_text": "",
+		"tr_text": "There is something there unlike other Weaponoids...<%br>Something that I feel I also possess.",
 		"fileID": 7
 	},
 	{
@@ -6324,7 +6324,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "明るい性格の奥に、何か隠れたものを……<%br>わたしの、気のせいだろうか。",
-		"tr_text": "",
+		"tr_text": "Behind his cheerful face, there hides something else...<%br>Perhaps it is only my imagination.",
 		"fileID": 7
 	},
 	{
@@ -6332,7 +6332,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "わたしの性格が書かせる、この日記。<%br>これからも、つづけていくだろう。",
-		"tr_text": "",
+		"tr_text": "This diary is an expression of my personality.<%br>Henceforth, it will continue.",
 		"fileID": 7
 	},
 	{
@@ -6340,7 +6340,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "ウェポノイドの観察も<%br>きっと、つづけていくことだろう。",
-		"tr_text": "",
+		"tr_text": "And I will continue to observe<%br>other Weaponoids as well.",
 		"fileID": 7
 	},
 	{
@@ -6348,7 +6348,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "その中でも、モア……<%br>彼からは、目が離せない。要注目。",
-		"tr_text": "",
+		"tr_text": "Amongst them, More...<%br>",
 		"fileID": 7
 	},
 	{

--- a/json/SideStoryEvent_Text.txt
+++ b/json/SideStoryEvent_Text.txt
@@ -6148,7 +6148,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "そういえばさ……",
-		"tr_text": "",
+		"tr_text": "By the way...",
 		"fileID": 7
 	},
 	{
@@ -6156,7 +6156,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "ん？　何？",
-		"tr_text": "",
+		"tr_text": "Hm? What?",
 		"fileID": 7
 	},
 	{
@@ -6164,7 +6164,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "オマエが前にいってた<%br>ウェポノイドの性格の話……",
-		"tr_text": "",
+		"tr_text": "That stuff you were saying before,<%br>about Weaponoid personalities...",
 		"fileID": 7
 	},
 	{
@@ -6172,7 +6172,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "オマエ、オレのことを元気がいいって<%br>いってくれたよなー。",
-		"tr_text": "",
+		"tr_text": "You wanted to know why I'm always so amped up, yeah?",
 		"fileID": 7
 	},
 	{
@@ -6180,7 +6180,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "うん。",
-		"tr_text": "",
+		"tr_text": "Mhm.",
 		"fileID": 7
 	},
 	{
@@ -6188,7 +6188,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "オレ、元々の武器はクレイモアっていって<%br>すごく弱っちい武器なんだ。",
-		"tr_text": "",
+		"tr_text": "See, my Origin Weapon is called<%br>Claymore, and it's real weak.",
 		"fileID": 7
 	},
 	{
@@ -6196,7 +6196,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "それがさ……なんか恥ずかしかったり<%br>くやしかったりしてさ……",
-		"tr_text": "",
+		"tr_text": "It's... kind of embarassing... and really annoying...",
 		"fileID": 7
 	},
 	{
@@ -6204,7 +6204,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "うん……",
-		"tr_text": "",
+		"tr_text": "Mhm...",
 		"fileID": 7
 	},
 	{
@@ -6212,7 +6212,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "だから、せめてウェポノイドのオレは<%br>他のやつらに負けないぞ！　って……",
-		"tr_text": "",
+		"tr_text": "That's why I can't let myself<%br>lose to any other Weaponoid!",
 		"fileID": 7
 	},
 	{
@@ -6220,7 +6220,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "そう思ってるから……<%br>元気に見えるのかもしれないなっ！",
-		"tr_text": "",
+		"tr_text": "I keep my energy up,<%br>so no-one will ever think I'm weak!",
 		"fileID": 7
 	},
 	{
@@ -6228,7 +6228,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "そう……<%br>ありがとう、話してくれて。",
-		"tr_text": "",
+		"tr_text": "I see...<%br>Thank you for telling me this.",
 		"fileID": 7
 	},
 	{
@@ -6236,7 +6236,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "でも、あなたの性格がそうなった理由は<%br>それだけじゃない気がする。",
-		"tr_text": "",
+		"tr_text": "But I feel that there are other reasons for<%br>your personality to have formed as it has.",
 		"fileID": 7
 	},
 	{
@@ -6244,7 +6244,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "それ以外にも、臆病だったり<%br>面倒くさがりだったり、いろいろあるし。",
-		"tr_text": "",
+		"tr_text": "Besides which, you have many other traits. For<%br>instance, you are cowardly, and you complain a lot",
 		"fileID": 7
 	},
 	{
@@ -6252,7 +6252,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "ちぇっ……<%br>ほんと、いろいろ見てるんだな、オマエ！",
-		"tr_text": "",
+		"tr_text": "That's-<%br>Hey, you've been spying on me!",
 		"fileID": 7
 	},
 	{
@@ -6260,7 +6260,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "ふふっ……<%br>それが、わたしの性格だから。",
-		"tr_text": "",
+		"tr_text": "Hehe...<%br>That is part of my personality, after all.",
 		"fileID": 7
 	},
 	{

--- a/json/SideStoryEvent_Text.txt
+++ b/json/SideStoryEvent_Text.txt
@@ -6172,7 +6172,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "オマエ、オレのことを元気がいいって<%br>いってくれたよなー。",
-		"tr_text": "You wanted to know why I'm always so amped up, yeah?",
+		"tr_text": "You wanted to know why I'm<%br>always so amped up, yeah?",
 		"fileID": 7
 	},
 	{

--- a/json/UI_Weaponoid_GrindMax.txt
+++ b/json/UI_Weaponoid_GrindMax.txt
@@ -57,7 +57,7 @@
 	{
 		"assign": "7",
 		"jp_text": "これからも、頼りにしてるってことで。",
-		"tr_text": ""
+		"tr_text": "From now on, I am counting on you."
 	},
 	{
 		"assign": "8",


### PR DESCRIPTION
- Improves the coverage check to give a more complete and accurate report by:
- - Checking more line names than just "tr_text"
- - Discounting lines where the japanese is empty, "-" or "---"
- - Not reporting lines where the japanese has just been copied into the translation as 'translated'
- - Clarifying what a possible error actually means
- Updates more active chips, makes previously updated descriptions consistent in regards to multiplicative and additive boosts, and adds frame information to all updated chip descriptions.
- Translates all current scratch and costume shop Cast part descriptions.
- Rewrites currency tickets and slightly tweaks/corrects gathering stamina drinks.
- Translates Final Impact's description.
- Translates Seraphy's notes on unreleased Zeno, Echo and the second More.
- Translates a common line in Seraphy's notes referring to Weaponoid chips.
- Translates Bio Triner's final side story chapter and her max grind line.
- A couple of other tweaks and fixes.