### PR TITLE
Mostly more chip info

### DIFF
--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -40,6 +40,8 @@ for files in json_files:
                         and (rmid[checkjp] != "")
                         and (rmid[checkjp] != "-")
                         and (rmid[checkjp] != "---")
+                        and (rmid[checkjp] != "－")
+                        and (re.fullmatch('d+', str(rmid[checkjp])) == None) # Filter out names that are just numbers - even if these aren't dummy strings, the numbers alone are fine
                         and (re.fullmatch('ENT_(ABN|SP)ダミー\d+', str(rmid[checkjp])) == None)): # Filter out dummy strings from Explain_Element_Abnormal and Explain_Element_Special
                         
                         countin += 1

--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -5,6 +5,7 @@ import fnmatch
 import json
 import os
 import sys
+import re
 
 # Error counter
 counterr = 0
@@ -35,7 +36,12 @@ for files in json_files:
             for rmid in djson:
                 for checkname in linenames:
                     checkjp = "jp_" + checkname
-                    if ((checkjp in rmid) and (rmid[checkjp] != "") and (rmid[checkjp] != "-") and (rmid[checkjp] != "---")):
+                    if ((checkjp in rmid)
+                        and (rmid[checkjp] != "")
+                        and (rmid[checkjp] != "-")
+                        and (rmid[checkjp] != "---")
+                        and (re.fullmatch('ENT_(ABN|SP)ダミー\d+', str(rmid[checkjp])) == None)): # Filter out dummy strings from Explain_Element_Abnormal and Explain_Element_Special
+                        
                         countin += 1
                         checktr = "tr_" + checkname
                         

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1138,14 +1138,14 @@
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Excellent)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Overwhelming)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31312",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Excellent)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Every 3 times you use an active chip or\n    a normal attack, dramatically increases ATK.\n    (Maximum boost: Overwhelming)\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31315",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -102,28 +102,28 @@
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Greatly increases ATK.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces Defense.\n② Greatly increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases ATK.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces Defense.\n② Dramatically increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage against\n    enemy elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1510",
@@ -214,21 +214,21 @@
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Slightly recover HP at regular intervals.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30002",
@@ -368,7 +368,7 @@
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "Normal attacks can [Panic] + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30034",
@@ -718,14 +718,14 @@
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31097",
@@ -746,14 +746,14 @@
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31100",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31119",
@@ -816,14 +816,14 @@
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
 		"tr_explainShort": "[Freeze] + damage boost vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
 		"tr_explainShort": "[Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Greatly boosts damage against\n    enemies affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31153",
@@ -928,7 +928,7 @@
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Each time you activate an active chip,\n    damage is slightly further boosted.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip,\n    this effect's duration is extended.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31202",
@@ -1082,14 +1082,14 @@
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31270",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Fixed Time"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Element values.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31271",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -240,28 +240,28 @@
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Mechs",
+		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Mechs",
+		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Darkers",
+		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Darkers",
+		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
@@ -282,28 +282,28 @@
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Dragons",
+		"tr_explainShort": "Additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Dragons",
+		"tr_explainShort": "Additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Darkers",
+		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
-		"tr_explainShort": "Deals additional damage to Darkers",
+		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
 		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -774,14 +774,14 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts ATK based on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts ATK based\n    on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "ATK boosted based on chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts ATK based on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts ATK based\n    on chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31137",
@@ -1292,14 +1292,14 @@
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31410",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31417",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1180,14 +1180,14 @@
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31328",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31335",
@@ -1306,14 +1306,14 @@
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力劇的強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs & Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31418",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts PAs & Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31419",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1558,14 +1558,14 @@
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種かダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n<color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31540",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種かダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n<color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases damage\n    dealt to Mechs and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31543",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -242,28 +242,28 @@
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30007",
@@ -284,28 +284,28 @@
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Dragons",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Dragons.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Deals additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30017",
@@ -767,7 +767,7 @@
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31131",
@@ -984,14 +984,14 @@
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals very large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals very large additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31241",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1164,212 +1164,212 @@
 	{
 		"assign": "31319",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
-		"tr_explainShort": "CP Consumption Down+ATK Boost against Wind Attribute.",
+		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts damage on enemies weak to Wind\nand reduces CP consumption."
+		"tr_explainLong": "① Dramatically boosts damage dealt\n    to enemies that are weak to wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31320",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
-		"tr_explainShort": "CP Consumption Down+ATK Boost against Wind Attribute.",
+		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts damage on enemies weak to Wind\nand reduces CP consumption."
+		"tr_explainLong": "① Dramatically boosts damage dealt\n    to enemies that are weak to wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31327",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
-		"tr_explainShort": "Increase Tech Power & CP Consumption",
+		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nincrease the power and CP consumption\nof Techs."
+		"tr_explainLong": "① Dramatically boosts the power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31328",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
-		"tr_explainShort": "Increase Tech Power & CP Consumption",
+		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に増加する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nincrease the power and CP consumption\nof Techs."
+		"tr_explainLong": "① Dramatically boosts the power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31335",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動小回復",
-		"tr_explainShort": "ATK Boost + Recover HP",
+		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK. Recovers HP proportional to the\namount of Light Chips equipped."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31336",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動回復",
-		"tr_explainShort": "ATK Boost + Recover HP",
+		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK. Recovers HP proportional to the\namount of Light Chips equipped."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP at regular intervals in proportion\n    to the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31339",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
-		"tr_explainShort": "ATK Boost + ATK Boost with Wind Weapons",
+		"tr_explainShort": "Damage boosted + Wind weapon boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK and further boosts ATK if\nusing a Wind Attribute. Weapon."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage further if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31340",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
-		"tr_explainShort": "ATK Boost + ATK Boost with Wind Weapons",
+		"tr_explainShort": "Damage boosted + Wind weapon boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK and further boosts ATK if\nusing a Wind Attribute. Weapon."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage further if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31345",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
-		"tr_explainShort": "ATK Boost + ATK Boost in Lilipa",
+		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 砂漠か地下坑道か採掘場での戦闘では\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, slightly\nboost ATK and further boosts ATK if\nin Lilipa."
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31346",
 		"jp_explainShort": "攻撃力大増加＋特定地形で攻撃力大増加",
-		"tr_explainShort": "ATK Boost + ATK Boost in Lilipa",
+		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 砂漠か地下坑道か採掘場での戦闘では\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, slightly\nboost ATK and further boosts ATK if\nin Lilipa."
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31355",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
-		"tr_explainShort": "ATK Boost + Periodic CP Recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts Attack enormously and periodically\nrecovers CP at fixed intervals for a long duration."
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31356",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
-		"tr_explainShort": "ATK Boost + Periodic CP Recovery",
+		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts Attack enormously and periodically\nrecovers CP at fixed intervals for a long duration."
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31379",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
-		"tr_explainShort": "ATK Boost + ATK Boost with Ice Weapons",
+		"tr_explainShort": "Damage boosted + Ice weapon boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK and further boosts ATK if\nusing an Ice Attribute. Weapon."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage further if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31380",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
-		"tr_explainShort": "ATK Boost + ATK Boost with Ice Weapons",
+		"tr_explainShort": "Damage boosted + Ice weapon boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically\nboosts ATK and further boosts ATK if\nusing an Ice Attribute. Weapon."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage further if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31389",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
-		"tr_explainShort": "ATK Boost+Quickens Actions+ATK Boost on Boss",
+		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts Attack, movement speed and attack speed for\na long duration. Further boosts Attack against\nbosses proportionally to the number of Ice Chips\nequipped."
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement\n    and normal attacks.\n③ Boosts damage against bosses in proportion\n    to the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
-		"tr_explainShort": "ATK Boost+Quickens Actions+ATK Boost on Boss",
+		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Boosts Attack, movement speed and attack speed for\na long duration. Further boosts Attack against\nbosses proportionally to the number of Ice Chips\nequipped."
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement\n    and normal attacks.\n③ Boosts damage against bosses in proportion\n    to the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31405",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力大増加",
-		"tr_explainShort": "CP Consumption Decreased + ATK Boost",
+		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boosts\nATK while reducing CP consumption."
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31406",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力劇的増加",
-		"tr_explainShort": "CP Consumption Decreased + ATK Boost",
+		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically boosts\nATK while reducing CP consumption."
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31409",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
-		"tr_explainShort": "ATK Boost + Quickens Actions",
+		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boosts\nATK while increasing movement & attacking speed."
+		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31410",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
-		"tr_explainShort": "ATK Boost + Quickens Actions",
+		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boosts\nATK while increasing movement & attacking speed."
+		"tr_explainLong": "① Deals huge additional damage to enemies.\n    <color=yellow>[Chase]</color>② Increases speed of movement\n    and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31417",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力劇的強化",
-		"tr_explainShort": "CP Consumption Decreased + Boost PA & Tech",
+		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, dramatically boosts\nPA & Tech while reducing CP consumption."
+		"tr_explainLong": "① Dramatically boosts PAs & Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31418",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
-		"tr_explainShort": "CP Consumption Decreased + Boost PA & Tech",
+		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boosts\nPA & Tech while reducing CP consumption."
+		"tr_explainLong": "① Immensely boosts PAs & Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31419",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP Consumption Decreased + Periodic ATK Boost",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, periodically\nboosts ATK (up to a dramatical boost) and\nreduce CP consumption."
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31420",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP Consumption Decreased + Periodic ATK Boost",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, periodically\nboosts ATK (up to a dramatical boost) and\nreduce CP consumption."
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31425",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "Imbues [Burn] + Boost ATK to [Burn] Afflicted",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Imbues [Burn] to attacks and increases\ndamage done to enemies afflicted with [Burn]\nfor a long duration."
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31426",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "Imbues [Burn] + Boost ATK to [Burn] Afflicted.",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "Imbues [Burn] to attacks and increases\ndamage done to enemies afflicted with [Burn]\nfor a long duration."
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage dealt to\n    enemies affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31427",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage dealt to Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31428",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage dealt to Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31437",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boosted based on ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to this chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31438",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
-		"tr_explainShort": "ATK boost Based on Ability Level",
+		"tr_explainShort": "Damage boosted based on ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, greatly boost\nATK according to ability level of chip."
+		"tr_explainLong": "① Greatly boosts damage in proportion\n    to this chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31443",
@@ -1458,16 +1458,16 @@
 	{
 		"assign": "31499",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce CP usage based on the\nchip's abillity level. Boosts the power of PA/Techs\nin addition to reducing CP usage."
+		"tr_explainLong": "① Boosts the power of PAs and Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31500",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法大強化",
-		"tr_explainShort": "",
+		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce CP usage based on the\nchip's abillity level. Boosts the power of PA/Techs\nsignificantly, in addition to reducing CP usage."
+		"tr_explainLong": "① Greatly boosts the power of PAs and Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31507",
@@ -1514,16 +1514,16 @@
 	{
 		"assign": "31519",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
-		"tr_explainShort": "Reduce CP Usage + Periodically Boost ATK",
+		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce CP usage. Periodically\nboosts ATK up to an enormously. CP usage reduction\nis further applied on chip activation."
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31520",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を増加",
-		"tr_explainShort": "",
+		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "For a long duration, reduce CP usage. Periodically\nboosts ATK up to an enormously. CP usage reduction\nis further applied on chip activation."
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31523",
@@ -6701,16 +6701,16 @@
 	{
 		"assign": "5310",
 		"jp_explainShort": "全体に闇属性の射撃による中ダメージ",
-		"tr_explainShort": "All Dark Attribute. All Attack",
+		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "Deals a dark attribute attack of medium damage to all\nenemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "5320",
 		"jp_explainShort": "全体に闇属性の射撃による大ダメージ",
-		"tr_explainShort": "Dark Attribute. All Attack",
+		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "Deals a dark attribute attack\nof large damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals large Dark shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "20005",
@@ -7037,16 +7037,16 @@
 	{
 		"assign": "9410",
 		"jp_explainShort": "全体に光属性の射撃による中ダメージ",
-		"tr_explainShort": "Light Attribute. All Attack",
+		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "Deals a ranged Light attribute\nattack of medium damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "9420",
 		"jp_explainShort": "全体に光属性の射撃による大ダメージ",
-		"tr_explainShort": "Light Attribute. All Attack",
+		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "Deals a ranged Light attribute\nattack of large damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals large Light shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "9423",
@@ -7121,16 +7121,16 @@
 	{
 		"assign": "9910",
 		"jp_explainShort": "全体に雷属性の射撃による中ダメージ",
-		"tr_explainShort": "Lightning Attribute. All Attack",
+		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "Deals a range Lightning attribute\nattack of medium damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Lightning shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "9920",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
-		"tr_explainShort": "Lightning Attribute. All Attack",
+		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "Deals a range Lightning attribute\nattack of large damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals large Lightning shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "10010",
@@ -7359,29 +7359,29 @@
 	{
 		"assign": "20011",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
-		"tr_explainShort": "Ice Attribute. All Attack",
+		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "Deals a range Ice attribute\nattack of large damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals large Ice shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "20012",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "[Damage Bomb]\n① Deals large Ice shooting\n    damage to all enemies."
 	},
 	{
 		"assign": "20019",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
-		"tr_explainShort": "ATK Boost with Distance from Target",
+		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "For a period of time, boost ATK\nincreasingly with the distance from target."
+		"tr_explainLong": "① Boosts damage in proportion to\n    how far you are from the target.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20020",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
-		"tr_explainShort": "ATK Boost with Distance from Target",
+		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "For a period of time, boost ATK\nincreasingly with the distance from target."
+		"tr_explainLong": "① Boosts damage in proportion to\n    how far you are from the target.\n[Effect Duration] Medium"
 	}
 ]

--- a/json/ChipExplain_BoostSkillExplain.txt
+++ b/json/ChipExplain_BoostSkillExplain.txt
@@ -1109,14 +1109,14 @@
 		"assign": "31243",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
 		"tr_explainLong": "Increases Fire Element damage by 4%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
 		"tr_explainLong": "Increases Fire Element damage by 4%\\nagainst enemies weak to Fire."
 	},
 	{
@@ -2201,14 +2201,14 @@
 		"assign": "31654",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
 		"tr_explainLong": "Increases Fire Element damage by 2%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31655",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
 		"tr_explainLong": "Increases Fire Element damage by 2%\\nagainst enemies weak to Fire."
 	},
 	{

--- a/json/ChipExplain_BoostSkillExplain.txt
+++ b/json/ChipExplain_BoostSkillExplain.txt
@@ -4,364 +4,364 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%."
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%."
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%."
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%."
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%."
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%."
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%."
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%."
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%."
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%."
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%."
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%."
 	},
 	{
 		"assign": "710",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "910",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "920",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1110",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "31121",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31122",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31491",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31492",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31535",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31041",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "31042",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "31053",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "31054",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "31055",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "31056",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "31075",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "31076",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "31159",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "31160",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "31127",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%."
 	},
 	{
 		"assign": "31128",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%."
 	},
 	{
 		"assign": "31283",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31284",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31179",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 20%."
+		"tr_explainLong": "Boosts linked chip's HP by 20%."
 	},
 	{
 		"assign": "31180",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 20%."
+		"tr_explainLong": "Boosts linked chip's HP by 20%."
 	},
 	{
 		"assign": "31553",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 25%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31554",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 25%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31555",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31556",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31557",
@@ -382,28 +382,28 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 25%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 25%."
 	},
 	{
 		"assign": "31563",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 25%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 25%."
 	},
 	{
 		"assign": "31564",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31566",
@@ -452,126 +452,126 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 25%."
+		"tr_explainLong": "Boosts linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31573",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 25%."
+		"tr_explainLong": "Boosts linked chip's Light element by 25%."
 	},
 	{
 		"assign": "2410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "2420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "2310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "2320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "2110",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "2120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "30051",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "30052",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%."
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%."
 	},
 	{
 		"assign": "30011",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "30012",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "30019",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "30020",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "31107",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "31108",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "1670",
@@ -592,196 +592,196 @@
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "31334",
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "31117",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "31118",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%."
 	},
 	{
 		"assign": "31079",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31080",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31129",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31130",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31173",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31174",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31175",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31057",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31058",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31039",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31040",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31059",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 30%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 30%."
 	},
 	{
 		"assign": "31060",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 30%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 30%."
 	},
 	{
 		"assign": "31217",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 30%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 30%."
 	},
 	{
 		"assign": "31218",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 30%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 30%."
 	},
 	{
 		"assign": "31163",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 30%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 30%."
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 30%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 30%."
 	},
 	{
 		"assign": "31183",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 30%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 30%."
 	},
 	{
 		"assign": "31184",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 30%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 30%."
 	},
 	{
 		"assign": "31115",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 30%."
+		"tr_explainLong": "Boosts linked chip's Light element by 30%."
 	},
 	{
 		"assign": "31116",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 30%."
+		"tr_explainLong": "Boosts linked chip's Light element by 30%."
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 30%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 30%."
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 30%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 30%."
 	},
 	{
 		"assign": "31574",
@@ -802,462 +802,462 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31580",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31583",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31584",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31585",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 25%."
+		"tr_explainLong": "Boosts linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31586",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 25%."
+		"tr_explainLong": "Boosts linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31119",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "31337",
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "31338",
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "30021",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "30022",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 10%."
+		"tr_explainLong": "Boosts linked chip's CP by 10%."
 	},
 	{
 		"assign": "31061",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31085",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30033",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30035",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30036",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30053",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30063",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30064",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "1610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 10%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31225",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 5."
 	},
 	{
 		"assign": "31226",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 5."
 	},
 	{
 		"assign": "31113",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "氷属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Ice Element by 5."
 	},
 	{
 		"assign": "31114",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "氷属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Ice Element by 5."
 	},
 	{
 		"assign": "31209",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 5."
 	},
 	{
 		"assign": "31210",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 5."
 	},
 	{
 		"assign": "31237",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "風属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Wind Element by 5."
 	},
 	{
 		"assign": "31238",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "風属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Wind Element by 5."
 	},
 	{
 		"assign": "31077",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 5."
 	},
 	{
 		"assign": "31078",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 5."
 	},
 	{
 		"assign": "31111",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "闇属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Dark Element by 5."
 	},
 	{
 		"assign": "31112",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "闇属性 の上限値が 5 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Dark Element by 5."
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"tr_explainLong": "Increases Fire Element damage by 4%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"tr_explainLong": "Increases Fire Element damage by 4%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31389",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "氷属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Ice Element damage by 4%\\nagainst enemies weak to Ice."
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "氷属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Ice Element damage by 4%\\nagainst enemies weak to Ice."
 	},
 	{
 		"assign": "31581",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31582",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31587",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 15."
 	},
 	{
 		"assign": "31588",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 15."
 	},
 	{
 		"assign": "31589",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "氷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Ice Element by 15."
 	},
 	{
 		"assign": "31590",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "氷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Ice Element by 15."
 	},
 	{
 		"assign": "31591",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 15."
 	},
 	{
 		"assign": "31592",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 15."
 	},
 	{
 		"assign": "31593",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's 光 element by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31594",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's 光 element by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31595",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31596",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31597",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 25%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31598",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 25%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31599",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31600",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31601",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31605",
@@ -1306,70 +1306,70 @@
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 10 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 10."
 	},
 	{
 		"assign": "31384",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "炎属性 の上限値が 10 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Fire Element by 10."
 	},
 	{
 		"assign": "31385",
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "31386",
 		"jp_explainShort": "効果時間延長",
 		"tr_explainShort": "Extend Effect Time",
 		"jp_explainLong": "装備したチップのアビリティ効果時間を 5秒 延長する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Extends the linked chip's effect duration by 5 seconds."
 	},
 	{
 		"assign": "31609",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31615",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "光属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Light Element damage by 2%\\nagainst enemies weak to Light."
 	},
 	{
 		"assign": "31616",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "光属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Light Element damage by 2%\\nagainst enemies weak to Light."
 	},
 	{
 		"assign": "31619",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 25%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 25%."
 	},
 	{
 		"assign": "31620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 25%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 25%."
 	},
 	{
 		"assign": "31624",
@@ -1404,420 +1404,420 @@
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 15."
 	},
 	{
 		"assign": "31614",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "雷属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Lightning Element by 15."
 	},
 	{
 		"assign": "31617",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 15."
 	},
 	{
 		"assign": "31618",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 15 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 15."
 	},
 	{
 		"assign": "31013",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31014",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30039",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30040",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31033",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31034",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30089",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30017",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30061",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "30062",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%\\nand boosts its CP by 5%."
 	},
 	{
 		"assign": "31157",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31158",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Fire element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Fire element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31177",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31178",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31227",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Wind element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Wind element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31213",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31214",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Lightning element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Lightning element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31125",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31126",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Light element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Light element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Dark element by 15%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's Dark element by 15%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31355",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "光属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Light Element damage by 4%\\nagainst enemies weak to Light."
 	},
 	{
 		"assign": "31356",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "光属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Light Element damage by 4%\\nagainst enemies weak to Light."
 	},
 	{
 		"assign": "31133",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "闇属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Dark Element damage by 4%\\nagainst enemies weak to Dark."
 	},
 	{
 		"assign": "31134",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "闇属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Dark Element damage by 4%\\nagainst enemies weak to Dark."
 	},
 	{
 		"assign": "31361",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31362",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31081",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31082",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31161",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31162",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31155",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31156",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 15%."
+		"tr_explainLong": "Boosts linked chip's HP by 15%."
 	},
 	{
 		"assign": "31123",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31124",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31367",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31368",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31221",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31222",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31131",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31181",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31182",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31261",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31262",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 5％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 5%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31626",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "風属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Wind Element damage by 2%\\nagainst enemies weak to Wind."
 	},
 	{
 		"assign": "31627",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "風属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Wind Element damage by 2%\\nagainst enemies weak to Wind."
 	},
 	{
 		"assign": "31628",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 20％\\nHP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 20%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31629",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 20％\\nHP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 20%\\nand boosts its HP by 5%."
 	},
 	{
 		"assign": "31636",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "雷属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Lightning Element damage by 2%\\nagainst enemies weak to Lightning."
 	},
 	{
 		"assign": "31637",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "雷属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Lightning Element damage by 2%\\nagainst enemies weak to Lightning."
 	},
 	{
 		"assign": "31638",
@@ -1838,336 +1838,336 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31641",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 5%."
+		"tr_explainLong": "Boosts linked chip's HP by 5%."
 	},
 	{
 		"assign": "31642",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31643",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31644",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31645",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31646",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31647",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
+		"tr_explainLong": "Boosts linked chip's HP by 10%\\nand boosts its CP by 10%."
 	},
 	{
 		"assign": "31417",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 10 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 10."
 	},
 	{
 		"assign": "31418",
 		"jp_explainShort": "属性値上限アップ",
 		"tr_explainShort": "Maximum Element Up",
 		"jp_explainLong": "光属性 の上限値が 10 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases your maximum Light Element by 10."
 	},
 	{
 		"assign": "31648",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31649",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "1690",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "1700",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "31011",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "31012",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "31251",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "31252",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "2210",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "2220",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "30091",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "30092",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "30093",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "30094",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 5％\\nHP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 5%\\nand boosts its HP by 15%."
 	},
 	{
 		"assign": "31233",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31234",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Fire Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31207",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31208",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Ice Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31289",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31290",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Lightning Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31285",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31286",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Wind Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31223",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31224",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Light Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31231",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31232",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nHP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked chip's Dark Element by 15%\\nand boosts its HP by 10%."
 	},
 	{
 		"assign": "31083",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "雷属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Lightning Element damage by 4%\\nagainst enemies weak to Lightning."
 	},
 	{
 		"assign": "31084",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "雷属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Lightning Element damage by 4%\\nagainst enemies weak to Lightning."
 	},
 	{
 		"assign": "31229",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "風属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Wind Element damage by 4%\\nagainst enemies weak to Wind."
 	},
 	{
 		"assign": "31230",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
 		"jp_explainLong": "風属性 が弱点の敵に対し\\nその属性によるダメージを 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases Wind Element damage by 4%\\nagainst enemies weak to Wind."
 	},
 	{
 		"assign": "31365",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31366",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31435",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31436",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31169",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31170",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31433",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31434",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31650",
@@ -2188,42 +2188,42 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31653",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31654",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"tr_explainLong": "Increases Fire Element damage by 2%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31655",
 		"jp_explainShort": "属性ダメージアップ",
 		"tr_explainShort": "Element Damage Up",
-		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを 2％ 増加する。",
-		"tr_explainLong": ""
+		"jp_explainLong": "炎属性 が弱点の敵に対し\\nその属性によるダメージを %1％ 増加する。",
+		"tr_explainLong": "Increases Fire Element damage by 2%\\nagainst enemies weak to Fire."
 	},
 	{
 		"assign": "31656",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 25%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 25%."
 	},
 	{
 		"assign": "31657",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases linked chip's Ice element by 25%."
+		"tr_explainLong": "Boosts linked chip's Ice element by 25%."
 	},
 	{
 		"assign": "31658",
@@ -2244,84 +2244,84 @@
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31661",
 		"jp_explainShort": "プレイヤーパラメータ増加",
 		"tr_explainShort": "Player Parameters Up",
 		"jp_explainLong": "プレイヤーの 攻撃力全般 を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts player attack power by 20%."
 	},
 	{
 		"assign": "31677",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": "Increases linked chip's HP by 30%."
+		"tr_explainLong": "Boosts linked chip's HP by 30%."
 	},
 	{
 		"assign": "31679",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": "Increases linked chip's CP by 20%."
+		"tr_explainLong": "Boosts linked chip's CP by 20%."
 	},
 	{
 		"assign": "50110",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50120",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50130",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50140",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50150",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50160",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50151",
@@ -2370,14 +2370,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50164",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50210",
@@ -2426,42 +2426,42 @@
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50320",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50330",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50340",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50350",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50360",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50351",
@@ -2510,14 +2510,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50364",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50410",
@@ -2594,14 +2594,14 @@
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50463",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50454",
@@ -2622,56 +2622,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50465",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50510",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50520",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50530",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50540",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50550",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50560",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50551",
@@ -2720,56 +2720,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50564",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50610",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50620",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50630",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50640",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50650",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50660",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50651",
@@ -2818,14 +2818,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50664",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50710",
@@ -2916,56 +2916,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50764",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50810",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50820",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50830",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50840",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50850",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50860",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50851",
@@ -3028,56 +3028,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50865",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50910",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50920",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50930",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50940",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50950",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50960",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "50951",
@@ -3126,14 +3126,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "50964",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51010",
@@ -3266,56 +3266,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51164",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51210",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51220",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51230",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51240",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51250",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51260",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51251",
@@ -3364,14 +3364,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51264",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51310",
@@ -3462,56 +3462,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51364",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51410",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51420",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51430",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51440",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51450",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51460",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "51451",
@@ -3560,14 +3560,14 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51464",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "51610",
@@ -3672,56 +3672,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "52364",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "52410",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52420",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52430",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52440",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52450",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52460",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "52451",
@@ -3784,56 +3784,56 @@
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "52465",
 		"jp_explainShort": "敵状態異常時ダメージアップ",
 		"tr_explainShort": "Damage Up Vs. Status",
 		"jp_explainLong": "状態異常の敵に対して、装備した必殺技・法術の\\nダメージ量を 4％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 4%\\nagainst enemies affected by a status effect."
 	},
 	{
 		"assign": "70110",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70120",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70130",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70140",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70150",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70160",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70510",
@@ -3882,42 +3882,42 @@
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70620",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70630",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70640",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70650",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "70660",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71010",
@@ -3966,126 +3966,126 @@
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71120",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71130",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71140",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71150",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71160",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71610",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71620",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71630",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71640",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71650",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "71660",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72110",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72120",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72130",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72140",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72150",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72160",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72410",
@@ -4148,41 +4148,41 @@
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72620",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72630",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72640",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72650",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	},
 	{
 		"assign": "72660",
 		"jp_explainShort": "ダメージアップ",
 		"tr_explainShort": "Damage Up",
 		"jp_explainLong": "装備した必殺技・法術のダメージ量を 3％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts damage of linked PA/Tech by 3%."
 	}
 ]

--- a/json/ChipExplain_BoostSkillExplain.txt
+++ b/json/ChipExplain_BoostSkillExplain.txt
@@ -4,364 +4,364 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 10%."
+		"tr_explainLong": "Increases linked chip's Fire element by 10%."
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 10%."
+		"tr_explainLong": "Increases linked chip's Fire element by 10%."
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 10%."
+		"tr_explainLong": "Increases linked chip's Ice element by 10%."
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 10%."
+		"tr_explainLong": "Increases linked chip's Ice element by 10%."
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 10%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%."
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 10%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%."
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 10%."
+		"tr_explainLong": "Increases linked chip's Wind element by 10%."
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 10%."
+		"tr_explainLong": "Increases linked chip's Wind element by 10%."
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 10%."
+		"tr_explainLong": "Increases linked chip's Light element by 10%."
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 10%."
+		"tr_explainLong": "Increases linked chip's Light element by 10%."
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%."
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%."
 	},
 	{
 		"assign": "710",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "910",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "920",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1110",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "31121",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31122",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31491",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31492",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31535",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31041",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 15%."
+		"tr_explainLong": "Increases linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "31042",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 15%."
+		"tr_explainLong": "Increases linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "31053",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 15%."
+		"tr_explainLong": "Increases linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "31054",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 15%."
+		"tr_explainLong": "Increases linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "31055",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 15%."
+		"tr_explainLong": "Increases linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "31056",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 15%."
+		"tr_explainLong": "Increases linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "31075",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 15%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "31076",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 15%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "31159",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 15%."
+		"tr_explainLong": "Increases linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "31160",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 15%."
+		"tr_explainLong": "Increases linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "31127",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 15%."
+		"tr_explainLong": "Increases linked chip's Light element by 15%."
 	},
 	{
 		"assign": "31128",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 15%."
+		"tr_explainLong": "Increases linked chip's Light element by 15%."
 	},
 	{
 		"assign": "31283",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 15%."
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31284",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 15%."
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31179",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 20％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 20%."
+		"tr_explainLong": "Increases linked chip's HP by 20%."
 	},
 	{
 		"assign": "31180",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 20％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 20%."
+		"tr_explainLong": "Increases linked chip's HP by 20%."
 	},
 	{
 		"assign": "31553",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 25%."
+		"tr_explainLong": "Increases linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31554",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 25%."
+		"tr_explainLong": "Increases linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31555",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%.\nCP increases by 10%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases CP by 10%."
 	},
 	{
 		"assign": "31556",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%.\nCP increases by 10%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases CP by 10%."
 	},
 	{
 		"assign": "31557",
@@ -382,210 +382,210 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 25%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 25%."
 	},
 	{
 		"assign": "31563",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 25%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 25%."
 	},
 	{
 		"assign": "31564",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 5%."
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31566",
 		"jp_explainShort": "発動ＣＰダウン",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したアクティブチップの消費ＣＰが 10％ 減少する。",
-		"tr_explainLong": "Reduces the CP usage of Active Chips by 10%."
+		"tr_explainLong": "Reduces the CP usage of a linked Active Chip by 10%."
 	},
 	{
 		"assign": "31567",
 		"jp_explainShort": "発動ＣＰダウン",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したアクティブチップの消費ＣＰが 10％ 減少する。",
-		"tr_explainLong": "Reduces the CP usage of Active Chips by 10%."
+		"tr_explainLong": "Reduces the CP usage of a linked Active Chip by 10%."
 	},
 	{
 		"assign": "31568",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": "Activation rate of Support Chips increased by 10%."
+		"tr_explainLong": "Activation rate of a linked Support Chip increased by 10%."
 	},
 	{
 		"assign": "31569",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": "Activation rate of Support Chips increased by 10%."
+		"tr_explainLong": "Activation rate of a linked Support Chip increased by 10%."
 	},
 	{
 		"assign": "31603",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": "Activation rate of Support Chips increased by 10%."
+		"tr_explainLong": "Activation rate of a linked Support Chip increased by 10%."
 	},
 	{
 		"assign": "31604",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": "Activation rate of Support Chips increased by 10%."
+		"tr_explainLong": "Activation rate of a linked Support Chip increased by 10%."
 	},
 	{
 		"assign": "31572",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 25%."
+		"tr_explainLong": "Increases linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31573",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 25%."
+		"tr_explainLong": "Increases linked chip's Light element by 25%."
 	},
 	{
 		"assign": "2410",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 15%."
+		"tr_explainLong": "Increases linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "2420",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 15%."
+		"tr_explainLong": "Increases linked chip's Fire element by 15%."
 	},
 	{
 		"assign": "2310",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 15%."
+		"tr_explainLong": "Increases linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "2320",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 15%."
+		"tr_explainLong": "Increases linked chip's Ice element by 15%."
 	},
 	{
 		"assign": "2110",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 15%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "2120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 15%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%."
 	},
 	{
 		"assign": "30051",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 15%."
+		"tr_explainLong": "Increases linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "30052",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 15%."
+		"tr_explainLong": "Increases linked chip's Wind element by 15%."
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 15%."
+		"tr_explainLong": "Increases linked chip's Light element by 15%."
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 15%."
+		"tr_explainLong": "Increases linked chip's Light element by 15%."
 	},
 	{
 		"assign": "30011",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 15%."
+		"tr_explainLong": "Increases linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "30012",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 15%."
+		"tr_explainLong": "Increases linked chip's Dark element by 15%."
 	},
 	{
 		"assign": "30019",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "30020",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "31107",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "31108",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "1670",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 5％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "1680",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 5％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31333",
@@ -606,252 +606,252 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "31118",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's HP by 10%."
+		"tr_explainLong": "Increases linked chip's HP by 10%."
 	},
 	{
 		"assign": "31079",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31080",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Fire element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31129",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31130",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Ice element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31173",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31174",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Lightning element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31175",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Wind element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31057",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31058",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Light element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31039",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31040",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nHP を 5％ 増加する。",
-		"tr_explainLong": "Increases chip's Dark element by 10%\\nand increases its HP by 5%."
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand increases its HP by 5%."
 	},
 	{
 		"assign": "31059",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 30%."
 	},
 	{
 		"assign": "31060",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 30%."
 	},
 	{
 		"assign": "31217",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 30%."
 	},
 	{
 		"assign": "31218",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 30%."
 	},
 	{
 		"assign": "31163",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 30%."
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 30%."
 	},
 	{
 		"assign": "31183",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 30%."
 	},
 	{
 		"assign": "31184",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 30%."
 	},
 	{
 		"assign": "31115",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 30%."
 	},
 	{
 		"assign": "31116",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 30%."
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 30%."
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 30%."
 	},
 	{
 		"assign": "31574",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31575",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31579",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31580",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31583",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31584",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31585",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31586",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 25%."
 	},
 	{
 		"assign": "31119",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "31337",
@@ -872,154 +872,154 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "30022",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 10％ 増加する。",
-		"tr_explainLong": "Increases chip's CP by 10%."
+		"tr_explainLong": "Increases linked chip's CP by 10%."
 	},
 	{
 		"assign": "31061",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31085",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30033",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30035",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30036",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30053",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30063",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30064",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "1610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 10％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 10%\\nand CP by 5%."
 	},
 	{
 		"assign": "31225",
@@ -1138,14 +1138,14 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31582",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31587",
@@ -1194,70 +1194,70 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's 光 element by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31594",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's 光 element by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31595",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31596",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31597",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31598",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 25%."
 	},
 	{
 		"assign": "31599",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31600",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31601",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31605",
@@ -1278,28 +1278,28 @@
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31608",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31165",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 5％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31166",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 5％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31383",
@@ -1334,14 +1334,14 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31610",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31615",
@@ -1362,14 +1362,14 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 25%."
 	},
 	{
 		"assign": "31620",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 25%."
 	},
 	{
 		"assign": "31624",
@@ -1390,14 +1390,14 @@
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31612",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 10％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31613",
@@ -1432,168 +1432,168 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31014",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30039",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30040",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31033",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31034",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30089",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30017",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30061",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "30062",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％\\nCP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%\\nand CP by 5%."
 	},
 	{
 		"assign": "31157",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31158",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 炎属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Fire element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31177",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31178",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31227",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 雷属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Wind element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31213",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31214",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 風属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Lightning element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31125",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31126",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 光属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Light element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 闇属性 を 15％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Dark element by 15%\\nand CP by 10%."
 	},
 	{
 		"assign": "31355",
@@ -1628,70 +1628,70 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31362",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31081",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31082",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31161",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31162",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31155",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31156",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 15％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 15%."
 	},
 	{
 		"assign": "31123",
@@ -1838,56 +1838,56 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31641",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 5％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 5%."
 	},
 	{
 		"assign": "31642",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31643",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31644",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31645",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31646",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31647",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 10％\\nCP を 10％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 10%\\nand CP by 10%."
 	},
 	{
 		"assign": "31417",
@@ -1908,14 +1908,14 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31649",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "1690",
@@ -2174,28 +2174,28 @@
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 20％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31651",
 		"jp_explainShort": "発動率アップ",
 		"tr_explainShort": "Boost Activation Rate",
 		"jp_explainLong": "装備したサポートチップの発動率が 20％ 上昇する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Boosts linked Support Chip's activation rate by 5%."
 	},
 	{
 		"assign": "31652",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31653",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31654",
@@ -2216,14 +2216,14 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 25%."
 	},
 	{
 		"assign": "31657",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの 氷属性 を 25％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's Ice element by 25%."
 	},
 	{
 		"assign": "31658",
@@ -2258,28 +2258,28 @@
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの HP を 30％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's HP by 30%."
 	},
 	{
 		"assign": "31679",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "チップパラメータ増加",
 		"tr_explainShort": "Chip Parameter Boost",
 		"jp_explainLong": "装備したチップの CP を 20％ 増加する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Increases linked chip's CP by 20%."
 	},
 	{
 		"assign": "50110",
@@ -2342,14 +2342,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50162",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50153",
@@ -2482,14 +2482,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50362",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50353",
@@ -2580,14 +2580,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50462",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50453",
@@ -2692,14 +2692,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50562",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50553",
@@ -2790,14 +2790,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50662",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50653",
@@ -2888,14 +2888,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50762",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50753",
@@ -2986,14 +2986,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50862",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50853",
@@ -3098,14 +3098,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50962",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "50953",
@@ -3238,14 +3238,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51162",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51153",
@@ -3336,14 +3336,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51262",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51253",
@@ -3434,14 +3434,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51362",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51353",
@@ -3532,14 +3532,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51462",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "51453",
@@ -3644,14 +3644,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "52362",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "52353",
@@ -3742,14 +3742,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "52462",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "52453",
@@ -4134,14 +4134,14 @@
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "72520",
 		"jp_explainShort": "ＣＰ消費量軽減",
 		"tr_explainShort": "Reduce CP Usage",
 		"jp_explainLong": "装備したチップの消費ＣＰを 10％ 軽減する。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Reduces linked chip's CP usage by 10%."
 	},
 	{
 		"assign": "72610",

--- a/json/ChipExplain_BoostSkillExplain.txt
+++ b/json/ChipExplain_BoostSkillExplain.txt
@@ -2384,42 +2384,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50220",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50230",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50240",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50250",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50260",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50310",
@@ -2524,42 +2524,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50420",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50430",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50440",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50450",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50460",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50451",
@@ -2832,42 +2832,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50720",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50730",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50740",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50750",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50760",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50751",
@@ -3000,14 +3000,14 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50863",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "50854",
@@ -3140,84 +3140,84 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51020",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51030",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51040",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51050",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51060",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51110",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51120",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51130",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51140",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51150",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51160",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51151",
@@ -3378,42 +3378,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51320",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51330",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51340",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51350",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51360",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51351",
@@ -3574,56 +3574,56 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "51620",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52310",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52320",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52330",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52340",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52350",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52360",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52351",
@@ -3756,14 +3756,14 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52463",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "52454",
@@ -3840,42 +3840,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70520",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70530",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70540",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70550",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70560",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "70610",
@@ -3924,42 +3924,42 @@
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71020",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71030",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71040",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71050",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71060",
 		"jp_explainShort": "追加ダメージ付与",
 		"tr_explainShort": "Additional Damage",
 		"jp_explainLong": "装備した必殺技・法術がヒットした時に\\n追加で 3％ のダメージを与える。",
-		"tr_explainLong": ""
+		"tr_explainLong": "Deals 3% additional damage each time\\nyou hit with the linked PA/Tech."
 	},
 	{
 		"assign": "71110",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -4,70 +4,70 @@
 		"jp_explainShort": "ＨＰが劇的回復",
 		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Condition] End of battle"
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "ＨＰが劇的回復",
 		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Condition] End of battle"
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Condition] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Condition] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Condition] Landing an attack"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional large damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional large damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Condition] Landing an attack"
+		"tr_explainLong": "① Deals additional large damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Decreases CP consumption.\n[Activation Condition] Activating an Active Chip"
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Decreases CP consumption.\n[Activation Condition] Activating an Active Chip"
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Condition] Taking lethal damage"
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Condition] Taking lethal damage"
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
 	},
 	{
 		"assign": "1630",
@@ -3252,14 +3252,14 @@
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Silghtly raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] Medium"
+		"tr_explainLong": "① Silghtly raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation Trigger] When landing an attack\n[Effect duration] Medium"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] Medium"
+		"tr_explainLong": "① Raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation Trigger] When landing an attack\n[Effect duration] Medium"
 	},
 	{
 		"assign": "31537",
@@ -7837,27 +7837,27 @@
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP Recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation condition] Taking damage"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
 	},
 	{
 		"assign": "20022",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP Recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation condition] Taking damage"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
 	},
 	{
 		"assign": "20045",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Condition] Taking an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20046",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Condition] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	}
 ]

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2,72 +2,72 @@
 	{
 		"assign": "710",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "Dramatically recovers HP",
+		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "Recovers HP dramatically after each\nbattle."
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Condition] End of battle"
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "Dramatically recovers HP",
+		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "Recovers HP dramatically after each\nbattle."
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Condition] End of battle"
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "攻撃力が大強化",
-		"tr_explainShort": "ATK Boost",
+		"tr_explainShort": "ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "JAs activates an effect that grants an\nATK Boost for a period of time."
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Condition] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "攻撃力が大強化",
-		"tr_explainShort": "ATK Boost",
+		"tr_explainShort": "ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "JAs activates an effect that grants an\nATK Boost for a period of time."
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Condition] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "追加で大ダメージ",
-		"tr_explainShort": "Additional Damage on Hit",
+		"tr_explainShort": "Additional damage",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "Deals additional damage on hit\nto target."
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Condition] Landing an attack"
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "追加で特大ダメージ",
-		"tr_explainShort": "Additional Damage on Hit",
+		"tr_explainShort": "Additional large damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "Deals additional damage on hit\nto target."
+		"tr_explainLong": "① Deals additional large damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Condition] Landing an attack"
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
-		"tr_explainShort": "CP Consumption Decreased",
+		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "Reduce CP consumption of active chips."
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Condition] Activating an Active Chip"
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
-		"tr_explainShort": "CP Consumption Decreased",
+		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "Greatly reduce CP consumption of active chips."
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Condition] Activating an Active Chip"
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
-		"tr_explainShort": "Chance of Withstanding Lethal Damage",
+		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "Grants a chance of withstanding\nlethal damage that would otherwise incapacitate\nyou, leaving you with 1 HP."
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Condition] Taking lethal damage"
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
-		"tr_explainShort": "Chance of Withstanding Lethal Damage",
+		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "Grants a chance of withstanding\nlethal damage that would otherwise incapacitate\nyou, leaving you with 1 HP."
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Condition] Taking lethal damage"
 	},
 	{
 		"assign": "1630",
@@ -3252,14 +3252,14 @@
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Silghtly raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] A fixed time"
+		"tr_explainLong": "① Silghtly raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] Medium"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] A fixed time"
+		"tr_explainLong": "① Raises the enemy's weakness element.\n② Boosts additional damage based on the\n    number of equipped chip elements.\n[Activation condition] When landing an attack\n[Effect duration] Medium"
 	},
 	{
 		"assign": "31537",
@@ -7837,27 +7837,27 @@
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP Recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "When damaged, recovers a large amount of CP."
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation condition] Taking damage"
 	},
 	{
 		"assign": "20022",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP Recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "When damaged, recovers a large amount of CP."
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation condition] Taking damage"
 	},
 	{
 		"assign": "20045",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Condition] Taking an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20046",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
-		"tr_explainShort": "",
+		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": ""
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted\n    enemy with a proportional counterattack.\n[Activation Condition] Taking an attack\n[Effect Duration] Medium"
 	}
 ]

--- a/json/Explain_Element_Abnormal.txt
+++ b/json/Explain_Element_Abnormal.txt
@@ -4,210 +4,210 @@
 		"jp_text": "バーンⅠ",
 		"tr_text": "Burn I",
 		"jp_explain": "バーンLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Burn Lv.1"
 	},
 	{
 		"assign": "1",
 		"jp_text": "バーンⅡ",
 		"tr_text": "Burn II",
 		"jp_explain": "バーンLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Burn Lv.2"
 	},
 	{
 		"assign": "2",
 		"jp_text": "バーンⅢ",
 		"tr_text": "Burn III",
 		"jp_explain": "バーンLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Burn Lv.3"
 	},
 	{
 		"assign": "3",
 		"jp_text": "バーンⅣ",
 		"tr_text": "Burn IV",
 		"jp_explain": "バーンLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Burn Lv.4"
 	},
 	{
 		"assign": "4",
 		"jp_text": "バーンⅤ",
 		"tr_text": "Burn V",
 		"jp_explain": "バーンLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Burn Lv.5"
 	},
 	{
 		"assign": "5",
 		"jp_text": "フリーズⅠ",
 		"tr_text": "Freeze I",
 		"jp_explain": "フリーズLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Freeze Lv.1"
 	},
 	{
 		"assign": "6",
 		"jp_text": "フリーズⅡ",
 		"tr_text": "Freeze II",
 		"jp_explain": "フリーズLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Freeze Lv.2"
 	},
 	{
 		"assign": "7",
 		"jp_text": "フリーズⅢ",
 		"tr_text": "Freeze III",
 		"jp_explain": "フリーズLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Freeze Lv.3"
 	},
 	{
 		"assign": "8",
 		"jp_text": "フリーズⅣ",
 		"tr_text": "Freeze IV",
 		"jp_explain": "フリーズLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Freeze Lv.4"
 	},
 	{
 		"assign": "9",
 		"jp_text": "フリーズⅤ",
 		"tr_text": "Freeze V",
 		"jp_explain": "フリーズLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Freeze Lv.5"
 	},
 	{
 		"assign": "10",
 		"jp_text": "ショックⅠ",
 		"tr_text": "Shock I",
 		"jp_explain": "ショックLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Shock Lv.1"
 	},
 	{
 		"assign": "11",
 		"jp_text": "ショックⅡ",
 		"tr_text": "Shock II",
 		"jp_explain": "ショックLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Shock Lv.2"
 	},
 	{
 		"assign": "12",
 		"jp_text": "ショックⅢ",
 		"tr_text": "Shock III",
 		"jp_explain": "ショックLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Shock Lv.3"
 	},
 	{
 		"assign": "13",
 		"jp_text": "ショックⅣ",
 		"tr_text": "Shock IV",
 		"jp_explain": "ショックLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Shock Lv.4"
 	},
 	{
 		"assign": "14",
 		"jp_text": "ショックⅤ",
 		"tr_text": "Shock V",
 		"jp_explain": "ショックLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Shock Lv.5"
 	},
 	{
 		"assign": "15",
 		"jp_text": "ミラージュⅠ",
 		"tr_text": "Mirage I",
 		"jp_explain": "ミラージュLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Mirage Lv.1"
 	},
 	{
 		"assign": "16",
 		"jp_text": "ミラージュⅡ",
 		"tr_text": "Mirage II",
 		"jp_explain": "ミラージュLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Mirage Lv.2"
 	},
 	{
 		"assign": "17",
 		"jp_text": "ミラージュⅢ",
 		"tr_text": "Mirage III",
 		"jp_explain": "ミラージュLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Mirage Lv.3"
 	},
 	{
 		"assign": "18",
 		"jp_text": "ミラージュⅣ",
 		"tr_text": "Mirage IV",
 		"jp_explain": "ミラージュLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Mirage Lv.4"
 	},
 	{
 		"assign": "19",
 		"jp_text": "ミラージュⅤ",
 		"tr_text": "Mirage V",
 		"jp_explain": "ミラージュLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Mirage Lv.5"
 	},
 	{
 		"assign": "20",
 		"jp_text": "ポイズンⅠ",
 		"tr_text": "Poison I",
 		"jp_explain": "ポイズンLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Poison Lv.1"
 	},
 	{
 		"assign": "21",
 		"jp_text": "ポイズンⅡ",
 		"tr_text": "Poison II",
 		"jp_explain": "ポイズンLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Poison Lv.2"
 	},
 	{
 		"assign": "22",
 		"jp_text": "ポイズンⅢ",
 		"tr_text": "Poison III",
 		"jp_explain": "ポイズンLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Poison Lv.3"
 	},
 	{
 		"assign": "23",
 		"jp_text": "ポイズンⅣ",
 		"tr_text": "Poison IV",
 		"jp_explain": "ポイズンLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Poison Lv.4"
 	},
 	{
 		"assign": "24",
 		"jp_text": "ポイズンⅤ",
 		"tr_text": "Poison V",
 		"jp_explain": "ポイズンLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Poison Lv.5"
 	},
 	{
 		"assign": "25",
 		"jp_text": "パニックⅠ",
 		"tr_text": "Panic I",
 		"jp_explain": "パニックLv.1を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Panic Lv.1"
 	},
 	{
 		"assign": "26",
 		"jp_text": "パニックⅡ",
 		"tr_text": "Panic II",
 		"jp_explain": "パニックLv.2を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Panic Lv.2"
 	},
 	{
 		"assign": "27",
 		"jp_text": "パニックⅢ",
 		"tr_text": "Panic III",
 		"jp_explain": "パニックLv.3を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Panic Lv.3"
 	},
 	{
 		"assign": "28",
 		"jp_text": "パニックⅣ",
 		"tr_text": "Panic IV",
 		"jp_explain": "パニックLv.4を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Panic Lv.4"
 	},
 	{
 		"assign": "29",
 		"jp_text": "パニックⅤ",
 		"tr_text": "Panic V",
 		"jp_explain": "パニックLv.5を付与する",
-		"tr_explain": ""
+		"tr_explain": "Grants Panic Lv.5"
 	},
 	{
 		"assign": "30",

--- a/json/Item_Stack_DeviceHT.txt
+++ b/json/Item_Stack_DeviceHT.txt
@@ -1012,21 +1012,21 @@
 		"jp_text": "進化Ｄ／フェリチェマクス",
 		"tr_text": "Evo. Device/Felice Max",
 		"jp_explain": "Ｌｖ．１００以上のマグに使用できる\nマグの形態進化デバイス。\n「フェリチェマクス」に進化する。",
-		"tr_explain": "Requires a Lv.100 mag or above to\nuse. Evolves your mag into a\nFelice Max"
+		"tr_explain": "Requires a Lv.100 mag or above to\nuse. Evolves your mag into a\nFelice Max."
 	},
 	{
 		"assign": "3120157",
 		"jp_text": "進化Ｄ／ホワイトラプラス",
-		"tr_text": "",
+		"tr_text": "Evo. Device/White Laplace",
 		"jp_explain": "Ｌｖ．１００以上のマグに使用できる\nマグの形態進化デバイス。\n「ホワイトラプラス」に進化する。",
-		"tr_explain": ""
+		"tr_explain": "Requires a Lv.100 mag or above to\nuse. Evolves your mag into a\nWhite Laplace."
 	},
 	{
 		"assign": "3120159",
 		"jp_text": "進化Ｄ／ラヴィ・エンペ",
-		"tr_text": "",
+		"tr_text": "Evo. Device/Lovey Emperappy",
 		"jp_explain": "Ｌｖ．１００以上のマグに使用できる\nマグの形態進化デバイス。\n「ラヴィ・エンペ」に進化する。",
-		"tr_explain": ""
+		"tr_explain": "Requires a Lv.100 mag or above to\nuse. Evolves your mag into a\nLovey Emperappy."
 	},
 	{
 		"assign": "3120163",

--- a/json/Item_Stack_DeviceHT.txt
+++ b/json/Item_Stack_DeviceHT.txt
@@ -823,7 +823,7 @@
 		"jp_text": "進化Ｄ／屋台ラッピー",
 		"tr_text": "Evo. D/Food Cart Rappy",
 		"jp_explain": "Ｌｖ．１００以上のマグに使用できる\nマグの形態進化デバイス。\n「屋台ラッピー」に進化する。",
-		"tr_explain": ""
+		"tr_explain": "Requires a Lv.100 mag or above to\nuse. Evolves your mag into a\nFood Cart Rappy."
 	},
 	{
 		"assign": "3120127",

--- a/json/Item_Stack_Enemy.txt
+++ b/json/Item_Stack_Enemy.txt
@@ -86,9 +86,9 @@
 	{
 		"assign": "331016",
 		"jp_text": "ゾロン・ゴラールトリガー",
-		"tr_text": "",
+		"tr_text": "Zoron Goraal Trigger",
 		"jp_explain": "ゾロン・ゴラールを\nクエスト中に出現させるトリガー。\n特定のフリーフィールドで使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Triggers the appearance of\nZoron Goraal.\nOnly works in the correct Free Field."
 	},
 	{
 		"assign": "331017",

--- a/json/Item_Stack_GatOMatMeat.txt
+++ b/json/Item_Stack_GatOMatMeat.txt
@@ -4,13 +4,13 @@
 		"jp_text": "赤身肉",
 		"tr_text": "Red Meat",
 		"jp_explain": "<c f0df60>全惑星<c>で手に入る肉。\n脂身が少なく、赤みが多い。\n焼き上げると歯応え抜群。",
-		"tr_explain": ""
+		"tr_explain": "Meat found on <c f0df60>all planets<c>.\nLean, red meat.\nDeliciously tender when cooked."
 	},
 	{
 		"assign": "37001",
 		"jp_text": "霜降り肉",
 		"tr_text": "Marbled Meat",
 		"jp_explain": "<c f0df60>全惑星<c>で手に入る肉。\n上質な脂肪が細かく網の目のように\nなっており、とても柔らかい。",
-		"tr_explain": ""
+		"tr_explain": "Meat found on <c f0df60>all planets<c>.\nHigh-quality meat made soft and\ntender by its marbling of fat."
 	}
 ]

--- a/json/Item_Stack_PaidTicket.txt
+++ b/json/Item_Stack_PaidTicket.txt
@@ -186,14 +186,14 @@
 		"jp_text": "マイルーム利用１日",
 		"tr_text": "My Room 1 Day",
 		"jp_explain": "マイルーム利用許可チケット。\n使用することで、１日間\nマイルームの利用が可能になる。",
-		"tr_explain": ""
+		"tr_explain": "Allows you to open your own room\nfor a single day."
 	},
 	{
 		"assign": "320028",
 		"jp_text": "マイショップ出店１日",
 		"tr_text": "My Shop 1 Day",
 		"jp_explain": "マイショップ出店許可チケット。\n使用することで、１日間\nマイショップの出品が可能になる。",
-		"tr_explain": ""
+		"tr_explain": "Allows you to sell items at the player\nshops for a single day."
 	},
 	{
 		"assign": "320029",
@@ -333,7 +333,7 @@
 		"jp_text": "シフタ／リセット",
 		"tr_text": "Shifta/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320052",
@@ -375,7 +375,7 @@
 		"jp_text": "デバンド／リセット",
 		"tr_text": "Deband/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320058",
@@ -417,7 +417,7 @@
 		"jp_text": "ゾンディール／リセット",
 		"tr_text": "Zondeel/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320064",
@@ -466,7 +466,7 @@
 		"jp_text": "ザンバース／リセット",
 		"tr_text": "Zanverse/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320071",
@@ -494,14 +494,14 @@
 		"jp_text": "レスタ／リセット",
 		"tr_text": "Resta/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320075",
 		"jp_text": "アンティ／リセット",
 		"tr_text": "Anti/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320076",
@@ -543,7 +543,7 @@
 		"jp_text": "メギバース／リセット",
 		"tr_text": "Megiverse/Reset",
 		"jp_explain": "使用すると該当テクニックの\nカスタマイズをリセットする。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "320082",
@@ -655,21 +655,21 @@
 		"jp_text": "リア／効果時間延長７日",
 		"tr_text": "Rear/Timed Ability Reset 7d",
 		"jp_explain": "装備中のリアユニットの\n時限能力を延長する。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "3200101",
 		"jp_text": "アーム／効果時間延長７日",
 		"tr_text": "Arm/Timed Ability Reset 7d",
 		"jp_explain": "装備中のアームユニットの\n時限能力を延長する。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "3200102",
 		"jp_text": "レッグ／効果時間延長７日",
 		"tr_text": "Leg/Timed Ability Reset 7d",
 		"jp_explain": "装備中のレッグユニットの\n時限能力を延長する。",
-		"tr_explain": ""
+		"tr_explain": "Resets any customizations to default."
 	},
 	{
 		"assign": "3200103",
@@ -1220,9 +1220,9 @@
 	{
 		"assign": "3200186",
 		"jp_text": "メインマッチブースト回復１",
-		"tr_text": "",
+		"tr_text": "Main Match Boost Recovery 1",
 		"jp_explain": "使用するとバスタークエストの\nメインマッチブーストの回数が１回復する。\n<yellow>※回数の上限値は超過しません。<c>",
-		"tr_explain": ""
+		"tr_explain": "Immediately recovers 1 Buster Quest\nMain Match Boost.\n<yellow>※Cannot exceed the maximum limit.<c>"
 	},
 	{
 		"assign": "3200187",

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -1334,7 +1334,7 @@
 		"jp_text": "PSO2 STATION!",
 		"tr_text": "PSO2 STATION!",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nPSO2 STATION!が選択可能。",
-		"tr_explain": "By using this ticket, the sticker\n\"\"\ncan be used in the Beauty Salon."
+		"tr_explain": "By using this ticket, the sticker\n\"PSO2 STATION!\"\ncan be used in the Beauty Salon."
 	},
 	{
 		"assign": "3170204",

--- a/json/Name_Actor_Enemy.txt
+++ b/json/Name_Actor_Enemy.txt
@@ -287,12 +287,12 @@
 	{
 		"assign": "RappyDragon",
 		"jp_text": "ドラグ・ラッピー",
-		"tr_text": ""
+		"tr_text": "Drago Rappy"
 	},
 	{
 		"assign": "RappyElep",
 		"jp_text": "エレフ・ラッピー",
-		"tr_text": ""
+		"tr_text": "Eleph Rappy"
 	},
 	{
 		"assign": "DragonRaptor",
@@ -2387,7 +2387,7 @@
 	{
 		"assign": "B1CatsCSP",
 		"jp_text": "魔神城・ミシルガスード",
-		"tr_text": ""
+		"tr_text": "Devil Castle - Misil Ghasud"
 	},
 	{
 		"assign": "B1OrBo",
@@ -2462,7 +2462,7 @@
 	{
 		"assign": "BD1Dp",
 		"jp_text": "オメガファルス・ルーサー",
-		"tr_text": ""
+		"tr_text": "Omega Falz Loser"
 	},
 	{
 		"assign": "FD1Dhu",
@@ -2472,12 +2472,12 @@
 	{
 		"assign": "RD",
 		"jp_text": "エリュトロン・ドラゴン",
-		"tr_text": ""
+		"tr_text": "Erythron Dragon"
 	},
 	{
 		"assign": "B2RdR",
 		"jp_text": "ドラゴン・アートルム",
-		"tr_text": ""
+		"tr_text": "Dragon Atrum"
 	},
 	{
 		"assign": "REHW",
@@ -2487,12 +2487,12 @@
 	{
 		"assign": "REVD",
 		"jp_text": "ラブ・エンペラッピー",
-		"tr_text": ""
+		"tr_text": "Love Emperappy"
 	},
 	{
 		"assign": "REWD",
 		"jp_text": "ラヴィ・エンペラッピー",
-		"tr_text": ""
+		"tr_text": "Lovey Emperappy"
 	},
 	{
 		"assign": "RP2",
@@ -2532,17 +2532,17 @@
 	{
 		"assign": "N1Dbe",
 		"jp_text": "サンダーロックベア",
-		"tr_text": ""
+		"tr_text": "Thunder Rockbear"
 	},
 	{
 		"assign": "P1Dbe",
 		"jp_text": "サンダーベア",
-		"tr_text": ""
+		"tr_text": "Thunder Bear"
 	},
 	{
 		"assign": "BD2Bhu",
 		"jp_text": "オメガ・アンゲル",
-		"tr_text": ""
+		"tr_text": "Omega Angel"
 	},
 	{
 		"assign": "KingRappy",
@@ -2877,7 +2877,7 @@
 	{
 		"assign": "DragonBerserkASP1",
 		"jp_text": "クローム・ドラゴン＋",
-		"tr_text": ""
+		"tr_text": "Chrome Dragon+"
 	},
 	{
 		"assign": "MarineTetraSP1",
@@ -2952,7 +2952,7 @@
 	{
 		"assign": "AbyssFlowerRareST0",
 		"jp_text": "アナティス",
-		"tr_text": ""
+		"tr_text": "Anatis"
 	},
 	{
 		"assign": "PantherBRareQU0",
@@ -3637,12 +3637,12 @@
 	{
 		"assign": "BirdCrestEx",
 		"jp_text": "ドリュアーダＥｘ",
-		"tr_text": ""
+		"tr_text": "Doluahda EX"
 	},
 	{
 		"assign": "BirdSoldierAEx",
 		"jp_text": "ソルダ・カピタＥｘ",
-		"tr_text": ""
+		"tr_text": "Solda Kapita EX"
 	},
 	{
 		"assign": "NativeBeastEx",
@@ -3912,7 +3912,7 @@
 	{
 		"assign": "AbyssTetraEx",
 		"jp_text": "ブルトルボンＥｘ",
-		"tr_text": ""
+		"tr_text": "Blutorbon EX"
 	},
 	{
 		"assign": "DarkerCannonAEx",
@@ -3967,7 +3967,7 @@
 	{
 		"assign": "AbyssFlowerRareST0Ex",
 		"jp_text": "アナティスＥｘ",
-		"tr_text": ""
+		"tr_text": "Anatis EX"
 	},
 	{
 		"assign": "PantherBRareQU0Ex",

--- a/json/Name_Chip_AbilityEffectExplain.txt
+++ b/json/Name_Chip_AbilityEffectExplain.txt
@@ -62,22 +62,22 @@
 	{
 		"assign": "13",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "14",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "15",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "16",
 		"jp_text": "ダメージ量／攻撃数／状態異常率アップ",
-		"tr_text": "Damage Boost/ATK/Status Up"
+		"tr_text": "Damage Boost Up/ATK/Status Up"
 	},
 	{
 		"assign": "17",
@@ -112,7 +112,7 @@
 	{
 		"assign": "23",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "24",
@@ -127,7 +127,7 @@
 	{
 		"assign": "26",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "27",
@@ -217,12 +217,12 @@
 	{
 		"assign": "44",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "45",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "46",
@@ -237,7 +237,7 @@
 	{
 		"assign": "48",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Boost"
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "49",
@@ -267,7 +267,7 @@
 	{
 		"assign": "54",
 		"jp_text": "ダメージ量上限アップ",
-		"tr_text": ""
+		"tr_text": "Max Damage Boost Up"
 	},
 	{
 		"assign": "55",
@@ -332,12 +332,12 @@
 	{
 		"assign": "67",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "68",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "69",
@@ -352,227 +352,227 @@
 	{
 		"assign": "71",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "72",
 		"jp_text": "ダメージ量アップ／ＨＰ回復量アップ",
-		"tr_text": "Damage Boost/HP Recovery Up"
+		"tr_text": "Damage Boost Up/HP Recovery Up"
 	},
 	{
 		"assign": "73",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "74",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "75",
 		"jp_text": "ダメージ量アップ／ＣＰ消費量ダウン",
-		"tr_text": "Damage Boost/CP Usage Down"
+		"tr_text": "Damage Boost Up/CP Usage Down"
 	},
 	{
 		"assign": "76",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "77",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "78",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "79",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "80",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "81",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "82",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "83",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "84",
 		"jp_text": "ダメージ量アップ／防御アップ",
-		"tr_text": "Damage Boost/HP Recovery Up"
+		"tr_text": "Damage Boost Up/HP Recovery Up"
 	},
 	{
 		"assign": "85",
 		"jp_text": "ダメージ量アップ／ＨＰ回復量アップ",
-		"tr_text": "Damage Boost/HP Recovery Up"
+		"tr_text": "Damage Boost Up/HP Recovery Up"
 	},
 	{
 		"assign": "86",
 		"jp_text": "ダメージ量アップ／ＣＰ回復量アップ",
-		"tr_text": "Damage Boost/CP Recovery Up"
+		"tr_text": "Damage Boost Up/CP Recovery Up"
 	},
 	{
 		"assign": "87",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "88",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "89",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "90",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "91",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "92",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "93",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "94",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "95",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "96",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "97",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "98",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "99",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "100",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "101",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "102",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "103",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "104",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "105",
 		"jp_text": "ダメージ量アップ／威力アップ",
-		"tr_text": "Damage Boost/Power Boost"
+		"tr_text": "Damage Boost Up/Power Boost"
 	},
 	{
 		"assign": "106",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "107",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "108",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "109",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "110",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Boost"
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "111",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Boost"
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "112",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "113",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "114",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "115",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Boost"
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "116",
@@ -582,32 +582,32 @@
 	{
 		"assign": "118",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "119",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "120",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "121",
 		"jp_text": "ダメージ量アップ／威力アップ",
-		"tr_text": "Damage Boost/Power Boost"
+		"tr_text": "Damage Boost Up/Power Boost"
 	},
 	{
 		"assign": "122",
 		"jp_text": "ダメージアップ／パラメータ上昇アップ",
-		"tr_text": ""
+		"tr_text": "Damage Up/Parameters Up"
 	},
 	{
 		"assign": "123",
 		"jp_text": "ＨＰＣＰ回復量アップ／ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "HP&CP Recovery Up/Damage Boost Up"
 	},
 	{
 		"assign": "124",
@@ -617,32 +617,32 @@
 	{
 		"assign": "125",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "126",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "127",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "128",
 		"jp_text": "威力アップ",
-		"tr_text": ""
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "129",
 		"jp_text": "ダメージ量アップ／ＣＰ回復量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up/CP Recovery Up"
 	},
 	{
 		"assign": "130",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost"
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "131",
@@ -812,41 +812,41 @@
 	{
 		"assign": "164",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "165",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "166",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "167",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "168",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Boost"
+		"tr_text": "Power Up"
 	},
 	{
 		"assign": "997",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "998",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": ""
+		"tr_text": "Damage Boost Up"
 	},
 	{
 		"assign": "999",
 		"jp_text": "威力アップ",
-		"tr_text": ""
+		"tr_text": "Power Up"
 	}
 ]

--- a/json/Name_Chip_ActiveName.txt
+++ b/json/Name_Chip_ActiveName.txt
@@ -1527,7 +1527,7 @@
 	{
 		"assign": "50154",
 		"jp_text": "昇刃３",
-		"tr_text": Rising Blade 3""
+		"tr_text": "Rising Blade 3"
 	},
 	{
 		"assign": "50164",

--- a/json/Name_Chip_ActiveName.txt
+++ b/json/Name_Chip_ActiveName.txt
@@ -772,12 +772,12 @@
 	{
 		"assign": "31269",
 		"jp_text": "スチーミィ・ウィスパー",
-		"tr_text": ""
+		"tr_text": "Steamy Whisper"
 	},
 	{
 		"assign": "31270",
 		"jp_text": "スチーミィ・ウィスパー＋",
-		"tr_text": ""
+		"tr_text": "Steamy Whisper+"
 	},
 	{
 		"assign": "31271",
@@ -797,17 +797,17 @@
 	{
 		"assign": "31278",
 		"jp_text": "弐ノ太刀要ラズ＋",
-		"tr_text": ""
+		"tr_text": "Twin Pivoting Blades Laz+"
 	},
 	{
 		"assign": "31291",
 		"jp_text": "インフォメーションサポート",
-		"tr_text": ""
+		"tr_text": "Information Support"
 	},
 	{
 		"assign": "31292",
 		"jp_text": "インフォメーションサポート＋",
-		"tr_text": ""
+		"tr_text": "Information Support+"
 	},
 	{
 		"assign": "31311",
@@ -872,12 +872,12 @@
 	{
 		"assign": "31345",
 		"jp_text": "リリーパスピリッツ",
-		"tr_text": ""
+		"tr_text": "Lillipa Spirits"
 	},
 	{
 		"assign": "31346",
 		"jp_text": "リリーパスピリッツ＋",
-		"tr_text": ""
+		"tr_text": "Lillipa Spirits+"
 	},
 	{
 		"assign": "31355",
@@ -912,22 +912,22 @@
 	{
 		"assign": "31405",
 		"jp_text": "メタモルキャッツアイ",
-		"tr_text": ""
+		"tr_text": "Metamor Cat's Eye"
 	},
 	{
 		"assign": "31406",
 		"jp_text": "メタモルキャッツアイ＋",
-		"tr_text": ""
+		"tr_text": "Metamor Cat's Eye+"
 	},
 	{
 		"assign": "31409",
 		"jp_text": "ラピッドスライサー",
-		"tr_text": ""
+		"tr_text": "Rapid Slicer"
 	},
 	{
 		"assign": "31410",
 		"jp_text": "ラピッドスライサー＋",
-		"tr_text": ""
+		"tr_text": "Rapid Slicer+"
 	},
 	{
 		"assign": "31417",
@@ -952,12 +952,12 @@
 	{
 		"assign": "31425",
 		"jp_text": "クロスインフェルノ",
-		"tr_text": ""
+		"tr_text": "Cross Inferno"
 	},
 	{
 		"assign": "31426",
 		"jp_text": "クロスインフェルノ＋",
-		"tr_text": ""
+		"tr_text": "Cross Inferno+"
 	},
 	{
 		"assign": "31427",
@@ -972,12 +972,12 @@
 	{
 		"assign": "31437",
 		"jp_text": "カーニバル・クラッカー",
-		"tr_text": ""
+		"tr_text": "Carnival Cracker"
 	},
 	{
 		"assign": "31438",
 		"jp_text": "カーニバル・クラッカー＋",
-		"tr_text": ""
+		"tr_text": "Carnival Cracker+"
 	},
 	{
 		"assign": "31443",
@@ -1002,12 +1002,12 @@
 	{
 		"assign": "31457",
 		"jp_text": "フロンティア・トラスト",
-		"tr_text": ""
+		"tr_text": "Frontier Trust"
 	},
 	{
 		"assign": "31458",
 		"jp_text": "フロンティア・トラスト＋",
-		"tr_text": ""
+		"tr_text": "Frontier Trust+"
 	},
 	{
 		"assign": "31475",
@@ -1042,22 +1042,22 @@
 	{
 		"assign": "31499",
 		"jp_text": "ブースト・ラッシュ",
-		"tr_text": ""
+		"tr_text": "Boost Rush"
 	},
 	{
 		"assign": "31500",
 		"jp_text": "ブースト・ラッシュ＋",
-		"tr_text": ""
+		"tr_text": "Boost Rush+"
 	},
 	{
 		"assign": "31507",
 		"jp_text": "ファイティング・ラッシュ",
-		"tr_text": ""
+		"tr_text": "Fighting Rush"
 	},
 	{
 		"assign": "31508",
 		"jp_text": "ファイティング・ラッシュ＋",
-		"tr_text": ""
+		"tr_text": "Fighting Rush+"
 	},
 	{
 		"assign": "31509",
@@ -1072,12 +1072,12 @@
 	{
 		"assign": "31517",
 		"jp_text": "ハートビートクレシェンド",
-		"tr_text": ""
+		"tr_text": "Heartbeat Crescendo"
 	},
 	{
 		"assign": "31518",
 		"jp_text": "ハートビートクレシェンド＋",
-		"tr_text": ""
+		"tr_text": "Heartbeat Crescendo+"
 	},
 	{
 		"assign": "31519",
@@ -1092,12 +1092,12 @@
 	{
 		"assign": "31523",
 		"jp_text": "エナジー・リチャージ",
-		"tr_text": ""
+		"tr_text": "Energy Recharge"
 	},
 	{
 		"assign": "31524",
 		"jp_text": "エナジー・リチャージ＋",
-		"tr_text": ""
+		"tr_text": "Energy Recharge+"
 	},
 	{
 		"assign": "31533",
@@ -1112,12 +1112,12 @@
 	{
 		"assign": "31539",
 		"jp_text": "メタルウィング",
-		"tr_text": ""
+		"tr_text": "Metal Wing"
 	},
 	{
 		"assign": "31540",
 		"jp_text": "メタルウィング＋",
-		"tr_text": ""
+		"tr_text": "Metal Wing+"
 	},
 	{
 		"assign": "31543",
@@ -1467,102 +1467,102 @@
 	{
 		"assign": "50110",
 		"jp_text": "昇刃１",
-		"tr_text": ""
+		"tr_text": "Rising Blade 1"
 	},
 	{
 		"assign": "50120",
 		"jp_text": "昇刃１＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 1+"
 	},
 	{
 		"assign": "50130",
 		"jp_text": "昇刃２",
-		"tr_text": ""
+		"tr_text": "Rising Blade 2"
 	},
 	{
 		"assign": "50140",
 		"jp_text": "昇刃２＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 2+"
 	},
 	{
 		"assign": "50150",
 		"jp_text": "昇刃３",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3"
 	},
 	{
 		"assign": "50160",
 		"jp_text": "昇刃３＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3+"
 	},
 	{
 		"assign": "50151",
 		"jp_text": "昇刃３",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3"
 	},
 	{
 		"assign": "50161",
 		"jp_text": "昇刃３＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3+"
 	},
 	{
 		"assign": "50152",
 		"jp_text": "昇刃３",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3"
 	},
 	{
 		"assign": "50162",
 		"jp_text": "昇刃３＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3+"
 	},
 	{
 		"assign": "50153",
 		"jp_text": "昇刃３",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3"
 	},
 	{
 		"assign": "50163",
 		"jp_text": "昇刃３＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3+"
 	},
 	{
 		"assign": "50154",
 		"jp_text": "昇刃３",
-		"tr_text": ""
+		"tr_text": Rising Blade 3""
 	},
 	{
 		"assign": "50164",
 		"jp_text": "昇刃３＋",
-		"tr_text": ""
+		"tr_text": "Rising Blade 3+"
 	},
 	{
 		"assign": "50210",
 		"jp_text": "輪斬１",
-		"tr_text": ""
+		"tr_text": "Circle Slash 1"
 	},
 	{
 		"assign": "50220",
 		"jp_text": "輪斬１＋",
-		"tr_text": ""
+		"tr_text": "Circle Slash 1+"
 	},
 	{
 		"assign": "50230",
 		"jp_text": "輪斬２",
-		"tr_text": ""
+		"tr_text": "Circle Slash 2"
 	},
 	{
 		"assign": "50240",
 		"jp_text": "輪斬２＋",
-		"tr_text": ""
+		"tr_text": "Circle Slash 2+"
 	},
 	{
 		"assign": "50250",
 		"jp_text": "輪斬３",
-		"tr_text": ""
+		"tr_text": "Circle Slash 3"
 	},
 	{
 		"assign": "50260",
 		"jp_text": "輪斬３＋",
-		"tr_text": ""
+		"tr_text": "Circle Slash 3+"
 	},
 	{
 		"assign": "50310",
@@ -4787,22 +4787,22 @@
 	{
 		"assign": "5310",
 		"jp_text": "キャラパスボルケーノ",
-		"tr_text": ""
+		"tr_text": "Carapace Volcano"
 	},
 	{
 		"assign": "5320",
 		"jp_text": "キャラパスインフェルノ",
-		"tr_text": ""
+		"tr_text": "Carapace Inferno"
 	},
 	{
 		"assign": "20005",
 		"jp_text": "シャドウストーム",
-		"tr_text": ""
+		"tr_text": "Shadow Storm"
 	},
 	{
 		"assign": "20006",
 		"jp_text": "ダークネストルネード",
-		"tr_text": ""
+		"tr_text": "Darkness Tornado"
 	},
 	{
 		"assign": "20007",
@@ -4827,12 +4827,12 @@
 	{
 		"assign": "20043",
 		"jp_text": "ダークランス",
-		"tr_text": ""
+		"tr_text": "Dark Lance"
 	},
 	{
 		"assign": "20044",
 		"jp_text": "ダークスティンガー",
-		"tr_text": ""
+		"tr_text": "Dark Stinger"
 	},
 	{
 		"assign": "5410",
@@ -4907,12 +4907,12 @@
 	{
 		"assign": "6810",
 		"jp_text": "ローリングアーム",
-		"tr_text": ""
+		"tr_text": "Rolling Arm"
 	},
 	{
 		"assign": "6820",
 		"jp_text": "メガトンローリングアーム",
-		"tr_text": ""
+		"tr_text": "Megaton Rolling Arm"
 	},
 	{
 		"assign": "7010",
@@ -5027,12 +5027,12 @@
 	{
 		"assign": "9410",
 		"jp_text": "ハンドレットレイ",
-		"tr_text": ""
+		"tr_text": "One Hundred Rays"
 	},
 	{
 		"assign": "9420",
 		"jp_text": "サウザントレイ",
-		"tr_text": ""
+		"tr_text": "One Thousand Rays"
 	},
 	{
 		"assign": "9423",
@@ -5047,12 +5047,12 @@
 	{
 		"assign": "9421",
 		"jp_text": "ダーククリスタル・ランス",
-		"tr_text": ""
+		"tr_text": "Dark Crystal Lance"
 	},
 	{
 		"assign": "9422",
 		"jp_text": "ダーククリスタル・レイン",
-		"tr_text": ""
+		"tr_text": "Dark Crystal Rain"
 	},
 	{
 		"assign": "20025",

--- a/json/Name_Chip_ActiveName.txt
+++ b/json/Name_Chip_ActiveName.txt
@@ -92,12 +92,12 @@
 	{
 		"assign": "1510",
 		"jp_text": "裁きの一閃",
-		"tr_text": "Flash of Judgement"
+		"tr_text": "Snap Verdict"
 	},
 	{
 		"assign": "1520",
 		"jp_text": "断罪の一閃",
-		"tr_text": "Flash of Conviction"
+		"tr_text": "Snap Judgement"
 	},
 	{
 		"assign": "1530",

--- a/json/Name_Chip_ActiveName.txt
+++ b/json/Name_Chip_ActiveName.txt
@@ -62,12 +62,12 @@
 	{
 		"assign": "910",
 		"jp_text": "発破",
-		"tr_text": ""
+		"tr_text": "Explosion"
 	},
 	{
 		"assign": "920",
 		"jp_text": "超発破",
-		"tr_text": ""
+		"tr_text": "Super Explosion"
 	},
 	{
 		"assign": "1110",
@@ -82,22 +82,22 @@
 	{
 		"assign": "1310",
 		"jp_text": "エレメンタルヒット",
-		"tr_text": ""
+		"tr_text": "Elemental Hit"
 	},
 	{
 		"assign": "1320",
 		"jp_text": "エレメンタルブレイク",
-		"tr_text": ""
+		"tr_text": "Elemental Break"
 	},
 	{
 		"assign": "1510",
 		"jp_text": "裁きの一閃",
-		"tr_text": ""
+		"tr_text": "Flash of Judgement"
 	},
 	{
 		"assign": "1520",
 		"jp_text": "断罪の一閃",
-		"tr_text": ""
+		"tr_text": "Flash of Conviction"
 	},
 	{
 		"assign": "1530",
@@ -482,12 +482,12 @@
 	{
 		"assign": "31071",
 		"jp_text": "エレメンタルチェンジャー",
-		"tr_text": ""
+		"tr_text": "Elemental Changer"
 	},
 	{
 		"assign": "31072",
 		"jp_text": "エレメンタルチェンジャー＋",
-		"tr_text": ""
+		"tr_text": "Elemental Changer+"
 	},
 	{
 		"assign": "31085",
@@ -532,22 +532,22 @@
 	{
 		"assign": "31099",
 		"jp_text": "ヘヴンズギフト",
-		"tr_text": ""
+		"tr_text": "Heaven's Gift"
 	},
 	{
 		"assign": "31100",
 		"jp_text": "ヘヴンズギフト＋",
-		"tr_text": ""
+		"tr_text": "Heaven's Gift+"
 	},
 	{
 		"assign": "31119",
 		"jp_text": "ニューイヤーナビゲーション",
-		"tr_text": ""
+		"tr_text": "New Year Navigation"
 	},
 	{
 		"assign": "31120",
 		"jp_text": "ニューイヤーナビゲーション＋",
-		"tr_text": ""
+		"tr_text": "New Year Navigation+"
 	},
 	{
 		"assign": "31131",
@@ -712,12 +712,12 @@
 	{
 		"assign": "31241",
 		"jp_text": "リフレッシュ・オペレーション",
-		"tr_text": ""
+		"tr_text": "Refresh Operation"
 	},
 	{
 		"assign": "31242",
 		"jp_text": "リフレッシュ・オペレーション＋",
-		"tr_text": ""
+		"tr_text": "Refresh Operation+"
 	},
 	{
 		"assign": "31243",
@@ -1022,12 +1022,12 @@
 	{
 		"assign": "31483",
 		"jp_text": "ブーケトス・バレット",
-		"tr_text": ""
+		"tr_text": "Bouquet's Bullet"
 	},
 	{
 		"assign": "31484",
 		"jp_text": "ブーケトス・バレット＋",
-		"tr_text": ""
+		"tr_text": "Bouquet's Bullet+"
 	},
 	{
 		"assign": "31485",
@@ -1187,32 +1187,32 @@
 	{
 		"assign": "31599",
 		"jp_text": "ニューイヤー・トレジャー",
-		"tr_text": ""
+		"tr_text": "New Year Treasure"
 	},
 	{
 		"assign": "31600",
 		"jp_text": "ニューイヤー・トレジャー＋",
-		"tr_text": ""
+		"tr_text": "New Year Treasure+"
 	},
 	{
 		"assign": "31605",
 		"jp_text": "ノンストップ・マグロトルネード",
-		"tr_text": ""
+		"tr_text": "Non-Stop Tuna Tornado"
 	},
 	{
 		"assign": "31606",
 		"jp_text": "ノンストップ・マグロトルネード＋",
-		"tr_text": ""
+		"tr_text": "Non-Stop Tuna Tornado+"
 	},
 	{
 		"assign": "31609",
 		"jp_text": "アーレス・エナジーストーム",
-		"tr_text": ""
+		"tr_text": "Ares Energy Storm"
 	},
 	{
 		"assign": "31610",
 		"jp_text": "アーレス・エナジーストーム＋",
-		"tr_text": ""
+		"tr_text": "Ares Energy Storm+"
 	},
 	{
 		"assign": "31624",
@@ -1227,37 +1227,37 @@
 	{
 		"assign": "31633",
 		"jp_text": "アーレス・ブレイブオーラ",
-		"tr_text": ""
+		"tr_text": "Ares Brave Aura"
 	},
 	{
 		"assign": "31634",
 		"jp_text": "アーレス・ブレイブオーラ＋",
-		"tr_text": ""
+		"tr_text": "Ares Brave Aura+"
 	},
 	{
 		"assign": "31635",
 		"jp_text": "アーレス・ブレイブオーラ＋＋",
-		"tr_text": ""
+		"tr_text": "Ares Brave Aura++"
 	},
 	{
 		"assign": "31644",
 		"jp_text": "ドリームスターシュート",
-		"tr_text": ""
+		"tr_text": "Dream Star Shoot"
 	},
 	{
 		"assign": "31645",
 		"jp_text": "ドリームスターシュート＋",
-		"tr_text": ""
+		"tr_text": "Dream Star Shoot+"
 	},
 	{
 		"assign": "31646",
 		"jp_text": "ユニオンクロスブレード",
-		"tr_text": ""
+		"tr_text": "Union Cross Blade"
 	},
 	{
 		"assign": "31647",
 		"jp_text": "ユニオンクロスブレード＋",
-		"tr_text": ""
+		"tr_text": "Union Cross Blade+"
 	},
 	{
 		"assign": "31652",
@@ -1272,12 +1272,12 @@
 	{
 		"assign": "31662",
 		"jp_text": "メーシレスファング",
-		"tr_text": ""
+		"tr_text": "Merciless Fang"
 	},
 	{
 		"assign": "31663",
 		"jp_text": "メーシレスファング＋",
-		"tr_text": ""
+		"tr_text": "Merciless Fang+"
 	},
 	{
 		"assign": "31664",
@@ -1317,12 +1317,12 @@
 	{
 		"assign": "31677",
 		"jp_text": "ダークネスブラッド",
-		"tr_text": ""
+		"tr_text": "Darkness Blood"
 	},
 	{
 		"assign": "31678",
 		"jp_text": "ダークネスブラッド＋",
-		"tr_text": ""
+		"tr_text": "Darkness Blood+"
 	},
 	{
 		"assign": "2110",
@@ -1337,12 +1337,12 @@
 	{
 		"assign": "2410",
 		"jp_text": "アベレージヒット",
-		"tr_text": ""
+		"tr_text": "Average Hit"
 	},
 	{
 		"assign": "2420",
 		"jp_text": "アベレージブレイク",
-		"tr_text": ""
+		"tr_text": "Average Break"
 	},
 	{
 		"assign": "80210",
@@ -1437,32 +1437,32 @@
 	{
 		"assign": "81610",
 		"jp_text": "ミラージュアシスト",
-		"tr_text": ""
+		"tr_text": "Mirage Assist"
 	},
 	{
 		"assign": "81620",
 		"jp_text": "ミラージュアシスト+",
-		"tr_text": ""
+		"tr_text": "Mirage Assist+"
 	},
 	{
 		"assign": "81710",
 		"jp_text": "サンダーチェンジャー",
-		"tr_text": ""
+		"tr_text": "Thunder Changer"
 	},
 	{
 		"assign": "81720",
 		"jp_text": "サンダーチェンジャー+",
-		"tr_text": ""
+		"tr_text": "Thunder Changer+"
 	},
 	{
 		"assign": "81810",
 		"jp_text": "フレイムチェンジャー",
-		"tr_text": ""
+		"tr_text": "Flame Changer"
 	},
 	{
 		"assign": "81820",
 		"jp_text": "フレイムチェンジャー+",
-		"tr_text": ""
+		"tr_text": "Flame Changer+"
 	},
 	{
 		"assign": "50110",
@@ -1637,82 +1637,82 @@
 	{
 		"assign": "50410",
 		"jp_text": "幻惑槍１",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 1"
 	},
 	{
 		"assign": "50420",
 		"jp_text": "幻惑槍１＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 1+"
 	},
 	{
 		"assign": "50430",
 		"jp_text": "幻惑槍２",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 2"
 	},
 	{
 		"assign": "50440",
 		"jp_text": "幻惑槍２＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 2+"
 	},
 	{
 		"assign": "50450",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50460",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50451",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50461",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50452",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50462",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50453",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50463",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50454",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50464",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50455",
 		"jp_text": "幻惑槍３",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3"
 	},
 	{
 		"assign": "50465",
 		"jp_text": "幻惑槍３＋",
-		"tr_text": ""
+		"tr_text": "Dazzling Spear 3+"
 	},
 	{
 		"assign": "50510",
@@ -3157,42 +3157,42 @@
 	{
 		"assign": "60109",
 		"jp_text": "拡散弾１",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet 1"
 	},
 	{
 		"assign": "60110",
 		"jp_text": "拡散弾１＋",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet +"
 	},
 	{
 		"assign": "60111",
 		"jp_text": "拡散弾２",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet 2"
 	},
 	{
 		"assign": "60112",
 		"jp_text": "拡散弾２＋",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet 2+"
 	},
 	{
 		"assign": "60113",
 		"jp_text": "拡散弾３",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet 3"
 	},
 	{
 		"assign": "60114",
 		"jp_text": "拡散弾３＋",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet 3+"
 	},
 	{
 		"assign": "60115",
 		"jp_text": "拡散弾ＥＸ",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet EX"
 	},
 	{
 		"assign": "60116",
 		"jp_text": "拡散弾ＥＸ＋",
-		"tr_text": ""
+		"tr_text": "Diffusion Bullet EX+"
 	},
 	{
 		"assign": "60117",
@@ -5077,22 +5077,22 @@
 	{
 		"assign": "9810",
 		"jp_text": "ギルナスビーム",
-		"tr_text": ""
+		"tr_text": "Gilnas Beam"
 	},
 	{
 		"assign": "9820",
 		"jp_text": "ギルナスビーム＋",
-		"tr_text": ""
+		"tr_text": "Gilnas Beam+"
 	},
 	{
 		"assign": "9910",
 		"jp_text": "ヴォルトウェーブ",
-		"tr_text": ""
+		"tr_text": "Volt Wave"
 	},
 	{
 		"assign": "9920",
 		"jp_text": "ヴォルトインパクト",
-		"tr_text": ""
+		"tr_text": "Volt Impact"
 	},
 	{
 		"assign": "10010",
@@ -5107,22 +5107,22 @@
 	{
 		"assign": "20035",
 		"jp_text": "ジェットキック",
-		"tr_text": ""
+		"tr_text": "Jet Kick"
 	},
 	{
 		"assign": "20036",
 		"jp_text": "ジェットキック・ターボ",
-		"tr_text": ""
+		"tr_text": "Jet Kick Turbo"
 	},
 	{
 		"assign": "20037",
 		"jp_text": "サンダーキャノン",
-		"tr_text": ""
+		"tr_text": "Thunder Cannon"
 	},
 	{
 		"assign": "20038",
 		"jp_text": "ケラウノキャノン",
-		"tr_text": ""
+		"tr_text": "Crown Cannon"
 	},
 	{
 		"assign": "30110",
@@ -5157,12 +5157,12 @@
 	{
 		"assign": "30410",
 		"jp_text": "ダーカーアタック",
-		"tr_text": ""
+		"tr_text": "Darker Attack"
 	},
 	{
 		"assign": "30420",
 		"jp_text": "ダーカーアタック＋",
-		"tr_text": ""
+		"tr_text": "Darker Attack+"
 	},
 	{
 		"assign": "25010",

--- a/json/Name_Chip_SPArksName.txt
+++ b/json/Name_Chip_SPArksName.txt
@@ -1632,12 +1632,12 @@
 	{
 		"assign": "529",
 		"jp_text": "ニョイボウ",
-		"tr_text": "Monkey King Bar (E)"
+		"tr_text": "Monkey King Bar"
 	},
 	{
 		"assign": "530",
 		"jp_text": "変幻自在の剛棍 ニョイボウ",
-		"tr_text": "Surreal Strong Club Monkey King Bar (E)"
+		"tr_text": "Surreal Strong Club Monkey King Bar"
 	},
 	{
 		"assign": "531",
@@ -1812,12 +1812,12 @@
 	{
 		"assign": "573",
 		"jp_text": "紅葉姫",
-		"tr_text": "Momiji Hime (E)"
+		"tr_text": "Momiji Hime"
 	},
 	{
 		"assign": "574",
 		"jp_text": "慈愛を宿す護剣 紅葉姫",
-		"tr_text": "Caring Fate's Blade Momiji Hime (E)"
+		"tr_text": "Caring Fate's Blade Momiji Hime"
 	},
 	{
 		"assign": "575",
@@ -1992,12 +1992,12 @@
 	{
 		"assign": "609",
 		"jp_text": "ナールクレセント",
-		"tr_text": "Narl Crescent (E)"
+		"tr_text": "Narl Crescent"
 	},
 	{
 		"assign": "610",
 		"jp_text": "魂惹の魄剣 ナールクレセント",
-		"tr_text": "Charming Sword Spirit Narl Crescent (E)"
+		"tr_text": "Charming Sword Spirit Narl Crescent"
 	},
 	{
 		"assign": "611",
@@ -2012,12 +2012,12 @@
 	{
 		"assign": "613",
 		"jp_text": "ブラオレット",
-		"tr_text": "Vraolet (E)"
+		"tr_text": "Vraolet"
 	},
 	{
 		"assign": "614",
 		"jp_text": "幸廻の使者 ブラオレット",
-		"tr_text": "Fortune's Ambassador Vraolet (E)"
+		"tr_text": "Fortune's Ambassador Vraolet"
 	},
 	{
 		"assign": "615",
@@ -2152,22 +2152,22 @@
 	{
 		"assign": "641",
 		"jp_text": "エリュシオン",
-		"tr_text": "Elysion (E+A)"
+		"tr_text": "Elysion"
 	},
 	{
 		"assign": "642",
 		"jp_text": "万古不易の知啓 エリュシオン",
-		"tr_text": "Perpetual Wisdom Elysion (E+A)"
+		"tr_text": "Perpetual Wisdom Elysion"
 	},
 	{
 		"assign": "643",
 		"jp_text": "ノクスディナス",
-		"tr_text": "Nox Dinas (E)"
+		"tr_text": "Nox Dinas"
 	},
 	{
 		"assign": "644",
 		"jp_text": "昏き魔光の双魔刃 ノクスディナス",
-		"tr_text": "Twin Magical Blades of Dusk Nox Dinas (E)"
+		"tr_text": "Twin Magical Blades of Dusk Nox Dinas"
 	},
 	{
 		"assign": "645",
@@ -2222,12 +2222,12 @@
 	{
 		"assign": "657",
 		"jp_text": "ルーライラ",
-		"tr_text": "Rulyra (A)"
+		"tr_text": "Rulyra"
 	},
 	{
 		"assign": "658",
 		"jp_text": "まばゆき光の奔流 ルーライラ",
-		"tr_text": "Dazzling Torrent of Light Rulyra (A)"
+		"tr_text": "Dazzling Torrent of Light Rulyra"
 	},
 	{
 		"assign": "659",
@@ -2292,12 +2292,12 @@
 	{
 		"assign": "675",
 		"jp_text": "フブキトウシュウ",
-		"tr_text": "Fubuki Toushuu (A)"
+		"tr_text": "Fubuki Toushuu"
 	},
 	{
 		"assign": "676",
 		"jp_text": "緋に染む剣姫 フブキトウシュウ",
-		"tr_text": "Scarlet Sword Princess Fubuki Toushuu (A)"
+		"tr_text": "Scarlet Sword Princess Fubuki Toushuu"
 	},
 	{
 		"assign": "677",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -362,62 +362,62 @@
 	{
 		"assign": "30095",
 		"jp_text": "超越の英気・大剣／抜剣",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Sword/Katana"
 	},
 	{
 		"assign": "30096",
 		"jp_text": "超越の英気・大剣／抜剣＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Sword/Katana+"
 	},
 	{
 		"assign": "30097",
 		"jp_text": "超越の英気・長槍",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Partizan"
 	},
 	{
 		"assign": "30098",
 		"jp_text": "超越の英気・長槍＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Partizan+"
 	},
 	{
 		"assign": "30099",
 		"jp_text": "超越の英気・導具",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Talis"
 	},
 	{
 		"assign": "30100",
 		"jp_text": "超越の英気・導具＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Talis+"
 	},
 	{
 		"assign": "31001",
 		"jp_text": "超越の英気・長杖",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Rod"
 	},
 	{
 		"assign": "31002",
 		"jp_text": "超越の英気・長杖＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Rod+"
 	},
 	{
 		"assign": "31003",
 		"jp_text": "超越の英気・鋼拳／自在槍",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Knuckles/Wired Lance"
 	},
 	{
 		"assign": "31004",
 		"jp_text": "超越の英気・鋼拳／自在槍＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Knuckles/Wired Lance+"
 	},
 	{
 		"assign": "31005",
 		"jp_text": "超越の英気・銃剣／長銃",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Gunslash/Assault Rifle"
 	},
 	{
 		"assign": "31006",
 		"jp_text": "超越の英気・銃剣／長銃＋",
-		"tr_text": ""
+		"tr_text": "Transcendent Strength - Gunslash/Assault Rifle+"
 	},
 	{
 		"assign": "31007",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -362,12 +362,12 @@
 	{
 		"assign": "30095",
 		"jp_text": "超越の英気・大剣／抜剣",
-		"tr_text": "Transcendent Strength - Sword/Katana"
+		"tr_text": "Transcendent Strength - Blades"
 	},
 	{
 		"assign": "30096",
 		"jp_text": "超越の英気・大剣／抜剣＋",
-		"tr_text": "Transcendent Strength - Sword/Katana+"
+		"tr_text": "Transcendent Strength - Blades+"
 	},
 	{
 		"assign": "30097",
@@ -402,22 +402,22 @@
 	{
 		"assign": "31003",
 		"jp_text": "超越の英気・鋼拳／自在槍",
-		"tr_text": "Transcendent Strength - Knuckles/Wired Lance"
+		"tr_text": "Transcendent Strength - Fists"
 	},
 	{
 		"assign": "31004",
 		"jp_text": "超越の英気・鋼拳／自在槍＋",
-		"tr_text": "Transcendent Strength - Knuckles/Wired Lance+"
+		"tr_text": "Transcendent Strength - Fists+"
 	},
 	{
 		"assign": "31005",
 		"jp_text": "超越の英気・銃剣／長銃",
-		"tr_text": "Transcendent Strength - Gunslash/Assault Rifle"
+		"tr_text": "Transcendent Strength - Snipers"
 	},
 	{
 		"assign": "31006",
 		"jp_text": "超越の英気・銃剣／長銃＋",
-		"tr_text": "Transcendent Strength - Gunslash/Assault Rifle+"
+		"tr_text": "Transcendent Strength - Snipers+"
 	},
 	{
 		"assign": "31007",

--- a/json/Name_Chip_SupportName.txt
+++ b/json/Name_Chip_SupportName.txt
@@ -32,12 +32,12 @@
 	{
 		"assign": "1210",
 		"jp_text": "事象の変動",
-		"tr_text": ""
+		"tr_text": "Event Alteration"
 	},
 	{
 		"assign": "1220",
 		"jp_text": "事象の改変",
-		"tr_text": ""
+		"tr_text": "Event Modification"
 	},
 	{
 		"assign": "1410",
@@ -1162,12 +1162,12 @@
 	{
 		"assign": "31221",
 		"jp_text": "雷輝結界",
-		"tr_text": "Shining Thunder Boundry"
+		"tr_text": "Shining Thunder Boundary"
 	},
 	{
 		"assign": "31222",
 		"jp_text": "雷輝結界＋",
-		"tr_text": "Shining Thunder Boundry+"
+		"tr_text": "Shining Thunder Boundary+"
 	},
 	{
 		"assign": "31223",
@@ -1452,12 +1452,12 @@
 	{
 		"assign": "31301",
 		"jp_text": "マスターオペレーション",
-		"tr_text": ""
+		"tr_text": "Master Operation"
 	},
 	{
 		"assign": "31302",
 		"jp_text": "マスターオペレーション＋",
-		"tr_text": ""
+		"tr_text": "Master Operation+"
 	},
 	{
 		"assign": "31303",
@@ -1532,22 +1532,22 @@
 	{
 		"assign": "31323",
 		"jp_text": "ボルカノバラージ",
-		"tr_text": ""
+		"tr_text": "Volcano Barrage"
 	},
 	{
 		"assign": "31324",
 		"jp_text": "ボルカノバラージ＋",
-		"tr_text": ""
+		"tr_text": "Volcano Barrage+"
 	},
 	{
 		"assign": "31325",
 		"jp_text": "パーティーデコレーション",
-		"tr_text": ""
+		"tr_text": "Party Decoration"
 	},
 	{
 		"assign": "31326",
 		"jp_text": "パーティーデコレーション＋",
-		"tr_text": ""
+		"tr_text": "Party Decoration+"
 	},
 	{
 		"assign": "31329",
@@ -1622,22 +1622,22 @@
 	{
 		"assign": "31349",
 		"jp_text": "チェイスヒットゲイン",
-		"tr_text": ""
+		"tr_text": "Chase Hit Gain"
 	},
 	{
 		"assign": "31350",
 		"jp_text": "チェイスヒットゲイン＋",
-		"tr_text": ""
+		"tr_text": "Chase Hit Gain+"
 	},
 	{
 		"assign": "31351",
 		"jp_text": "マルチプルスナイプ",
-		"tr_text": ""
+		"tr_text": "Multiple Snipe"
 	},
 	{
 		"assign": "31352",
 		"jp_text": "マルチプルスナイプ＋",
-		"tr_text": ""
+		"tr_text": "Multiple Snipe+"
 	},
 	{
 		"assign": "31353",
@@ -1782,12 +1782,12 @@
 	{
 		"assign": "31385",
 		"jp_text": "メルティスイートギフト",
-		"tr_text": ""
+		"tr_text": "Melty Sweet Gift"
 	},
 	{
 		"assign": "31386",
 		"jp_text": "メルティスイートギフト＋",
-		"tr_text": ""
+		"tr_text": "Melty Sweet Gift+"
 	},
 	{
 		"assign": "31387",
@@ -1882,12 +1882,12 @@
 	{
 		"assign": "31411",
 		"jp_text": "ビルドアップキャノン",
-		"tr_text": ""
+		"tr_text": "Build-Up Cannon"
 	},
 	{
 		"assign": "31412",
 		"jp_text": "ビルドアップキャノン＋",
-		"tr_text": ""
+		"tr_text": "Build-Up Cannon+"
 	},
 	{
 		"assign": "31413",
@@ -1982,22 +1982,22 @@
 	{
 		"assign": "31441",
 		"jp_text": "レーザーライトバレット",
-		"tr_text": ""
+		"tr_text": "Laser Light Bullet"
 	},
 	{
 		"assign": "31442",
 		"jp_text": "レーザーライトバレット＋",
-		"tr_text": ""
+		"tr_text": "Laser Light Bullet+"
 	},
 	{
 		"assign": "31445",
 		"jp_text": "ノーザン・ブリザード",
-		"tr_text": ""
+		"tr_text": "Northern Blizzard"
 	},
 	{
 		"assign": "31446",
 		"jp_text": "ノーザン・ブリザード＋",
-		"tr_text": ""
+		"tr_text": "Northern Blizzard+"
 	},
 	{
 		"assign": "31447",
@@ -2012,12 +2012,12 @@
 	{
 		"assign": "31449",
 		"jp_text": "メテオライトハンマー",
-		"tr_text": ""
+		"tr_text": "Meteorite Hammer"
 	},
 	{
 		"assign": "31450",
 		"jp_text": "メテオライトハンマー＋",
-		"tr_text": ""
+		"tr_text": "Meteorite Hammer+"
 	},
 	{
 		"assign": "31451",
@@ -2092,12 +2092,12 @@
 	{
 		"assign": "31469",
 		"jp_text": "フェアリートリック",
-		"tr_text": ""
+		"tr_text": "Fairy Trick"
 	},
 	{
 		"assign": "31470",
 		"jp_text": "フェアリートリック＋",
-		"tr_text": ""
+		"tr_text": "Fairy Trick+"
 	},
 	{
 		"assign": "31471",
@@ -2122,22 +2122,22 @@
 	{
 		"assign": "31477",
 		"jp_text": "クリティカル・インフォメーション",
-		"tr_text": ""
+		"tr_text": "Critical Information"
 	},
 	{
 		"assign": "31478",
 		"jp_text": "クリティカル・インフォメーション＋",
-		"tr_text": ""
+		"tr_text": "Critical Information+"
 	},
 	{
 		"assign": "31479",
 		"jp_text": "ライジング・サン",
-		"tr_text": ""
+		"tr_text": "Rising Sun"
 	},
 	{
 		"assign": "31480",
 		"jp_text": "ライジング・サン＋",
-		"tr_text": ""
+		"tr_text": "Rising Sun+"
 	},
 	{
 		"assign": "31481",
@@ -2352,12 +2352,12 @@
 	{
 		"assign": "31545",
 		"jp_text": "パッション・バレット",
-		"tr_text": ""
+		"tr_text": "Passion Bullet"
 	},
 	{
 		"assign": "31546",
 		"jp_text": "パッション・バレット＋",
-		"tr_text": ""
+		"tr_text": "Passion Bullet+"
 	},
 	{
 		"assign": "31547",
@@ -2372,12 +2372,12 @@
 	{
 		"assign": "31549",
 		"jp_text": "スウィートトリック",
-		"tr_text": ""
+		"tr_text": "Sweet Trick"
 	},
 	{
 		"assign": "31550",
 		"jp_text": "スウィートトリック＋",
-		"tr_text": ""
+		"tr_text": "Sweet Trick+"
 	},
 	{
 		"assign": "31551",
@@ -2557,12 +2557,12 @@
 	{
 		"assign": "31597",
 		"jp_text": "ソウルウィッシュエナジー",
-		"tr_text": ""
+		"tr_text": "Soul Wish Energy"
 	},
 	{
 		"assign": "31598",
 		"jp_text": "ソウルウィッシュエナジー＋",
-		"tr_text": ""
+		"tr_text": "Soul Wish Energy+"
 	},
 	{
 		"assign": "31601",
@@ -2637,27 +2637,27 @@
 	{
 		"assign": "31619",
 		"jp_text": "アーレス・バーニングホーン",
-		"tr_text": ""
+		"tr_text": "Ares Burning Horn"
 	},
 	{
 		"assign": "31620",
 		"jp_text": "アーレス・バーニングホーン＋",
-		"tr_text": ""
+		"tr_text": "Ares Burning Horn+"
 	},
 	{
 		"assign": "31621",
 		"jp_text": "ライトニング・ブリーチ",
-		"tr_text": ""
+		"tr_text": "Lightning Breach"
 	},
 	{
 		"assign": "31622",
 		"jp_text": "ライトニング・ブリーチ＋",
-		"tr_text": ""
+		"tr_text": "Lightning Breach+"
 	},
 	{
 		"assign": "31623",
 		"jp_text": "ライトニング・ブリーチ＋＋",
-		"tr_text": ""
+		"tr_text": "Lightning Breach++"
 	},
 	{
 		"assign": "31626",
@@ -2672,12 +2672,12 @@
 	{
 		"assign": "31628",
 		"jp_text": "ライトニングパニッシュ",
-		"tr_text": ""
+		"tr_text": "Lightning Punish"
 	},
 	{
 		"assign": "31629",
 		"jp_text": "ライトニングパニッシュ＋",
-		"tr_text": ""
+		"tr_text": "Lightning Punish+"
 	},
 	{
 		"assign": "31630",
@@ -2707,12 +2707,12 @@
 	{
 		"assign": "31638",
 		"jp_text": "バーニングハートスナイパー",
-		"tr_text": ""
+		"tr_text": "Burning Heart Sniper"
 	},
 	{
 		"assign": "31639",
 		"jp_text": "バーニングハートスナイパー＋",
-		"tr_text": ""
+		"tr_text": "Burning Heart Sniper+"
 	},
 	{
 		"assign": "31640",
@@ -2727,12 +2727,12 @@
 	{
 		"assign": "31642",
 		"jp_text": "ダンシングバレット",
-		"tr_text": ""
+		"tr_text": "Dancing Bullet"
 	},
 	{
 		"assign": "31643",
 		"jp_text": "ダンシングバレット＋",
-		"tr_text": ""
+		"tr_text": "Dancing Bullet+"
 	},
 	{
 		"assign": "31648",
@@ -2747,12 +2747,12 @@
 	{
 		"assign": "31650",
 		"jp_text": "アーレス・タイフーンスティング",
-		"tr_text": ""
+		"tr_text": "Ares Typhoon Sting"
 	},
 	{
 		"assign": "31651",
 		"jp_text": "アーレス・タイフーンスティング＋",
-		"tr_text": ""
+		"tr_text": "Ares Typhoon Sting+"
 	},
 	{
 		"assign": "31654",
@@ -2797,22 +2797,22 @@
 	{
 		"assign": "31669",
 		"jp_text": "ホーリーブレッシング",
-		"tr_text": ""
+		"tr_text": "Holy Blessing"
 	},
 	{
 		"assign": "31670",
 		"jp_text": "ホーリーブレッシング＋",
-		"tr_text": ""
+		"tr_text": "Holy Blessing+"
 	},
 	{
 		"assign": "31671",
 		"jp_text": "ベルセルクウイング",
-		"tr_text": ""
+		"tr_text": "Berserk Wing"
 	},
 	{
 		"assign": "31672",
 		"jp_text": "ベルセルクウイング＋",
-		"tr_text": ""
+		"tr_text": "Berserk Wing+"
 	},
 	{
 		"assign": "31675",
@@ -2827,52 +2827,52 @@
 	{
 		"assign": "31679",
 		"jp_text": "バトルスピリット",
-		"tr_text": ""
+		"tr_text": "Battle Spirit"
 	},
 	{
 		"assign": "31680",
 		"jp_text": "バトルスピリット＋",
-		"tr_text": ""
+		"tr_text": "Battle Spirit+"
 	},
 	{
 		"assign": "31681",
 		"jp_text": "アーレス・トルネイドスラッシュ",
-		"tr_text": ""
+		"tr_text": "Ares Tornado Slash"
 	},
 	{
 		"assign": "31682",
 		"jp_text": "アーレス・トルネイドスラッシュ＋",
-		"tr_text": ""
+		"tr_text": "Ares Tornado Slash+"
 	},
 	{
 		"assign": "11030",
 		"jp_text": "エナジーチューニング",
-		"tr_text": ""
+		"tr_text": "Energy Tuning"
 	},
 	{
 		"assign": "11040",
 		"jp_text": "エナジーチューニング＋",
-		"tr_text": ""
+		"tr_text": "Energy Tuning+"
 	},
 	{
 		"assign": "2210",
 		"jp_text": "スタイリッシュカウンター",
-		"tr_text": ""
+		"tr_text": "Stylish Counter"
 	},
 	{
 		"assign": "2220",
 		"jp_text": "スタイリッシュカウンター＋",
-		"tr_text": ""
+		"tr_text": "Stylish Counter+"
 	},
 	{
 		"assign": "2310",
 		"jp_text": "スイートキュア",
-		"tr_text": "Suite Cure"
+		"tr_text": "Sweet Cure"
 	},
 	{
 		"assign": "2320",
 		"jp_text": "スイートヒール",
-		"tr_text": "Suite Heal"
+		"tr_text": "Sweet Heal"
 	},
 	{
 		"assign": "80110",

--- a/json/Name_Quest_PlaceName.txt
+++ b/json/Name_Quest_PlaceName.txt
@@ -47,12 +47,12 @@
 	{
 		"assign": "Dimension",
 		"jp_text": "？",
-		"tr_text": ""
+		"tr_text": "?"
 	},
 	{
 		"assign": "PlayGround",
 		"jp_text": "？",
-		"tr_text": ""
+		"tr_text": "?"
 	},
 	{
 		"assign": "Stadium",

--- a/json/Name_UICharMake_BodyPartsName.txt
+++ b/json/Name_UICharMake_BodyPartsName.txt
@@ -617,7 +617,7 @@
 	{
 		"assign": "No40511",
 		"jp_text": "ヴォーダム・ボディＣＶ",
-		"tr_text": ""
+		"tr_text": "Vodham Body CV"
 	},
 	{
 		"assign": "No40293",
@@ -677,12 +677,12 @@
 	{
 		"assign": "No40403",
 		"jp_text": "ラシオス・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Lacios Body GV"
 	},
 	{
 		"assign": "No40540",
 		"jp_text": "シュバル・ボディ",
-		"tr_text": ""
+		"tr_text": "Cheval Body"
 	},
 	{
 		"assign": "No40541",
@@ -697,22 +697,22 @@
 	{
 		"assign": "No40393",
 		"jp_text": "センガミ・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Sengami Body GV"
 	},
 	{
 		"assign": "No40173",
 		"jp_text": "ヒュリオン・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Hurion Body"
 	},
 	{
 		"assign": "No40413",
 		"jp_text": "アコーディ・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Accordi Body GV"
 	},
 	{
 		"assign": "No40630",
 		"jp_text": "クリスト・ボディ",
-		"tr_text": ""
+		"tr_text": "Crysto Body"
 	},
 	{
 		"assign": "No40631",
@@ -1472,7 +1472,7 @@
 	{
 		"assign": "No50571",
 		"jp_text": "クロワール・ボディＣＶ",
-		"tr_text": ""
+		"tr_text": "Croire Body CV"
 	},
 	{
 		"assign": "No50313",
@@ -1532,12 +1532,12 @@
 	{
 		"assign": "No50453",
 		"jp_text": "ルセリア・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Luceria Body GV"
 	},
 	{
 		"assign": "No50610",
 		"jp_text": "シュバリア・ボディ",
-		"tr_text": ""
+		"tr_text": "Chevalier Body"
 	},
 	{
 		"assign": "No50611",
@@ -1552,22 +1552,22 @@
 	{
 		"assign": "No50443",
 		"jp_text": "シャンフー・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Xianghu Body GV"
 	},
 	{
 		"assign": "No50193",
 		"jp_text": "ケルビナ・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Cherubina Body GV"
 	},
 	{
 		"assign": "No50463",
 		"jp_text": "デルマーチ・ボディＧＶ",
-		"tr_text": ""
+		"tr_text": "Delmarch Body GV"
 	},
 	{
 		"assign": "No50660",
 		"jp_text": "マーヴ・ボディ",
-		"tr_text": ""
+		"tr_text": "Marv Body"
 	},
 	{
 		"assign": "No50661",
@@ -7147,7 +7147,7 @@
 	{
 		"assign": "No01822",
 		"jp_text": "ソルプロテクトル夜",
-		"tr_text": ""
+		"tr_text": "Sol Protector Night"
 	},
 	{
 		"assign": "No01823",

--- a/json/Season2_Text.txt
+++ b/json/Season2_Text.txt
@@ -92,7 +92,7 @@
 		"jp_name": "",
 		"tr_name": "",
 		"jp_text": "誰かが思いついたことは<%br>すでにどこかで<%br>それは実現している。",
-		"tr_text": "By the time anyone realised.<%br>it was too late.<%br>It was already taking shape.",
+		"tr_text": "By the time anyone realised,<%br>it was too late.<%br>It was already taking shape.",
 		"fileID": 1
 	},
 	{
@@ -108,7 +108,7 @@
 		"jp_name": "アナティス",
 		"tr_name": "Anatis",
 		"jp_text": "『その……小さな手と<%br>　その　小さな瞳で』",
-		"tr_text": "\"With eyes so tiny,<%br>  and hands so tiny...\"",
+		"tr_text": "\"With eyes so tiny,<%br> and hands so tiny...\"",
 		"fileID": 1
 	},
 	{
@@ -132,7 +132,7 @@
 		"jp_name": "ヘイド",
 		"tr_name": "Hade",
 		"jp_text": "そうだな。食事の準備をしてこよう……",
-		"tr_text": "That's right. Let us get ready to eat...",
+		"tr_text": "That's right. Let us get ready to feed...",
 		"fileID": 1
 	},
 	{
@@ -308,7 +308,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ようやく、ダンテたちの尻尾が掴めた<%br>ってことで、アンタに協力して欲しいんだ。",
-		"tr_text": "And now I finally think I have a lead on<%br>Dante, so I want your help to catch him.",
+		"tr_text": "And now I think I finally have a lead on<%br>Dante, so I want your help to catch him.",
 		"fileID": 1
 	},
 	{

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -7,7 +7,7 @@
 	{
 		"text_id": 1001000,
 		"jp_text": "どのような効果なのでしょう……？\n<%CHARANAME>さんの\n入手情報、お待ちしております！",
-		"tr_text": "What kind of effect is it...?\n<%CHARANAME>,\nwe need you to get your hands\non one so that we can find out!"
+		"tr_text": "What kind of effect is it...?\n<%CHARANAME>, we need you\nto get your hands\non one so that we can find out!"
 	},
 	{
 		"text_id": 1001200,
@@ -17,7 +17,7 @@
 	{
 		"text_id": 1001200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、炎属性値を\n強化してくれます！",
-		"tr_text": "His ability is called\n\"<%abi>\".\nIt boosts your ATK and your Fire Element!"
+		"tr_text": "His ability is called \"<%abi>\".\nIt boosts your ATK\nand your Fire Element!"
 	},
 	{
 		"text_id": 1001200,
@@ -47,7 +47,7 @@
 	{
 		"text_id": 1002200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1002200,
@@ -82,12 +82,14 @@
 	{
 		"text_id": 1003200,
 		"jp_text": "先輩アークス\nエコーさんのチップです。\nいつも後輩のみなさんを\n優しく見守ってくれている\nとっても素敵な方なんですよ！",
-		"tr_text": "This is a chip of your senior in ARKS, Echo.\nShe's a lovely person who always\nlooks after her juniors!"
+		"tr_text": "
+        This is a chip of Echo, your\n
+        senior in ARKS.\nShe's a lovely person who always\nlooks after her juniors!"
 	},
 	{
 		"text_id": 1003200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、氷属性値を\n強化してくれます！",
-		"tr_text": "Her ability is called\n\"<%abi>\".\nIt boosts your ATK and your Ice Element!"
+		"tr_text": "Her ability is called \"<%abi>\".\nIt boosts your ATK\nand your Ice Element!"
 	},
 	{
 		"text_id": 1003200,
@@ -117,7 +119,7 @@
 	{
 		"text_id": 1004200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1004200,
@@ -182,7 +184,7 @@
 	{
 		"text_id": 1006200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1006200,
@@ -252,7 +254,7 @@
 	{
 		"text_id": 1008200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1008200,
@@ -322,7 +324,7 @@
 	{
 		"text_id": 1010200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1010200,
@@ -387,7 +389,7 @@
 	{
 		"text_id": 1012200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1012200,
@@ -452,7 +454,7 @@
 	{
 		"text_id": 1014200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1014200,
@@ -517,7 +519,7 @@
 	{
 		"text_id": 1016200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1016200,
@@ -582,7 +584,7 @@
 	{
 		"text_id": 1018200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1018200,
@@ -647,7 +649,7 @@
 	{
 		"text_id": 1020200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1020200,
@@ -717,7 +719,7 @@
 	{
 		"text_id": 1022200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1022200,
@@ -782,7 +784,7 @@
 	{
 		"text_id": 1024200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1024200,
@@ -842,7 +844,7 @@
 	{
 		"text_id": 1026200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1026200,
@@ -912,7 +914,7 @@
 	{
 		"text_id": 1028200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1028200,
@@ -977,7 +979,7 @@
 	{
 		"text_id": 1030200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1030200,
@@ -1027,7 +1029,7 @@
 	{
 		"text_id": 1032200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1032200,
@@ -1077,7 +1079,7 @@
 	{
 		"text_id": 1034200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1034200,
@@ -1132,7 +1134,7 @@
 	{
 		"text_id": 1036200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1036200,
@@ -1187,7 +1189,7 @@
 	{
 		"text_id": 1038200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1038200,
@@ -1242,7 +1244,7 @@
 	{
 		"text_id": 1040200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1040200,
@@ -1307,7 +1309,7 @@
 	{
 		"text_id": 1042200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1042200,
@@ -1372,7 +1374,7 @@
 	{
 		"text_id": 1044200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1044200,
@@ -1432,7 +1434,7 @@
 	{
 		"text_id": 1050200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1050200,
@@ -1497,7 +1499,7 @@
 	{
 		"text_id": 1054200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1054200,
@@ -1557,7 +1559,7 @@
 	{
 		"text_id": 1056200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1056200,
@@ -1617,7 +1619,7 @@
 	{
 		"text_id": 1080200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1080200,
@@ -1677,7 +1679,7 @@
 	{
 		"text_id": 1082200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1082200,
@@ -1737,7 +1739,7 @@
 	{
 		"text_id": 1084200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1084200,
@@ -1817,7 +1819,7 @@
 	{
 		"text_id": 1086200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1086200,
@@ -1957,7 +1959,7 @@
 	{
 		"text_id": 1108200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1108200,
@@ -2002,7 +2004,7 @@
 	{
 		"text_id": 1110200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1110200,
@@ -2047,7 +2049,7 @@
 	{
 		"text_id": 1112200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1112200,
@@ -2112,7 +2114,7 @@
 	{
 		"text_id": 1116200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1116200,
@@ -2157,7 +2159,7 @@
 	{
 		"text_id": 1118200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1118200,
@@ -2207,7 +2209,7 @@
 	{
 		"text_id": 1120200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1120200,
@@ -2257,7 +2259,7 @@
 	{
 		"text_id": 1122200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1122200,
@@ -2302,7 +2304,7 @@
 	{
 		"text_id": 1124200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1124200,
@@ -2347,7 +2349,7 @@
 	{
 		"text_id": 1126200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1126200,
@@ -2397,7 +2399,7 @@
 	{
 		"text_id": 1128200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1128200,
@@ -2447,7 +2449,7 @@
 	{
 		"text_id": 1130200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1130200,
@@ -2492,7 +2494,7 @@
 	{
 		"text_id": 1132200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1132200,
@@ -2537,7 +2539,7 @@
 	{
 		"text_id": 1134200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1134200,
@@ -2582,7 +2584,7 @@
 	{
 		"text_id": 1136200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1136200,
@@ -9367,7 +9369,7 @@
 	{
 		"text_id": 7002200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7002200,
@@ -9412,7 +9414,7 @@
 	{
 		"text_id": 7004200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7004200,
@@ -9457,7 +9459,7 @@
 	{
 		"text_id": 7006200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7006200,
@@ -9527,7 +9529,7 @@
 	{
 		"text_id": 7010200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7010200,
@@ -9572,7 +9574,7 @@
 	{
 		"text_id": 7012200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7012200,
@@ -9617,7 +9619,7 @@
 	{
 		"text_id": 7014200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7014200,
@@ -9662,7 +9664,7 @@
 	{
 		"text_id": 7016200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7016200,
@@ -9712,7 +9714,7 @@
 	{
 		"text_id": 7018200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7018200,
@@ -9757,7 +9759,7 @@
 	{
 		"text_id": 7020200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7020200,
@@ -9822,7 +9824,7 @@
 	{
 		"text_id": 7024200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7024200,
@@ -9887,7 +9889,7 @@
 	{
 		"text_id": 7028200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7028200,
@@ -9932,7 +9934,7 @@
 	{
 		"text_id": 7030200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7030200,
@@ -9977,7 +9979,7 @@
 	{
 		"text_id": 7032200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7032200,
@@ -10022,7 +10024,7 @@
 	{
 		"text_id": 7034200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7034200,
@@ -10107,7 +10109,7 @@
 	{
 		"text_id": 7040200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7040200,
@@ -10157,7 +10159,7 @@
 	{
 		"text_id": 7042200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7042200,
@@ -10202,7 +10204,7 @@
 	{
 		"text_id": 7044200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7044200,
@@ -10267,7 +10269,7 @@
 	{
 		"text_id": 7048200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7048200,
@@ -10322,7 +10324,7 @@
 	{
 		"text_id": 7050200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7050200,
@@ -10467,7 +10469,7 @@
 	{
 		"text_id": 7102200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7102200,
@@ -10517,7 +10519,7 @@
 	{
 		"text_id": 7104200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7104200,
@@ -10562,7 +10564,7 @@
 	{
 		"text_id": 7106200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7106200,
@@ -10607,7 +10609,7 @@
 	{
 		"text_id": 7108200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7108200,
@@ -10652,7 +10654,7 @@
 	{
 		"text_id": 7110200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7110200,
@@ -10717,7 +10719,7 @@
 	{
 		"text_id": 7114200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7114200,
@@ -10762,7 +10764,7 @@
 	{
 		"text_id": 7116200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7116200,
@@ -10807,7 +10809,7 @@
 	{
 		"text_id": 7118200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7118200,
@@ -10852,7 +10854,7 @@
 	{
 		"text_id": 7120200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7120200,
@@ -10897,7 +10899,7 @@
 	{
 		"text_id": 7122200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7122200,
@@ -10942,7 +10944,7 @@
 	{
 		"text_id": 7124200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7124200,
@@ -10987,7 +10989,7 @@
 	{
 		"text_id": 7126200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7126200,
@@ -11052,7 +11054,7 @@
 	{
 		"text_id": 7130200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7130200,
@@ -11117,7 +11119,7 @@
 	{
 		"text_id": 7134200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7134200,
@@ -11167,7 +11169,7 @@
 	{
 		"text_id": 7138200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7138200,
@@ -11212,7 +11214,7 @@
 	{
 		"text_id": 7142200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7142200,
@@ -11282,7 +11284,7 @@
 	{
 		"text_id": 7146200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7146200,
@@ -11387,7 +11389,7 @@
 	{
 		"text_id": 7206200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7206200,
@@ -11432,7 +11434,7 @@
 	{
 		"text_id": 7208200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7208200,
@@ -11477,7 +11479,7 @@
 	{
 		"text_id": 7210200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7210200,
@@ -11522,7 +11524,7 @@
 	{
 		"text_id": 7212200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7212200,
@@ -11567,7 +11569,7 @@
 	{
 		"text_id": 7214200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7214200,
@@ -11612,7 +11614,7 @@
 	{
 		"text_id": 7216200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7216200,
@@ -11657,7 +11659,7 @@
 	{
 		"text_id": 7218200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7218200,
@@ -11702,7 +11704,7 @@
 	{
 		"text_id": 7220200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7220200,
@@ -11767,7 +11769,7 @@
 	{
 		"text_id": 7224200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7224200,
@@ -11812,7 +11814,7 @@
 	{
 		"text_id": 7226200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7226200,
@@ -11857,7 +11859,7 @@
 	{
 		"text_id": 7228200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7228200,
@@ -11922,7 +11924,7 @@
 	{
 		"text_id": 7232200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7232200,
@@ -11967,7 +11969,7 @@
 	{
 		"text_id": 7234200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7234200,
@@ -12032,7 +12034,7 @@
 	{
 		"text_id": 7238200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7238200,
@@ -12082,7 +12084,7 @@
 	{
 		"text_id": 7240200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7240200,
@@ -12127,7 +12129,7 @@
 	{
 		"text_id": 7242200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7242200,
@@ -12177,7 +12179,7 @@
 	{
 		"text_id": 7244200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7244200,
@@ -12262,7 +12264,7 @@
 	{
 		"text_id": 7306200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7306200,
@@ -12307,7 +12309,7 @@
 	{
 		"text_id": 7308200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7308200,
@@ -12372,7 +12374,7 @@
 	{
 		"text_id": 7312200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7312200,
@@ -12457,7 +12459,7 @@
 	{
 		"text_id": 7318200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7318200,
@@ -12522,7 +12524,7 @@
 	{
 		"text_id": 7322200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7322200,
@@ -12572,7 +12574,7 @@
 	{
 		"text_id": 7324200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7324200,
@@ -13062,7 +13064,7 @@
 	{
 		"text_id": 1088200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1088200,
@@ -13117,7 +13119,7 @@
 	{
 		"text_id": 1090200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1090200,
@@ -13172,7 +13174,7 @@
 	{
 		"text_id": 1092200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1092200,
@@ -13222,7 +13224,7 @@
 	{
 		"text_id": 1142200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1142200,
@@ -13552,7 +13554,7 @@
 	{
 		"text_id": 1064200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1064200,
@@ -13607,7 +13609,7 @@
 	{
 		"text_id": 1094200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1094200,
@@ -13657,7 +13659,7 @@
 	{
 		"text_id": 1138200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1138200,
@@ -13712,7 +13714,7 @@
 	{
 		"text_id": 1140200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1140200,
@@ -14312,7 +14314,7 @@
 	{
 		"text_id": 1144200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1144200,
@@ -14392,7 +14394,7 @@
 	{
 		"text_id": 1146200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1146200,
@@ -14452,7 +14454,7 @@
 	{
 		"text_id": 1148200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1148200,
@@ -15402,7 +15404,7 @@
 	{
 		"text_id": 7423200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7423200,
@@ -15462,7 +15464,7 @@
 	{
 		"text_id": 1096200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1096200,
@@ -15527,7 +15529,7 @@
 	{
 		"text_id": 1098200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1098200,
@@ -15592,7 +15594,7 @@
 	{
 		"text_id": 1100200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1100200,
@@ -15657,7 +15659,7 @@
 	{
 		"text_id": 1152200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1152200,
@@ -15712,7 +15714,7 @@
 	{
 		"text_id": 1154200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1154200,
@@ -15772,7 +15774,7 @@
 	{
 		"text_id": 1156200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1156200,
@@ -15842,7 +15844,7 @@
 	{
 		"text_id": 1158200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1158200,
@@ -15907,7 +15909,7 @@
 	{
 		"text_id": 1160200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1160200,
@@ -15972,7 +15974,7 @@
 	{
 		"text_id": 1162200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1162200,
@@ -16032,7 +16034,7 @@
 	{
 		"text_id": 1164200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1164200,
@@ -16087,7 +16089,7 @@
 	{
 		"text_id": 1166200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1166200,
@@ -16692,7 +16694,7 @@
 	{
 		"text_id": 1046200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1046200,
@@ -16752,7 +16754,7 @@
 	{
 		"text_id": 1048200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1048200,
@@ -18132,7 +18134,7 @@
 	{
 		"text_id": 1068200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1068200,
@@ -18187,7 +18189,7 @@
 	{
 		"text_id": 1070200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1070200,
@@ -18237,7 +18239,7 @@
 	{
 		"text_id": 1168200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1168200,
@@ -18287,7 +18289,7 @@
 	{
 		"text_id": 1170200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1170200,
@@ -18352,7 +18354,7 @@
 	{
 		"text_id": 1172200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1172200,
@@ -18427,7 +18429,7 @@
 	{
 		"text_id": 1174200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1174200,
@@ -18482,7 +18484,7 @@
 	{
 		"text_id": 1176200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1176200,
@@ -20797,7 +20799,7 @@
 	{
 		"text_id": 7064200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7064200,
@@ -20857,7 +20859,7 @@
 	{
 		"text_id": 7066200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7066200,
@@ -21057,7 +21059,7 @@
 	{
 		"text_id": 1308200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1308200,
@@ -21132,7 +21134,7 @@
 	{
 		"text_id": 1310200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1310200,
@@ -21202,7 +21204,7 @@
 	{
 		"text_id": 1312200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1312200,
@@ -21267,7 +21269,7 @@
 	{
 		"text_id": 1314200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1314200,
@@ -21332,7 +21334,7 @@
 	{
 		"text_id": 1102200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1102200,
@@ -21387,7 +21389,7 @@
 	{
 		"text_id": 1178200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1178200,
@@ -21442,7 +21444,7 @@
 	{
 		"text_id": 1180200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1180200,
@@ -21502,7 +21504,7 @@
 	{
 		"text_id": 1182200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1182200,
@@ -21557,7 +21559,7 @@
 	{
 		"text_id": 1184200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1184200,
@@ -21607,7 +21609,7 @@
 	{
 		"text_id": 1186200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1186200,
@@ -21657,7 +21659,7 @@
 	{
 		"text_id": 1188200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1188200,
@@ -21717,7 +21719,7 @@
 	{
 		"text_id": 1190200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1190200,
@@ -21772,7 +21774,7 @@
 	{
 		"text_id": 1192200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1192200,
@@ -21827,7 +21829,7 @@
 	{
 		"text_id": 1194200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1194200,
@@ -21882,7 +21884,7 @@
 	{
 		"text_id": 1196200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1196200,
@@ -21942,7 +21944,7 @@
 	{
 		"text_id": 1197003,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197003,
@@ -21992,7 +21994,7 @@
 	{
 		"text_id": 1197007,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197007,
@@ -22047,7 +22049,7 @@
 	{
 		"text_id": 1197011,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197011,
@@ -22102,7 +22104,7 @@
 	{
 		"text_id": 1197015,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197015,
@@ -22157,7 +22159,7 @@
 	{
 		"text_id": 1197019,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197019,
@@ -22212,7 +22214,7 @@
 	{
 		"text_id": 1197023,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197023,
@@ -22262,7 +22264,7 @@
 	{
 		"text_id": 1197027,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197027,
@@ -23477,7 +23479,7 @@
 	{
 		"text_id": 1197131,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197131,
@@ -23532,7 +23534,7 @@
 	{
 		"text_id": 1197135,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197135,
@@ -23587,7 +23589,7 @@
 	{
 		"text_id": 1197139,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197139,
@@ -23647,7 +23649,7 @@
 	{
 		"text_id": 1197143,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197143,
@@ -23712,7 +23714,7 @@
 	{
 		"text_id": 1197147,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197147,
@@ -23782,7 +23784,7 @@
 	{
 		"text_id": 1197151,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197151,
@@ -23847,7 +23849,7 @@
 	{
 		"text_id": 1197155,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197155,
@@ -23902,7 +23904,7 @@
 	{
 		"text_id": 1197159,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197159,
@@ -23957,7 +23959,7 @@
 	{
 		"text_id": 1197163,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197163,
@@ -24557,7 +24559,7 @@
 	{
 		"text_id": 1197211,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197211,
@@ -24602,7 +24604,7 @@
 	{
 		"text_id": 1197215,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1197215,
@@ -25112,7 +25114,7 @@
 	{
 		"text_id": 1516200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1516200,
@@ -25192,7 +25194,7 @@
 	{
 		"text_id": 1518200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1518200,
@@ -25232,12 +25234,12 @@
 	{
 		"text_id": 1519200,
 		"jp_text": "このチップは、大剣の\n「クレイモア」が元になっています。\nとっても元気な男の子で\n私は「モア」くんと呼んでいますよ！",
-		"tr_text": "This chip is based on the\nsword \"Claymore\".\nIt takes the form of an energetic little\nboy, who I've nicknamed \"More\"!."
+		"tr_text": "This chip is based on the sword\n\"Claymore\".\nIt takes the form of an energetic little\nboy, who I've nicknamed \"More\"!"
 	},
 	{
 		"text_id": 1519200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃がヒットした時\nHPが定期的に回復し、加えて\n攻撃力を強化する効果があります！",
-		"tr_text": "His ability is called\n\"<%abi>\".\nWhen you land a hit on an enemy, he\nstarts periodically recovering your HP,\nand even boosts your attack power too!"
+		"tr_text": "His ability is called \"<%abi>\".\nWhen you land a hit on an enemy, he\nstarts periodically recovering your HP,\nand even boosts your attack power too!"
 	},
 	{
 		"text_id": 1519200,
@@ -25252,7 +25254,7 @@
 	{
 		"text_id": 1519200,
 		"jp_text": "モアくんが社交性に\n富んでいるのには\n前世代にクレイモアの愛用者が\n多かったからなのでは……と\n私は色々と想像しちゃっています！",
-		"tr_text": "For instance, Claymore used to have a\nlot of fans, and that could explain why\nMore is so sociable... I could think of all\nsorts of things!"
+		"tr_text": "For instance, Claymore used to have a\nlot of fans, and that could explain why\nMore is so sociable...\nI could think of all sorts of things!"
 	},
 	{
 		"text_id": 1519200,
@@ -25272,7 +25274,7 @@
 	{
 		"text_id": 1520200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1520200,
@@ -25342,7 +25344,7 @@
 	{
 		"text_id": 1522200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1522200,
@@ -25412,7 +25414,7 @@
 	{
 		"text_id": 1524200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1524200,
@@ -25487,7 +25489,7 @@
 	{
 		"text_id": 1526200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1526200,
@@ -25557,7 +25559,7 @@
 	{
 		"text_id": 1528200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1528200,
@@ -25627,7 +25629,7 @@
 	{
 		"text_id": 1530200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1530200,
@@ -25702,7 +25704,7 @@
 	{
 		"text_id": 1532200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1532200,
@@ -25777,7 +25779,7 @@
 	{
 		"text_id": 1534200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1534200,
@@ -25847,7 +25849,7 @@
 	{
 		"text_id": 1536200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1536200,
@@ -25927,7 +25929,7 @@
 	{
 		"text_id": 1538200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1538200,
@@ -26007,7 +26009,7 @@
 	{
 		"text_id": 1540200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1540200,
@@ -26087,7 +26089,7 @@
 	{
 		"text_id": 1542200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1542200,
@@ -26147,7 +26149,7 @@
 	{
 		"text_id": 1544200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1544200,
@@ -26222,7 +26224,7 @@
 	{
 		"text_id": 1546200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1546200,
@@ -27222,7 +27224,7 @@
 	{
 		"text_id": 1512200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1512200,
@@ -27277,7 +27279,7 @@
 	{
 		"text_id": 1554200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1554200,
@@ -27332,7 +27334,7 @@
 	{
 		"text_id": 1556200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1556200,
@@ -27387,7 +27389,7 @@
 	{
 		"text_id": 1558200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1558200,
@@ -27442,7 +27444,7 @@
 	{
 		"text_id": 1560200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1560200,
@@ -27497,7 +27499,7 @@
 	{
 		"text_id": 1562200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1562200,
@@ -27552,7 +27554,7 @@
 	{
 		"text_id": 1564200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1564200,
@@ -28792,7 +28794,7 @@
 	{
 		"text_id": 1566000,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1566000,
@@ -28857,7 +28859,7 @@
 	{
 		"text_id": 1568200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1568200,
@@ -28917,7 +28919,7 @@
 	{
 		"text_id": 1572200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1572200,
@@ -28977,7 +28979,7 @@
 	{
 		"text_id": 1574200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1574200,
@@ -29047,7 +29049,7 @@
 	{
 		"text_id": 1576200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1576200,
@@ -29102,7 +29104,7 @@
 	{
 		"text_id": 1578200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1578200,
@@ -29162,7 +29164,7 @@
 	{
 		"text_id": 1580200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1580200,
@@ -29222,7 +29224,7 @@
 	{
 		"text_id": 1582200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1582200,
@@ -29277,7 +29279,7 @@
 	{
 		"text_id": 1584200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1584200,
@@ -29332,7 +29334,7 @@
 	{
 		"text_id": 1586200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1586200,
@@ -29387,7 +29389,7 @@
 	{
 		"text_id": 1588200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1588200,
@@ -29452,7 +29454,7 @@
 	{
 		"text_id": 1590200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1590200,
@@ -29517,7 +29519,7 @@
 	{
 		"text_id": 1592200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1592200,
@@ -29587,7 +29589,7 @@
 	{
 		"text_id": 7054200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7054200,
@@ -29632,7 +29634,7 @@
 	{
 		"text_id": 7068200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7068200,
@@ -29677,7 +29679,7 @@
 	{
 		"text_id": 7070200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7070200,
@@ -29722,7 +29724,7 @@
 	{
 		"text_id": 7606200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7606200,
@@ -29767,7 +29769,7 @@
 	{
 		"text_id": 7608200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7608200,
@@ -30227,7 +30229,7 @@
 	{
 		"text_id": 1594200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1594200,
@@ -30292,7 +30294,7 @@
 	{
 		"text_id": 1596200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1596200,
@@ -30352,7 +30354,7 @@
 	{
 		"text_id": 1598200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1598200,
@@ -30407,7 +30409,7 @@
 	{
 		"text_id": 1600200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1600200,
@@ -30462,7 +30464,7 @@
 	{
 		"text_id": 1602200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1602200,
@@ -30522,7 +30524,7 @@
 	{
 		"text_id": 1604200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1604200,
@@ -30577,7 +30579,7 @@
 	{
 		"text_id": 1606200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1606200,
@@ -30632,7 +30634,7 @@
 	{
 		"text_id": 1608200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1608200,
@@ -30687,7 +30689,7 @@
 	{
 		"text_id": 1610200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1610200,
@@ -30742,7 +30744,7 @@
 	{
 		"text_id": 1612200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1612200,
@@ -30797,7 +30799,7 @@
 	{
 		"text_id": 1614200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1614200,
@@ -30852,7 +30854,7 @@
 	{
 		"text_id": 1616200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1616200,
@@ -31637,7 +31639,7 @@
 	{
 		"text_id": 7140200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7140200,
@@ -31682,7 +31684,7 @@
 	{
 		"text_id": 7602200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7602200,
@@ -31732,7 +31734,7 @@
 	{
 		"text_id": 1618200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1618200,
@@ -31792,7 +31794,7 @@
 	{
 		"text_id": 1620200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1620200,
@@ -31847,7 +31849,7 @@
 	{
 		"text_id": 1622200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1622200,
@@ -31902,7 +31904,7 @@
 	{
 		"text_id": 1624200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1624200,
@@ -31957,7 +31959,7 @@
 	{
 		"text_id": 1626200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1626200,
@@ -32012,7 +32014,7 @@
 	{
 		"text_id": 1628200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1628200,
@@ -32352,7 +32354,7 @@
 	{
 		"text_id": 1630200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1630200,
@@ -32407,7 +32409,7 @@
 	{
 		"text_id": 1632200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1632200,
@@ -32462,7 +32464,7 @@
 	{
 		"text_id": 1634200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1634200,
@@ -32517,7 +32519,7 @@
 	{
 		"text_id": 1636200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1636200,
@@ -32572,7 +32574,7 @@
 	{
 		"text_id": 1638200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1638200,
@@ -32627,7 +32629,7 @@
 	{
 		"text_id": 1640200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1640200,
@@ -32682,7 +32684,7 @@
 	{
 		"text_id": 1642200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1642200,
@@ -32737,7 +32739,7 @@
 	{
 		"text_id": 1644200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1644200,
@@ -33202,7 +33204,7 @@
 	{
 		"text_id": 1646200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1646200,
@@ -33262,7 +33264,7 @@
 	{
 		"text_id": 1648200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1648200,
@@ -33322,7 +33324,7 @@
 	{
 		"text_id": 1650200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1650200,
@@ -33382,7 +33384,7 @@
 	{
 		"text_id": 1654200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1654200,
@@ -33437,7 +33439,7 @@
 	{
 		"text_id": 1656200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1656200,
@@ -33497,7 +33499,7 @@
 	{
 		"text_id": 1658200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1658200,
@@ -33557,7 +33559,7 @@
 	{
 		"text_id": 1660200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1660200,
@@ -33612,7 +33614,7 @@
 	{
 		"text_id": 1662200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1662200,
@@ -33667,7 +33669,7 @@
 	{
 		"text_id": 1664200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1664200,
@@ -33722,7 +33724,7 @@
 	{
 		"text_id": 1668200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1668200,
@@ -33777,7 +33779,7 @@
 	{
 		"text_id": 1678200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1678200,
@@ -34067,7 +34069,7 @@
 	{
 		"text_id": 7250200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7250200,
@@ -34127,7 +34129,7 @@
 	{
 		"text_id": 7252200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7252200,
@@ -34172,7 +34174,7 @@
 	{
 		"text_id": 7254200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7254200,
@@ -34217,7 +34219,7 @@
 	{
 		"text_id": 7256200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7256200,
@@ -34262,7 +34264,7 @@
 	{
 		"text_id": 7258200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7258200,
@@ -34312,7 +34314,7 @@
 	{
 		"text_id": 1672200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1672200,
@@ -34367,7 +34369,7 @@
 	{
 		"text_id": 1674200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1674200,
@@ -34422,7 +34424,7 @@
 	{
 		"text_id": 1676200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1676200,
@@ -34477,7 +34479,7 @@
 	{
 		"text_id": 1680200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1680200,
@@ -34532,7 +34534,7 @@
 	{
 		"text_id": 1682200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1682200,
@@ -35157,7 +35159,7 @@
 	{
 		"text_id": 1684200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1684200,
@@ -35212,7 +35214,7 @@
 	{
 		"text_id": 1688200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1688200,
@@ -35267,7 +35269,7 @@
 	{
 		"text_id": 1690200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1690200,
@@ -35322,7 +35324,7 @@
 	{
 		"text_id": 1692200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1692200,
@@ -35782,7 +35784,7 @@
 	{
 		"text_id": 1694200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1694200,
@@ -35837,7 +35839,7 @@
 	{
 		"text_id": 1698200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1698200,
@@ -35892,7 +35894,7 @@
 	{
 		"text_id": 1700200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1700200,
@@ -35947,7 +35949,7 @@
 	{
 		"text_id": 1702200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1702200,
@@ -36002,7 +36004,7 @@
 	{
 		"text_id": 1704200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1704200,
@@ -36062,7 +36064,7 @@
 	{
 		"text_id": 1708200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1708200,
@@ -36117,7 +36119,7 @@
 	{
 		"text_id": 1710200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1710200,
@@ -36177,7 +36179,7 @@
 	{
 		"text_id": 1712200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1712200,
@@ -36237,7 +36239,7 @@
 	{
 		"text_id": 1714200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1714200,
@@ -36642,7 +36644,7 @@
 	{
 		"text_id": 1716200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1716200,
@@ -36697,7 +36699,7 @@
 	{
 		"text_id": 1718200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1718200,
@@ -36752,7 +36754,7 @@
 	{
 		"text_id": 1720200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1720200,
@@ -36807,7 +36809,7 @@
 	{
 		"text_id": 1722200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1722200,
@@ -36862,7 +36864,7 @@
 	{
 		"text_id": 1724200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1724200,
@@ -36917,7 +36919,7 @@
 	{
 		"text_id": 1726200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1726200,
@@ -36972,7 +36974,7 @@
 	{
 		"text_id": 1728200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1728200,
@@ -37027,7 +37029,7 @@
 	{
 		"text_id": 1730200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1730200,
@@ -37082,7 +37084,7 @@
 	{
 		"text_id": 1732200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1732200,
@@ -37137,7 +37139,7 @@
 	{
 		"text_id": 1734200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1734200,
@@ -37192,7 +37194,7 @@
 	{
 		"text_id": 1736200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1736200,
@@ -37247,7 +37249,7 @@
 	{
 		"text_id": 1738200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1738200,
@@ -37302,7 +37304,7 @@
 	{
 		"text_id": 1740200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1740200,
@@ -37362,7 +37364,7 @@
 	{
 		"text_id": 1742200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1742200,
@@ -37422,7 +37424,7 @@
 	{
 		"text_id": 1744200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1744200,
@@ -37477,7 +37479,7 @@
 	{
 		"text_id": 1746200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1746200,
@@ -37532,7 +37534,7 @@
 	{
 		"text_id": 1748200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1748200,
@@ -37587,7 +37589,7 @@
 	{
 		"text_id": 1750200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1750200,
@@ -37647,7 +37649,7 @@
 	{
 		"text_id": 1752200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1752200,
@@ -37702,7 +37704,7 @@
 	{
 		"text_id": 1754200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1754200,
@@ -37757,7 +37759,7 @@
 	{
 		"text_id": 1756200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1756200,
@@ -37812,7 +37814,7 @@
 	{
 		"text_id": 1758200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1758200,
@@ -37867,7 +37869,7 @@
 	{
 		"text_id": 1760200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1760200,
@@ -37922,7 +37924,7 @@
 	{
 		"text_id": 1762200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1762200,
@@ -37982,7 +37984,7 @@
 	{
 		"text_id": 1764200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1764200,
@@ -38037,7 +38039,7 @@
 	{
 		"text_id": 1766200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1766200,
@@ -38097,7 +38099,7 @@
 	{
 		"text_id": 1768200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1768200,
@@ -38157,7 +38159,7 @@
 	{
 		"text_id": 1770200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1770200,
@@ -38867,7 +38869,7 @@
 	{
 		"text_id": 7330200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7330200,
@@ -38912,7 +38914,7 @@
 	{
 		"text_id": 7332200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7332200,
@@ -38972,7 +38974,7 @@
 	{
 		"text_id": 7334200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7334200,
@@ -39022,7 +39024,7 @@
 	{
 		"text_id": 1772200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1772200,
@@ -39077,7 +39079,7 @@
 	{
 		"text_id": 1774200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1774200,
@@ -39132,7 +39134,7 @@
 	{
 		"text_id": 1776200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1776200,
@@ -39187,7 +39189,7 @@
 	{
 		"text_id": 1778200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1778200,
@@ -39242,7 +39244,7 @@
 	{
 		"text_id": 1780200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1780200,
@@ -39297,7 +39299,7 @@
 	{
 		"text_id": 1782200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1782200,
@@ -39352,7 +39354,7 @@
 	{
 		"text_id": 1784200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1784200,
@@ -39412,7 +39414,7 @@
 	{
 		"text_id": 1786200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1786200,
@@ -39472,7 +39474,7 @@
 	{
 		"text_id": 1788200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1788200,
@@ -39527,7 +39529,7 @@
 	{
 		"text_id": 1790200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1790200,
@@ -40057,7 +40059,7 @@
 	{
 		"text_id": 7336200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7336200,
@@ -40107,7 +40109,7 @@
 	{
 		"text_id": 1792200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1792200,
@@ -40167,7 +40169,7 @@
 	{
 		"text_id": 1794200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1794200,
@@ -40227,7 +40229,7 @@
 	{
 		"text_id": 1796200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1796200,
@@ -40287,7 +40289,7 @@
 	{
 		"text_id": 1798200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1798200,
@@ -40342,7 +40344,7 @@
 	{
 		"text_id": 1800200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1800200,
@@ -40397,7 +40399,7 @@
 	{
 		"text_id": 1052200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1052200,
@@ -40452,7 +40454,7 @@
 	{
 		"text_id": 1058200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1058200,
@@ -40507,7 +40509,7 @@
 	{
 		"text_id": 1060200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1060200,
@@ -40562,7 +40564,7 @@
 	{
 		"text_id": 1062200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1062200,
@@ -40617,7 +40619,7 @@
 	{
 		"text_id": 1066200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1066200,
@@ -40672,7 +40674,7 @@
 	{
 		"text_id": 1072200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1072200,
@@ -40732,7 +40734,7 @@
 	{
 		"text_id": 1074200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1074200,
@@ -41092,7 +41094,7 @@
 	{
 		"text_id": 1076200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1076200,
@@ -41147,7 +41149,7 @@
 	{
 		"text_id": 1078200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1078200,
@@ -41202,7 +41204,7 @@
 	{
 		"text_id": 1300200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1300200,
@@ -41257,7 +41259,7 @@
 	{
 		"text_id": 1302200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1302200,
@@ -41312,7 +41314,7 @@
 	{
 		"text_id": 1304200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1304200,
@@ -41367,7 +41369,7 @@
 	{
 		"text_id": 1306200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1306200,
@@ -41422,7 +41424,7 @@
 	{
 		"text_id": 1548200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1548200,
@@ -41547,7 +41549,7 @@
 	{
 		"text_id": 1550200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1550200,
@@ -41602,7 +41604,7 @@
 	{
 		"text_id": 1552200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1552200,
@@ -41662,7 +41664,7 @@
 	{
 		"text_id": 1652200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1652200,
@@ -41717,7 +41719,7 @@
 	{
 		"text_id": 1666200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1666200,
@@ -41777,7 +41779,7 @@
 	{
 		"text_id": 1670200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1670200,
@@ -42082,7 +42084,7 @@
 	{
 		"text_id": 1570200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1570200,
@@ -42137,7 +42139,7 @@
 	{
 		"text_id": 1686200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1686200,
@@ -42197,7 +42199,7 @@
 	{
 		"text_id": 1696200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1696200,
@@ -42252,7 +42254,7 @@
 	{
 		"text_id": 1706200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1706200,
@@ -42307,7 +42309,7 @@
 	{
 		"text_id": 8002200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8002200,
@@ -42367,7 +42369,7 @@
 	{
 		"text_id": 8004200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8004200,
@@ -42422,7 +42424,7 @@
 	{
 		"text_id": 8006200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8006200,
@@ -42477,7 +42479,7 @@
 	{
 		"text_id": 8008200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8008200,
@@ -42537,7 +42539,7 @@
 	{
 		"text_id": 8010200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8010200,
@@ -42597,7 +42599,7 @@
 	{
 		"text_id": 8012200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8012200,
@@ -42652,7 +42654,7 @@
 	{
 		"text_id": 8014200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8014200,
@@ -42712,7 +42714,7 @@
 	{
 		"text_id": 8016200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8016200,
@@ -42772,7 +42774,7 @@
 	{
 		"text_id": 8018200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8018200,
@@ -42832,7 +42834,7 @@
 	{
 		"text_id": 8020200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8020200,
@@ -42887,7 +42889,7 @@
 	{
 		"text_id": 8022200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8022200,
@@ -43347,7 +43349,7 @@
 	{
 		"text_id": 8026200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8026200,
@@ -43407,7 +43409,7 @@
 	{
 		"text_id": 8028200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8028200,
@@ -43467,7 +43469,7 @@
 	{
 		"text_id": 8030200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8030200,
@@ -43527,7 +43529,7 @@
 	{
 		"text_id": 8032200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8032200,
@@ -43587,7 +43589,7 @@
 	{
 		"text_id": 8034200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8034200,
@@ -43647,7 +43649,7 @@
 	{
 		"text_id": 8036200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8036200,
@@ -43707,7 +43709,7 @@
 	{
 		"text_id": 8038200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8038200,
@@ -43762,7 +43764,7 @@
 	{
 		"text_id": 8040200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8040200,
@@ -43822,7 +43824,7 @@
 	{
 		"text_id": 8042200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8042200,
@@ -43922,7 +43924,7 @@
 	{
 		"text_id": 8024200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8024200,
@@ -43982,7 +43984,7 @@
 	{
 		"text_id": 8044200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8044200,
@@ -44037,7 +44039,7 @@
 	{
 		"text_id": 8046200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8046200,
@@ -44097,7 +44099,7 @@
 	{
 		"text_id": 8048200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8048200,
@@ -44152,7 +44154,7 @@
 	{
 		"text_id": 8050200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8050200,
@@ -44207,7 +44209,7 @@
 	{
 		"text_id": 8052200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8052200,
@@ -44267,7 +44269,7 @@
 	{
 		"text_id": 8054200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8054200,
@@ -44322,7 +44324,7 @@
 	{
 		"text_id": 8056200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8056200,
@@ -44382,7 +44384,7 @@
 	{
 		"text_id": 8058200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8058200,
@@ -44742,7 +44744,7 @@
 	{
 		"text_id": 8060200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8060200,
@@ -44797,7 +44799,7 @@
 	{
 		"text_id": 8080200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8080200,
@@ -44852,7 +44854,7 @@
 	{
 		"text_id": 8064200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8064200,
@@ -44907,7 +44909,7 @@
 	{
 		"text_id": 8068200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8068200,
@@ -45122,7 +45124,7 @@
 	{
 		"text_id": 8066200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8066200,
@@ -45177,7 +45179,7 @@
 	{
 		"text_id": 8070200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8070200,
@@ -45232,7 +45234,7 @@
 	{
 		"text_id": 8072200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8072200,
@@ -45287,7 +45289,7 @@
 	{
 		"text_id": 8074200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8074200,
@@ -45342,7 +45344,7 @@
 	{
 		"text_id": 8076200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8076200,
@@ -45397,7 +45399,7 @@
 	{
 		"text_id": 8078200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8078200,
@@ -45702,7 +45704,7 @@
 	{
 		"text_id": 8062200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8062200,
@@ -45762,7 +45764,7 @@
 	{
 		"text_id": 8082200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8082200,
@@ -45822,7 +45824,7 @@
 	{
 		"text_id": 8084200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8084200,
@@ -45877,7 +45879,7 @@
 	{
 		"text_id": 8086200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8086200,
@@ -45937,7 +45939,7 @@
 	{
 		"text_id": 8088200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8088200,
@@ -45992,7 +45994,7 @@
 	{
 		"text_id": 8090200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8090200,
@@ -46047,7 +46049,7 @@
 	{
 		"text_id": 8092200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8092200,
@@ -46107,7 +46109,7 @@
 	{
 		"text_id": 8094200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8094200,
@@ -46167,7 +46169,7 @@
 	{
 		"text_id": 8096200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8096200,
@@ -46227,7 +46229,7 @@
 	{
 		"text_id": 8104200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8104200,
@@ -46282,7 +46284,7 @@
 	{
 		"text_id": 8098200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8098200,
@@ -46387,7 +46389,7 @@
 	{
 		"text_id": 8100200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8100200,
@@ -46442,7 +46444,7 @@
 	{
 		"text_id": 8102200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8102200,
@@ -46672,7 +46674,7 @@
 	{
 		"text_id": 8106200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8106200,
@@ -46727,7 +46729,7 @@
 	{
 		"text_id": 8108200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8108200,
@@ -46782,7 +46784,7 @@
 	{
 		"text_id": 8110200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8110200,
@@ -46847,7 +46849,7 @@
 	{
 		"text_id": 8112200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8112200,
@@ -46932,7 +46934,7 @@
 	{
 		"text_id": 8115200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8115200,
@@ -46992,7 +46994,7 @@
 	{
 		"text_id": 8117200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8117200,
@@ -47252,7 +47254,7 @@
 	{
 		"text_id": 7248200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7248200,
@@ -47452,7 +47454,7 @@
 	{
 		"text_id": 8119200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8119200,
@@ -47512,7 +47514,7 @@
 	{
 		"text_id": 8121200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8121200,
@@ -47567,7 +47569,7 @@
 	{
 		"text_id": 8156200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8156200,
@@ -47622,7 +47624,7 @@
 	{
 		"text_id": 8125200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8125200,
@@ -47722,7 +47724,7 @@
 	{
 		"text_id": 8127200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8127200,
@@ -47787,7 +47789,7 @@
 	{
 		"text_id": 8129200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8129200,
@@ -47877,7 +47879,7 @@
 	{
 		"text_id": 8132200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8132200,
@@ -47932,7 +47934,7 @@
 	{
 		"text_id": 8136200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8136200,
@@ -47992,7 +47994,7 @@
 	{
 		"text_id": 8138200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8138200,
@@ -48237,7 +48239,7 @@
 	{
 		"text_id": 7246200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7246200,
@@ -48287,7 +48289,7 @@
 	{
 		"text_id": 8134200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8134200,
@@ -48347,7 +48349,7 @@
 	{
 		"text_id": 8140200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8140200,
@@ -48402,7 +48404,7 @@
 	{
 		"text_id": 8142200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8142200,
@@ -48462,7 +48464,7 @@
 	{
 		"text_id": 8144200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8144200,
@@ -48517,7 +48519,7 @@
 	{
 		"text_id": 8146200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8146200,
@@ -48572,7 +48574,7 @@
 	{
 		"text_id": 8148200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8148200,
@@ -48627,7 +48629,7 @@
 	{
 		"text_id": 8150200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8150200,
@@ -48687,7 +48689,7 @@
 	{
 		"text_id": 8152200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8152200,
@@ -48747,7 +48749,7 @@
 	{
 		"text_id": 8154200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8154200,
@@ -48802,7 +48804,7 @@
 	{
 		"text_id": 8158200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8158200,
@@ -48862,7 +48864,7 @@
 	{
 		"text_id": 8160200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8160200,
@@ -49077,7 +49079,7 @@
 	{
 		"text_id": 8162200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8162200,
@@ -49132,7 +49134,7 @@
 	{
 		"text_id": 8164200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8164200,
@@ -49192,7 +49194,7 @@
 	{
 		"text_id": 8166200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8166200,
@@ -49252,7 +49254,7 @@
 	{
 		"text_id": 8168200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8168200,
@@ -49312,7 +49314,7 @@
 	{
 		"text_id": 8170200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8170200,
@@ -49367,7 +49369,7 @@
 	{
 		"text_id": 8172200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8172200,
@@ -49437,7 +49439,7 @@
 	{
 		"text_id": 8174200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8174200,
@@ -49522,7 +49524,7 @@
 	{
 		"text_id": 8177200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8177200,
@@ -49687,7 +49689,7 @@
 	{
 		"text_id": 8179200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8179200,
@@ -49747,7 +49749,7 @@
 	{
 		"text_id": 8181200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8181200,
@@ -49812,7 +49814,7 @@
 	{
 		"text_id": 8183200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8183200,
@@ -49907,7 +49909,7 @@
 	{
 		"text_id": 8186200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8186200,
@@ -49992,7 +49994,7 @@
 	{
 		"text_id": 8189200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8189200,
@@ -50052,7 +50054,7 @@
 	{
 		"text_id": 8191200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8191200,
@@ -50102,7 +50104,7 @@
 	{
 		"text_id": 7072200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7072200,
@@ -50147,7 +50149,7 @@
 	{
 		"text_id": 7074200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7074200,
@@ -50197,7 +50199,7 @@
 	{
 		"text_id": 7610200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7610200,
@@ -50247,7 +50249,7 @@
 	{
 		"text_id": 8193200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8193200,
@@ -50307,7 +50309,7 @@
 	{
 		"text_id": 8195200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8195200,
@@ -50367,7 +50369,7 @@
 	{
 		"text_id": 8197200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8197200,
@@ -50427,7 +50429,7 @@
 	{
 		"text_id": 8199200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8199200,
@@ -50482,7 +50484,7 @@
 	{
 		"text_id": 8201200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8201200,
@@ -50702,7 +50704,7 @@
 	{
 		"text_id": 8203200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8203200,
@@ -50757,7 +50759,7 @@
 	{
 		"text_id": 8205200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8205200,
@@ -50812,7 +50814,7 @@
 	{
 		"text_id": 8207200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8207200,
@@ -50872,7 +50874,7 @@
 	{
 		"text_id": 8209200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8209200,
@@ -50932,7 +50934,7 @@
 	{
 		"text_id": 8211200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8211200,
@@ -50987,7 +50989,7 @@
 	{
 		"text_id": 8213200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8213200,
@@ -51152,7 +51154,7 @@
 	{
 		"text_id": 8230200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8230200,
@@ -51182,7 +51184,7 @@
 	{
 		"text_id": 8231200,
 		"jp_text": "このチップは、大剣の\n「クレイモア」が\n元になっています。\nベーシックな大剣であり\n多くの新人アークスが使ってきました。",
-		"tr_text": "This chip is based on the\nsword \"Claymore\".\nIt is a basic sword, used by\ncountless new ARKS through\nthe years."
+		"tr_text": "This chip is based on the sword\n\"Claymore\".\nIt is a basic sword, used by\ncountless new ARKS through\nthe years."
 	},
 	{
 		"text_id": 8231200,
@@ -51207,7 +51209,7 @@
 	{
 		"text_id": 8232200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further\nthan before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8232200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -12,7 +12,7 @@
 	{
 		"text_id": 1001200,
 		"jp_text": "<%CHARANAME>さんの\n先輩アークス\nゼノさんのチップです。\nどなたにも面倒見のよい\nとっても頼りになる方です！",
-		"tr_text": "<%CHARANAME>, this is\na chip of your senior in ARKS, Zeno.\nHe's a reliable, dependable person!"
+		"tr_text": "<%CHARANAME>, this is\na chip of Zeno, your senior in ARKS.\nHe's a reliable, dependable person!"
 	},
 	{
 		"text_id": 1001200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -82,9 +82,7 @@
 	{
 		"text_id": 1003200,
 		"jp_text": "先輩アークス\nエコーさんのチップです。\nいつも後輩のみなさんを\n優しく見守ってくれている\nとっても素敵な方なんですよ！",
-		"tr_text": "
-        This is a chip of Echo, your\n
-        senior in ARKS.\nShe's a lovely person who always\nlooks after her juniors!"
+		"tr_text": "This is a chip of Echo, your\nsenior in ARKS.\nShe's a lovely person who always\nlooks after her juniors!"
 	},
 	{
 		"text_id": 1003200,

--- a/json/SeraphyRoom_TalkChipShowResponse.txt
+++ b/json/SeraphyRoom_TalkChipShowResponse.txt
@@ -362,182 +362,182 @@
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "きゃあっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis... this chip...!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "<%CHARANAME>さん！\nこれっ、とっても貴重な\nエレクトロニック・ディーヴァ\nコラボチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Electronic\nDiva Collaboration Chip!"
 	},
 	{
 		"text_id": 202000,
 		"jp_text": "すごい……\n歌声が心に響き渡るようです……！\n感激です！　ありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Amazing...\nJust looking at this, it's as if I\ncan hear that beautiful voice...!\nI'm deeply moved!\nThank you!"
 	},
 	{
 		"text_id": 291000,

--- a/json/SeraphyRoom_TalkChipShowResponse.txt
+++ b/json/SeraphyRoom_TalkChipShowResponse.txt
@@ -542,47 +542,47 @@
 	{
 		"text_id": 291000,
 		"jp_text": "ええっ！\nこっ、このチップは……\n★11チップ！\nなんてエネルギーなの！",
-		"tr_text": ""
+		"tr_text": "Huh?!\nThi- this chip...\nThis is an ★11 chip!\nSuch energy!"
 	},
 	{
 		"text_id": 291001,
 		"jp_text": "ええっ！\nこっ、このチップは\n初めて本物をこの目で！\nす、すごい……！",
-		"tr_text": ""
+		"tr_text": "Huh?!\nI- I never imagined I'd see this chip for myself!\nA-amazing...!"
 	},
 	{
 		"text_id": 291002,
 		"jp_text": "きゃあっ！\nこっ、このチップは……\n★11チップじゃないですか！\nなんてことなの！\nこの目で見られるなんて！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThi- this chip...This is an ★11 chip!\nWhat a thing to find!\nI can't believe my eyes!"
 	},
 	{
 		"text_id": 291003,
 		"jp_text": "こっ、このチップは……\n★11のチップじゃないですか！\nこの目で見られるなんて！\n感激……！",
-		"tr_text": ""
+		"tr_text": "Thi- this chip...\nThis is an ★11 chip!\nI can't believe my eyes!\nThis feeling...!"
 	},
 	{
 		"text_id": 291004,
 		"jp_text": "こっ、このチップは……\n★11のチップじゃないですか！\nし、信じられない！\nこんなに強大な力を……！",
-		"tr_text": ""
+		"tr_text": "Thi- this chip...\nThis is an ★11 chip!\nI don't believe it!\nSuch incredible power...!"
 	},
 	{
 		"text_id": 203000,
 		"jp_text": "あっ！\nこれはフォニュエールさんの\nチップですね！\nよかった、無事受け取って\nいただけたんですね！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis is a FOnewearl chip!\nI'm glad to see it got to you safely!"
 	},
 	{
 		"text_id": 292000,
 		"jp_text": "えっ、こ、このチップは……！\n★10のチップ！\nすごい……\nすごいエネルギーだわ！",
-		"tr_text": ""
+		"tr_text": "Ah, thi- this chip...\nThis is a ★10 chip!Amazing...\nSuch amazing energy!"
 	},
 	{
 		"text_id": 292001,
 		"jp_text": "えっ、こ、このチップは！\n★10チップ！\nす、すごい！　すごい力だわ！",
-		"tr_text": ""
+		"tr_text": "Ah, thi- this chip!\nThis is a ★10 chip!\nA-amazing! Such awesome power!"
 	},
 	{
 		"text_id": 292002,
 		"jp_text": "きゃっ！\nこのチップは★10のチップ……！\nあ、あの希少な！　すごい！",
-		"tr_text": ""
+		"tr_text": "Eek!\nThis is a ★10 chip...!\nTh-these are so rare! Amazing!"
 	},
 	{
 		"text_id": 293000,
@@ -662,11 +662,11 @@
 	{
 		"text_id": 297000,
 		"jp_text": "信じられません！こんなに強大な力を\n持つチップが存在するなんて……！\n★12のチップを見られるなんて\n思いませんでした……\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "I can't believe it! This chip is\nunimaginably powerful...!\nI never thought I would see a\n★12 chip for myself...\nThank you so much!"
 	},
 	{
 		"text_id": 298000,
 		"jp_text": "このチップまさか……★13チップ！\nエネルギーに満ち溢れていて\nとってもきれい……\nありがとうございます！　感激です！",
-		"tr_text": ""
+		"tr_text": "No way, this chip...\nThis is a ★13 chip!\nSo beautiful, and\nso full of energy...\nThank you very much!\nI'm deeply moved!"
 	}
 ]

--- a/json/SeraphyRoom_TalkChipShowResponse.txt
+++ b/json/SeraphyRoom_TalkChipShowResponse.txt
@@ -587,77 +587,77 @@
 	{
 		"text_id": 293000,
 		"jp_text": "えっ、このチップは……\n★9のチップじゃないですか！\nなんてすごい力なの……\nなるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Huh, this chip...\This is a ★9 chip!\nSuch amazing power...\nI see, I see..."
 	},
 	{
 		"text_id": 293001,
 		"jp_text": "あっ！\nこ、このチップは★9チップ！\nすごい力だわ……ふむふむ……",
-		"tr_text": ""
+		"tr_text": "Ah!\nThi- this is a ★9 chip!\nThis amazing power... Hmm..."
 	},
 	{
 		"text_id": 293002,
 		"jp_text": "あっ……こ、このチップは！\n★9のチップ……なんて力なの……\nなるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Ah...\nThi- this chip!\nThis is a ★9 chip... Such power...\nI see, I see..."
 	},
 	{
 		"text_id": 294000,
 		"jp_text": "あっ！\nこれは珍しいチップですね！\nフムフム……なるほど……",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis is a rare chip!\nHm... I see..."
 	},
 	{
 		"text_id": 294001,
 		"jp_text": "あっ！\nこれはかなり珍しいチップですね！\nなるほど、こうなってたのね……\nふむふむ……",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis is a pretty rare chip!\nI see, so this is what it does...\nHmm..."
 	},
 	{
 		"text_id": 295000,
 		"jp_text": "あっ……すごい！\nこのチップは……\nなるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Oh... wow!\nThis chip is...\nI see, I see..."
 	},
 	{
 		"text_id": 295001,
 		"jp_text": "えっと……\nあっ、すごい！\nこのチップは……\nなるほど、なるほど……",
-		"tr_text": ""
+		"tr_text": "Uh...\nOh, wow!\nThis chip is...\nI see, I see..."
 	},
 	{
 		"text_id": 295002,
 		"jp_text": "えっと……\nあ、このチップは！\nなるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Uh...\nOh, this chip!\nI see, I see..."
 	},
 	{
 		"text_id": 295003,
 		"jp_text": "ふむふむ……\nこのチップは……！\nな、なるほどぉ！",
-		"tr_text": ""
+		"tr_text": "Hmm...\nThis chip is...\nOoh, I see...!"
 	},
 	{
 		"text_id": 295004,
 		"jp_text": "あっ、このチップは……！\nな、なるほど……！",
-		"tr_text": ""
+		"tr_text": "Oh, this chip is...!\nOoh, I see...!"
 	},
 	{
 		"text_id": 296000,
 		"jp_text": "フムフム……\nあっ、このチップは……\nなるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Hmm...\nAh, this chip...\nI see, I see..."
 	},
 	{
 		"text_id": 296001,
 		"jp_text": "えっと……\nあっ、このチップは……\nなるほど、なるほど……",
-		"tr_text": ""
+		"tr_text": "Uh...\nAh, this chip...\nI see, I see..."
 	},
 	{
 		"text_id": 296002,
 		"jp_text": "えっと……\nこのチップは……\nわっ、なるほどなるほど……",
-		"tr_text": ""
+		"tr_text": "Uh...\nThis chip is...\nAh, I see, I see..."
 	},
 	{
 		"text_id": 296003,
 		"jp_text": "ふむふむ……\nこのチップは……\nな、なるほどぉ……！",
-		"tr_text": ""
+		"tr_text": "Hm...\nThis chip is...\nOoh, I see...!"
 	},
 	{
 		"text_id": 296004,
 		"jp_text": "ふむふむ……\nこのチップは……\nあ、なるほど……！",
-		"tr_text": ""
+		"tr_text": "Hmm...\nThis chip is...\nOh, I see...!"
 	},
 	{
 		"text_id": 297000,

--- a/json/SeraphyRoom_TalkChipShowResponse.txt
+++ b/json/SeraphyRoom_TalkChipShowResponse.txt
@@ -182,182 +182,182 @@
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "あぁっ！\nこっ……このチップは……！",
-		"tr_text": ""
+		"tr_text": "Ah!\nThis... this chip...!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "<%CHARANAME>さん！\nこっ、これ、かなり希少な\nシャイニング・ヒーローズコラボ\nチップじゃないですか！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>!\nThis is a very rare Shining\nHeroes Collaboration Chip!"
 	},
 	{
 		"text_id": 201000,
 		"jp_text": "壮大な冒険の情景が\n目に浮かびますね……\n大変良いものを見せていただき\nありがとうございます！",
-		"tr_text": ""
+		"tr_text": "Just looking at this makes me\nthink of a spectacular adventure...\nThank you so much for showing me this!"
 	},
 	{
 		"text_id": 202000,

--- a/json/SeraphyRoom_TalkChipShowResponse.txt
+++ b/json/SeraphyRoom_TalkChipShowResponse.txt
@@ -587,7 +587,7 @@
 	{
 		"text_id": 293000,
 		"jp_text": "えっ、このチップは……\n★9のチップじゃないですか！\nなんてすごい力なの……\nなるほどなるほど……",
-		"tr_text": "Huh, this chip...\This is a ★9 chip!\nSuch amazing power...\nI see, I see..."
+		"tr_text": "Huh, this chip...\nThis is a ★9 chip!\nSuch amazing power...\nI see, I see..."
 	},
 	{
 		"text_id": 293001,

--- a/json/SeraphyRoom_TalkTouch3rd.txt
+++ b/json/SeraphyRoom_TalkTouch3rd.txt
@@ -122,7 +122,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded' out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
 	},
 	{
 		"text_id": 670004,
@@ -302,7 +302,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded' out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
 	},
 	{
 		"text_id": 670004,
@@ -482,7 +482,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded' out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
 	},
 	{
 		"text_id": 670004,

--- a/json/SeraphyRoom_TalkTouch3rd.txt
+++ b/json/SeraphyRoom_TalkTouch3rd.txt
@@ -427,6 +427,7 @@
 	{
 		"text_id": 670002,
 		"jp_text": "<%CHARANAME>さん！\n突然ですが、ナゾナゾです！",
+		"tr_text": "<%CHARANAME>!\nI know it's a bit sudden,\nbut I have a riddle for you!"
 	},
 	{
 		"text_id": 670002,

--- a/json/SeraphyRoom_TalkTouch3rd.txt
+++ b/json/SeraphyRoom_TalkTouch3rd.txt
@@ -122,7 +122,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\nout in no time!"
 	},
 	{
 		"text_id": 670004,
@@ -302,7 +302,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\nout in no time!"
 	},
 	{
 		"text_id": 670004,
@@ -427,7 +427,6 @@
 	{
 		"text_id": 670002,
 		"jp_text": "<%CHARANAME>さん！\n突然ですが、ナゾナゾです！",
-		"tr_text": "<%CHARANAME>!I\n know it's a bit sudden,\nbut I have a riddle for you!"
 	},
 	{
 		"text_id": 670002,
@@ -482,7 +481,7 @@
 	{
 		"text_id": 670004,
 		"jp_text": "ハンターでした！\n理由は……\n体験（大剣）できるから！\nです！",
-		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\n out in no time!"
+		"tr_text": "Hunter!\nWhy?\nBecause you get 'sworded'\nout in no time!"
 	},
 	{
 		"text_id": 670004,

--- a/json/SideStoryEvent_Text.txt
+++ b/json/SideStoryEvent_Text.txt
@@ -6220,7 +6220,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "そう思ってるから……<%br>元気に見えるのかもしれないなっ！",
-		"tr_text": "I keep my energy up,<%br>so no-one will ever think I'm weak!",
+		"tr_text": "I keep my energy up, so nobody<%br>will ever think I'm weak!",
 		"fileID": 7
 	},
 	{
@@ -6228,7 +6228,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "そう……<%br>ありがとう、話してくれて。",
-		"tr_text": "I see...<%br>Thank you for telling me this.",
+		"tr_text": "I see...<%br>Thank you for informing me.",
 		"fileID": 7
 	},
 	{
@@ -6244,7 +6244,7 @@
 		"jp_name": "バイオトライナー",
 		"tr_name": "Bio Triner",
 		"jp_text": "それ以外にも、臆病だったり<%br>面倒くさがりだったり、いろいろあるし。",
-		"tr_text": "Besides which, you have many other traits. For<%br>instance, you are cowardly, and you complain a lot",
+		"tr_text": "Besides which, you have many other traits. For<%br>instance, you are cowardly, and you complain a lot.",
 		"fileID": 7
 	},
 	{

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -19367,7 +19367,7 @@
 	{
 		"assign": "chip_details_ghost_explains",
 		"jp_text": "【条件】必殺技は武器の種類、法術は属性が一致\nラッシュゲージ最大時\n装備先の<%type>発動後のジャストアタックに成功すると\n分身となる「ラッシュ」が出現して\n「<%name>」が\n追加で発動する。",
-		"tr_text": ""
+		"tr_text": "[Condition] Same-weapon PA, same-Element Tech\nWhen the Rush Arts gauge is full, by performing a\nJust Attack after using the linked <%type>, a \"Rush\"\nghost of yourself will appear and follow up with\n\"<%name>\"."
 	},
 	{
 		"assign": "chip_details_ghost_explains_pa",

--- a/json/UI_Tips.txt
+++ b/json/UI_Tips.txt
@@ -57,17 +57,17 @@
 	{
 		"assign": "11",
 		"jp_text": "<color=black>……</color>",
-		"tr_text": ""
+		"tr_text": "<color=black>...</color>"
 	},
 	{
 		"assign": "12",
 		"jp_text": "<color=black>…………</color>",
-		"tr_text": ""
+		"tr_text": "<color=black>......</color>"
 	},
 	{
 		"assign": "13",
 		"jp_text": "<color=black>………………</color>",
-		"tr_text": ""
+		"tr_text": "<color=black>.........</color>"
 	},
 	{
 		"assign": "14",
@@ -212,11 +212,11 @@
 	{
 		"assign": "42",
 		"jp_text": "<color=black>……</color>",
-		"tr_text": ""
+		"tr_text": "<color=black>...</color>"
 	},
 	{
 		"assign": "43",
 		"jp_text": "<color=black>……</color>",
-		"tr_text": ""
+		"tr_text": "<color=black>...</color>"
 	}
 ]

--- a/json/UI_Weaponoid_SideStoryOpen.txt
+++ b/json/UI_Weaponoid_SideStoryOpen.txt
@@ -17,7 +17,7 @@
 	{
 		"assign": "4",
 		"jp_text": "やっほー！\nアダマンの杖なんダマン！",
-		"tr_text": "Yahoo!\nMace of Adaman here, daman!"
+		"tr_text": "Yahoo!\nMace of Adaman here-daman!"
 	},
 	{
 		"assign": "14",


### PR DESCRIPTION
More chip abilities updated, more chip ability names translated, more link skills translated and updated, frame info removed from chip names where the chip's ability has been updated to include it, and Seraphy's responses to the different kinds of new chips you can show her translated, plus minor tweaks and fixes. Also improves coverage.py again, preventing it from counting certain dummy strings as translatable.