### PR TITLE
Item updates, chip corrections, EQ achievements

### DIFF
--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -38,7 +38,7 @@ for files in json_files:
                     if (
                         (checkjp in rmid)
                         and (rmid[checkjp] not in ["", "-", "－", "---", "仮設定", "仮テキスト"])
-                        and (re.fullmatch('d+', str(rmid[checkjp])) is None)
+                        and (re.fullmatch(r'^\d+$', str(rmid[checkjp])) is None)
                         # Filter out names that are just numbers - even if these aren't dummy strings, the numbers alone are fine
                         and (re.fullmatch('ENT_(ABN|SP)ダミー\d+', str(rmid[checkjp])) is None)
                        ):  # Filter out dummy strings from Explain_Element_Abnormal and Explain_Element_Special

--- a/_py/coverage.py
+++ b/_py/coverage.py
@@ -40,7 +40,7 @@ for files in json_files:
                         and (rmid[checkjp] not in ["", "-", "－", "---", "仮設定", "仮テキスト"])
                         and (re.fullmatch(r'^\d+$', str(rmid[checkjp])) is None)
                         # Filter out names that are just numbers - even if these aren't dummy strings, the numbers alone are fine
-                        and (re.fullmatch('ENT_(ABN|SP)ダミー\d+', str(rmid[checkjp])) is None)
+                        and (re.fullmatch(r'ENT_(ABN|SP)ダミー\d+', str(rmid[checkjp])) is None)
                        ):  # Filter out dummy strings from Explain_Element_Abnormal and Explain_Element_Special
 
                         countin += 1

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1843,14 +1843,14 @@
 	{
 		"assign": "31677",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
 		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -326,42 +326,42 @@
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of Ice\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n     equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of Ice\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30033",
@@ -438,14 +438,14 @@
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    different chip elements equipped.\n② Increases DEF in proportion to the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    different chip elements equipped.\n② Increases DEF in proportion to the number\n    of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30071",
@@ -466,42 +466,42 @@
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30082",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped..\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30083",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped..\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30084",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped..\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30085",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30086",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to the number of\n    Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30089",
@@ -634,28 +634,28 @@
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Wind Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
@@ -690,28 +690,28 @@
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Dark Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to your\n    Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",
@@ -774,42 +774,42 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "ATK boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "ATK boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n     different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + dam. reduced",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to the\n    number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
@@ -844,14 +844,14 @@
 		"jp_explainShort": "定期的に劇的ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた劇的ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals regular dramatic damage to the targeted\n    enemy in proportion to your ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals regular dramatic damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "定期的に絶大ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた絶大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals regular massive damage to the targeted\n    enemy in proportion to your ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "① Deals regular massive damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31171",
@@ -1054,28 +1054,28 @@
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31259",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    based on this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31260",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    in proportion to this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts the power of Light Techs\n    based on this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31269",
@@ -1152,14 +1152,14 @@
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage in proportion to the number of\n    Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum Increase: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage based on the number of Lightning\n    chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum Increase: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31316",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage in proportion to the number of\n    Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum Increase: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage based on the number of Lightning\n    chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum Increase: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31319",
@@ -1194,14 +1194,14 @@
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31336",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP at regular intervals in proportion\n    to the number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP at regular intervals based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31339",
@@ -1264,14 +1264,14 @@
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses in\n    proportion to the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses in\n    proportion to the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31405",
@@ -1362,14 +1362,14 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31438",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31443",
@@ -1404,84 +1404,84 @@
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage in proportion to the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31458",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage in proportion to the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31475",
 		"jp_explainShort": "雷枚数攻撃力絶大増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to\n    the number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31476",
 		"jp_explainShort": "雷枚数攻撃力超絶増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n① チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to\n    the number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31483",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Immensely boosts damage in proportion to\n    the number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31484",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Immensely boosts damage in proportion to\n    the number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31485",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Immensely boosts damage in proportion to\n    the number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    in proportion to your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31486",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Immensely boosts damage in proportion to\n    the number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    in proportion to your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31499",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts PAs and Techs in proportion to this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts PAs and Techs based on this chip's ability\n     level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31500",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs in proportion to\n    this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31507",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to\n    the number of Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31508",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to\n    the number of Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31509",
@@ -1691,14 +1691,14 @@
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP boosted",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。(最大時：超絶)\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK in proportion to this chip's\n    ability level each time you successfully perform\n    a Just Attack.\n    (Maximum Increase: Overwhelming)\n③ Boosts maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum Increase: Overwhelming)\n③ Boosts maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31610",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP boosted",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。(最大時：超絶)\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK in proportion to this chip's\n    ability level each time you successfully perform\n    a Just Attack.\n    (Maximum Increase: Overwhelming)\n③ Boosts maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum Increase: Overwhelming)\n③ Boosts maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31624",
@@ -1719,49 +1719,49 @@
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage in proportion to the number of\n    Dark chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31634",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage in proportion to the number of\n    Dark chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31635",
 		"jp_explainShort": "攻撃力極度増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage in proportion to the number of\n    Dark chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31644",
 		"jp_explainShort": "アビリティＬｖ攻撃劇的増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to\n    this chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31645",
 		"jp_explainShort": "アビリティＬｖ攻撃絶大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to\n    this chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31646",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs in proportion to this chip's\n    ability level.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31647",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs in proportion to this\n    chip's ability level.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31652",
@@ -1810,21 +1810,21 @@
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage in proportion to the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31667",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage in proportion to the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31668",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage in proportion to the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts damage based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31673",
@@ -1859,14 +1859,14 @@
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を劇的に増加する\n② ジャストアタックごとに\n　　 攻撃力を強化する。(最大時：劇的)\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Just Attacks in proportion to\n    the number of different chip elements equipped.\n    <color=yellow>[?-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[?-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31701",
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を劇絶大に増加する\n② ジャストアタックごとに\n　　 攻撃力を強化する。(最大時：劇的)\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Just Attacks in proportion to\n    the number of different chip elements equipped.\n    <color=yellow>[?-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[?-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31702",
@@ -6640,14 +6640,14 @@
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Dark Element in\n    proportion to its value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "4020",
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Dark Element in\n    proportion to its value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "4110",
@@ -7060,14 +7060,14 @@
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Light Element in\n    proportion to its value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "9320",
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Light Element in\n    proportion to its value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "9410",
@@ -7186,14 +7186,14 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage in proportion to how far you are\n    from the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts damage based on how far you are from\n    the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20036",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が大増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to how far\n    you are from the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on how far you are\n    from the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20037",
@@ -7410,13 +7410,13 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK in proportion to how far you are\n    from the target.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20020",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK in proportion to how far you are\n    from the target.\n[Effect Duration] Medium"
+		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
 	}
 ]

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1845,14 +1845,14 @@
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31700",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -1500,14 +1500,14 @@
 	{
 		"assign": "31193",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力大増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
 		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31194",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
 		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
@@ -3320,14 +3320,14 @@
 	{
 		"assign": "31549",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
 		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31550",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
 		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
@@ -3957,14 +3957,14 @@
 	{
 		"assign": "31679",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力小増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力をわずかに増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
 		"tr_explainLong": "① Slightly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力増加",
-		"tr_explainShort": "HP recovery over time + damage boost",
+		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
 		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -4001,14 +4001,14 @@
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31686",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31687",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -1502,14 +1502,14 @@
 		"jp_explainShort": "定期的にＨＰ小回復＋威力大増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31194",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31195",
@@ -3322,14 +3322,14 @@
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31550",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31551",
@@ -3959,14 +3959,14 @@
 		"jp_explainShort": "定期的にＨＰ小回復＋威力小増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力をわずかに増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力増加",
 		"tr_explainShort": "HP recovery over time + damage boost",
 		"jp_explainLong": "① 威力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31681",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2048,7 +2048,7 @@
 		"jp_explainShort": "発見済みエネミーチップ数に応じ特大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of Enemy Chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of Enemy Chips discovered\n   in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31304",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -186,28 +186,28 @@
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30024",
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30025",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30026",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30035",
@@ -228,14 +228,14 @@
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to the\n    number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30038",
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken in proportion to the\n    number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30039",
@@ -382,14 +382,14 @@
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
 		"tr_explainShort": "Add. damage x # chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n   Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30066",
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
 		"tr_explainShort": "Add. damage x # chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n   Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30069",
@@ -438,28 +438,28 @@
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30078",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30079",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30080",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    the number of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30087",
@@ -676,14 +676,14 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31024",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31027",
@@ -774,14 +774,14 @@
 		"jp_explainShort": "風チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31042",
 		"jp_explainShort": "風チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31043",
@@ -802,28 +802,28 @@
 		"jp_explainShort": "炎チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31054",
 		"jp_explainShort": "炎チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31055",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31056",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31057",
@@ -900,14 +900,14 @@
 		"jp_explainShort": "雷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31076",
 		"jp_explainShort": "雷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31077",
@@ -970,14 +970,14 @@
 		"jp_explainShort": "雷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion\n    to your Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31090",
 		"jp_explainShort": "雷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion\n    to your Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31091",
@@ -1040,42 +1040,42 @@
 		"jp_explainShort": "光属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion\n    to your Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31106",
 		"jp_explainShort": "光属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion\n    to your Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31107",
 		"jp_explainShort": "炎属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31108",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion\n    to your Fire Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31109",
 		"jp_explainShort": "氷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31110",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion\n    to your Ice Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31111",
@@ -1110,14 +1110,14 @@
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31116",
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31117",
@@ -1180,14 +1180,14 @@
 		"jp_explainShort": "光チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31128",
 		"jp_explainShort": "光チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31129",
@@ -1222,28 +1222,28 @@
 		"jp_explainShort": "属性種類数ダメージ大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31136",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋追加ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage in proportion to\n    the number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31139",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of different\n    chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31140",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of different\n    chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31143",
@@ -1320,84 +1320,84 @@
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31158",
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31159",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31160",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31161",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31162",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31165",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31166",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31167",
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31168",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31169",
 		"jp_explainShort": "チップ発見数攻撃力劇的増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to\n    the number of different chips discovered in\n    the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n   of different chips discovered in\n    the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31170",
 		"jp_explainShort": "チップ発見数攻撃力絶大増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to\n    the number of different chips discovered in\n    the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n   of different chips discovered in\n    the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31173",
@@ -1418,14 +1418,14 @@
 		"jp_explainShort": "氷チップ数攻撃力大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage in proportion to\n    thenumber of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31178",
 		"jp_explainShort": "氷チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage in proportion to\n    the number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31179",
@@ -1446,14 +1446,14 @@
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31182",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31183",
@@ -1558,14 +1558,14 @@
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31208",
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals in\n    proportion to the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31209",
@@ -1614,56 +1614,56 @@
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31220",
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31221",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    in proportion to the number of Lightning chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31222",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    in proportion to the number of Lightning chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31223",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage in proportion to\n    the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31224",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage in proportion to\n    the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31225",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to how\n    close you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31226",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to how\n    close you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31229",
@@ -1684,14 +1684,14 @@
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals in\n    proportion to the number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31232",
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals in proportion\n    to the number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals based on the\n    number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31233",
@@ -1768,14 +1768,14 @@
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31252",
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31253",
@@ -1810,14 +1810,14 @@
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Dark Techs in proportion to\n    this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31262",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Dark Techs in proportion to\n    this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31263",
@@ -1838,14 +1838,14 @@
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31266",
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31267",
@@ -1880,14 +1880,14 @@
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31276",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31279",
@@ -2048,14 +2048,14 @@
 		"jp_explainShort": "発見済みエネミーチップ数に応じ特大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    in proportion to the number of Enemy Chips\n    discovered in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of Enemy Chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31304",
 		"jp_explainShort": "発見済みエネミーチップ数に応じ絶大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で絶大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies\n    in proportion to the number of Enemy Chips\n    discovered in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies\n    based on the number of Enemy Chips discovered\n    in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31305",
@@ -2104,14 +2104,14 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31314",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31317",
@@ -2300,14 +2300,14 @@
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31354",
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31357",
@@ -2370,56 +2370,56 @@
 		"jp_explainShort": "アビリティレベル攻撃大増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② 定期的にＣＰがわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31366",
 		"jp_explainShort": "アビリティレベル攻撃劇的増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② 定期的にＣＰがわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31367",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Ice Techs in proportion to\n    this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31368",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Ice Techs in proportion to\n    this chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31369",
 		"jp_explainShort": "攻撃絶大増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses in\n    proportion to the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses in proportion\n    to the number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31370",
 		"jp_explainShort": "攻撃超絶増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses in\n    proportion to the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses in proportion\n    to the number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31371",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31372",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31373",
@@ -2496,14 +2496,14 @@
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    your Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31386",
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    your Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31387",
@@ -2664,14 +2664,14 @@
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP boosted",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力をわずかに強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK in proportion to this\n    chip's ability level.\n② Boosts maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Slightly increases ATK based on this chip's ability\n    level.\n② Boosts maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31416",
 		"jp_explainShort": "ジャストアタックごと攻撃力強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP boosted",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力を強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK in proportion to this chip's\n    ability level.\n② Boosts maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases ATK based on this chip's ability level.\n② Boosts maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31421",
@@ -2734,28 +2734,28 @@
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs in proportion to this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31434",
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs in proportion to this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31435",
 		"jp_explainShort": "全種族に対してダメージが増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against all races in proportion to\n    this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts damage against all races based on this\n    chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31436",
 		"jp_explainShort": "全種族に対してダメージが大増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against all races in\n    proportion to this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage against all races based\n    on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31439",
@@ -2818,28 +2818,28 @@
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies in proportion\n    to your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31450",
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage in proportion to the\n    number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies in proportion\n    to your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31451",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31452",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31455",
@@ -2916,14 +2916,14 @@
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage in proportion to the\n    number of Ice chips equipped each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31468",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage in proportion to the\n    number of Ice chips equipped each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31469",
@@ -2944,42 +2944,42 @@
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals heavy additional damage in proportion to\n    the number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Deals heavy additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31472",
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage in proportion to\n    the number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31473",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31474",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31477",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31478",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31479",
@@ -3042,14 +3042,14 @@
 		"jp_explainShort": "全属性を小強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases all elements.\n② Deals addititional damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31492",
 		"jp_explainShort": "全属性を強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases all elements.\n② Deals addititional damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31493",
@@ -3070,14 +3070,14 @@
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31496",
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31497",
@@ -3098,14 +3098,14 @@
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31502",
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31503",
@@ -3140,28 +3140,28 @@
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31512",
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in proportion to\n    the number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31513",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against Oceanids and Natives in\n    proportion to this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts damage against Oceanids and Natives\n    based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31514",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ大増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを大きく増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against Oceanids and\n    Natives in proportion to this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage against Oceanids and\n    Natives based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31515",
@@ -3252,14 +3252,14 @@
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Boosts additional damage in proportion to the\n    number of equipped chip elements.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Boosts additional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases the enemy's weakness element.\n② Boosts additional damage in proportion to the\n    number of equipped chip elements.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Increases the enemy's weakness element.\n② Boosts additional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31537",
@@ -3336,14 +3336,14 @@
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31552",
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31553",
@@ -3413,14 +3413,14 @@
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to a percentage of your HP proportional\n    to the number of different Elements equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to a percentage of your HP proportional\n    to the number of different Elements equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31568",
@@ -3469,28 +3469,28 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK in proportion to\n    how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31575",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が絶大強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を絶大に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely increases ATK in proportion to\n    how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31579",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs in proportion to this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31580",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs in proportion to this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31583",
@@ -3511,14 +3511,14 @@
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31586",
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31587",
@@ -3595,28 +3595,28 @@
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage in proportion to this\n    chip's ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31603",
 		"jp_explainShort": "攻撃力劇的強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Deals heavy additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31604",
 		"jp_explainShort": "攻撃力絶大強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely increases ATK.\n② Deals heavy additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31607",
@@ -3637,14 +3637,14 @@
 		"jp_explainShort": "攻撃大増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31612",
 		"jp_explainShort": "攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies in\n    proportion to your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31613",
@@ -3819,14 +3819,14 @@
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs in proportion to this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31643",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs in proportion to this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31648",
@@ -3903,14 +3903,14 @@
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies in\n    proportion to this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31661",
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies in\n    proportion to this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31669",
@@ -4001,49 +4001,49 @@
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental damage in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31686",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental damage in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Overwhelmingly boosts elemental damage based\n    on the number of different chip\n    elements equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31687",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31688",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31689",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning in proportion to the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning based on the number\n    of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31690",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning in proportion to the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning based on the number\n    of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31691",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning in proportion to the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Boosts Lightning elemental damage against\n    enemies weak to Lightning based on the number\n    of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31692",
@@ -4106,14 +4106,14 @@
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋最大ＣＰ増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② 最大ＣＰを上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage in proportion to this chip's ability\n    level if equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31706",
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋最大ＣＰ増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② 最大ＣＰを上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage in proportion to this chip's ability\n    level if equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31707",
@@ -4134,14 +4134,14 @@
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31710",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "11030",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2958,14 +2958,14 @@
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31474",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31477",
@@ -3651,14 +3651,14 @@
 		"jp_explainShort": "炎雷風技法攻撃力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31614",
 		"jp_explainShort": "炎雷風技法攻撃力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n②Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31615",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -1936,14 +1936,14 @@
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31286",
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31287",
@@ -2510,14 +2510,14 @@
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31388",
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31391",
@@ -4015,14 +4015,14 @@
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31688",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies in\n    proportion to the number of different chip\n    elements equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31689",
@@ -8026,13 +8026,13 @@
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Taking an attack\n[Effect Duration] Short"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20046",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	}
 ]

--- a/json/Item_Addon_Unit.txt
+++ b/json/Item_Addon_Unit.txt
@@ -389,7 +389,7 @@
 		"jp_text": "サブ／ウェポンズバリア",
 		"tr_text": "Sub/Weapons Barrier",
 		"jp_explain": "汎用装備可能なユニット。\n全ての属性への耐性を持ち\n最大ＨＰを大幅に上昇させる。 ",
-		"tr_explain": ""
+		"tr_explain": "An equippable all-purpose unit.\nProvides resistance to all attributes\nand greatly increases maximum HP."
 	},
 	{
 		"assign": "54056",

--- a/json/Item_Costume_Female.txt
+++ b/json/Item_Costume_Female.txt
@@ -6862,42 +6862,42 @@
 	{
 		"assign": "2201182",
 		"jp_text": "少名比売神衣",
-		"tr_text": "Sukunahime Divine Wear",
+		"tr_text": "Sukuna-hime Divine Wear",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2201183",
 		"jp_text": "少名比売神衣　影",
-		"tr_text": "Sukunahime Divine Shadow",
+		"tr_text": "Sukuna-hime Divine Shadow",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2201184",
 		"jp_text": "少名比売神衣　紅",
-		"tr_text": "Sukunahime Divine Crimson",
+		"tr_text": "Sukuna-hime Divine Crimson",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2201185",
 		"jp_text": "少名比売神衣　海",
-		"tr_text": "Sukunahime Divine Sea",
+		"tr_text": "Sukuna-hime Divine Sea",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2201186",
 		"jp_text": "少名比売神衣　月",
-		"tr_text": "Sukunahime Divine Moon",
+		"tr_text": "Sukuna-hime Divine Moon",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2201187",
 		"jp_text": "少名比売神衣　鋼",
-		"tr_text": "Sukunahime Divine Steel",
+		"tr_text": "Sukuna-hime Divine Steel",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
@@ -11496,7 +11496,7 @@
 	{
 		"assign": "2201861",
 		"jp_text": "少名比売神衣７１１",
-		"tr_text": "Sukunahime Divine Wear 711",
+		"tr_text": "Sukuna-hime Divine Wear 711",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
@@ -13211,21 +13211,21 @@
 	{
 		"assign": "2202112",
 		"jp_text": "少名比売神衣　銀",
-		"tr_text": "Sukunahime Divine Wear Silver",
+		"tr_text": "Sukuna-hime Divine Silver",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2202113",
 		"jp_text": "少名比売神衣　玄",
-		"tr_text": "Sukunahime Divine Wear Mysterious",
+		"tr_text": "Sukuna-hime Divine Mysterious",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "2202114",
 		"jp_text": "少名比売神衣　茜",
-		"tr_text": "Sukunahime Divine Wear Madder",
+		"tr_text": "Sukuna-hime Divine Madder",
 		"jp_explain": "灰の神子スクナヒメがその身に纏う\n荘厳な雰囲気と美しさを併せ持つ神衣。\n神代の力により紡ぎ上げられている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -22115,9 +22115,9 @@
 	{
 		"assign": "3803413",
 		"jp_text": "頭乗せ雛ラッピー",
-		"tr_text": "",
+		"tr_text": "Head Riding Rappy Chick",
 		"jp_explain": "使用すると、新しいアクセサリーの\n頭乗せ雛ラッピーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Head Riding Rappy Chick\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803414",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -5931,9 +5931,9 @@
 	{
 		"assign": "380939",
 		"jp_text": "スクナヒメの角",
-		"tr_text": "Sukuna-hime's Horn",
+		"tr_text": "Sukunahime's Horn",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスクナヒメの角が選択可能。",
-		"tr_explain": "Unlocks the accessory\n\"Sukuna-hime's Horn\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the accessory\n\"Sukunahime's Horn\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "380941",
@@ -13120,9 +13120,9 @@
 	{
 		"assign": "3802005",
 		"jp_text": "スクナヒメの角７１１",
-		"tr_text": "Sukuna-hime's Horn 711",
+		"tr_text": "Sukunahime's Horn 711",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスクナヒメの角７１１が選択可能。",
-		"tr_explain": "Unlocks the accessory\n\"Sukuna-hime's Horn 711\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the accessory\n\"Sukunahime's Horn 711\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3802006",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -21942,7 +21942,7 @@
 		"jp_text": "レドーム・ユニット",
 		"tr_text": "Radome Unit",
 		"jp_explain": "使用すると、新しいアクセサリーの\nレドーム・ユニットが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Radome Unit\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803386",
@@ -21963,63 +21963,63 @@
 		"jp_text": "クローハンド",
 		"tr_text": "Claw Hands",
 		"jp_explain": "使用すると、新しいアクセサリーの\nクローハンドが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Claw Hands\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803389",
 		"jp_text": "クローブーツ",
 		"tr_text": "Claw Boots",
 		"jp_explain": "使用すると、新しいアクセサリーの\nクローブーツが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Claw Boots\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803390",
 		"jp_text": "デフォルメマスク",
 		"tr_text": "Deformed Mask",
 		"jp_explain": "使用すると、新しいアクセサリーの\nデフォルメマスクが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Deformed Mask\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803391",
 		"jp_text": "イビルウィング白",
 		"tr_text": "Evil Wings White",
 		"jp_explain": "使用すると、新しいアクセサリーの\nイビルウィング白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Evil Wings White\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803392",
 		"jp_text": "イビルウィング黒",
 		"tr_text": "Evil Wings Black",
 		"jp_explain": "使用すると、新しいアクセサリーの\nイビルウィング黒が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Evil Wings Black\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803393",
 		"jp_text": "ふわもこ羽マフラーＢ",
 		"tr_text": "Fluffy Wings Scarf B",
 		"jp_explain": "使用すると、新しいアクセサリーの\nふわもこ羽マフラーＢが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Fluffy Wings Scarf B\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803394",
 		"jp_text": "フォトンバタフライ水",
 		"tr_text": "Photon Butterfly Aqua",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフォトンバタフライ水が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Photon Butterfly Aqua\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803395",
 		"jp_text": "フォトンバタフライ緑",
 		"tr_text": "Photon Butterfly Green",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフォトンバタフライ緑が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Photon Butterfly Green\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803396",
 		"jp_text": "フォトンバタフライ黄",
 		"tr_text": "Photon Butterfly Yellow",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフォトンバタフライ黄が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Photon Butterfly Yellow\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803397",
@@ -22047,7 +22047,7 @@
 		"jp_text": "フレイランツェインカム",
 		"tr_text": "Frei Lanze Intercom",
 		"jp_explain": "使用すると、新しいアクセサリーの\nフレイランツェインカムが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Frei Lanze Intercom\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803404",
@@ -22075,42 +22075,42 @@
 		"jp_text": "グラスラージュゴーグル",
 		"tr_text": "Grassoulage Goggles",
 		"jp_explain": "使用すると、新しいアクセサリーの\nグラスラージュゴーグルが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Grassoulage Goggles\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803408",
 		"jp_text": "カラカズライヤリング",
 		"tr_text": "Karakazura Earrings",
 		"jp_explain": "使用すると、新しいアクセサリーの\nカラカズライヤリングが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Karakazura Earrings\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803409",
 		"jp_text": "ポップ・ラ・フード",
 		"tr_text": "Pop La Hood",
 		"jp_explain": "使用すると、新しいアクセサリーの\nポップ・ラ・フードが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Pop La Hood\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803410",
 		"jp_text": "ポップ・ラ・マフラー",
 		"tr_text": "Pop La Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\nポップ・ラ・マフラーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Pop La Scarf\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803411",
 		"jp_text": "ポップ・ラ・リボン",
 		"tr_text": "Pop La Ribbon",
 		"jp_explain": "使用すると、新しいアクセサリーの\nポップ・ラ・リボンが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Pop La Ribbon\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803412",
 		"jp_text": "メルキュリーナアイマスク",
 		"tr_text": "Mercurina Eye Mask",
 		"jp_explain": "使用すると、新しいアクセサリーの\nメルキュリーナアイマスクが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Mercurina Eye Mask\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803413",
@@ -22201,7 +22201,7 @@
 		"jp_text": "肩乗せステレオ",
 		"tr_text": "Shoulder Stereo",
 		"jp_explain": "使用すると、新しいアクセサリーの\n肩乗せステレオが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Shoulder Stereo\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803426",
@@ -22257,6 +22257,6 @@
 		"jp_text": "ふわもこ羽マフラー",
 		"tr_text": "Fluffy Wings Scarf",
 		"jp_explain": "使用すると、新しいアクセサリーの\nふわもこ羽マフラーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Fluffy Wings Scarf\"\nfor use in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -5931,9 +5931,9 @@
 	{
 		"assign": "380939",
 		"jp_text": "スクナヒメの角",
-		"tr_text": "Sukunahime's Horn",
+		"tr_text": "Sukuna-hime's Horn",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスクナヒメの角が選択可能。",
-		"tr_explain": "Unlocks the accessory\n\"Sukunahime's Horn\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the accessory\n\"Sukuna-hime's Horn\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "380941",
@@ -13120,9 +13120,9 @@
 	{
 		"assign": "3802005",
 		"jp_text": "スクナヒメの角７１１",
-		"tr_text": "Sukunahime's Horn 711",
+		"tr_text": "Sukuna-hime's Horn 711",
 		"jp_explain": "使用すると、新しいアクセサリーの\nスクナヒメの角７１１が選択可能。",
-		"tr_explain": "Unlocks the accessory\n\"Sukunahime's Horn 711\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the accessory\n\"Sukuna-hime's Horn 711\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3802006",

--- a/json/Item_Stack_BodyPaint.txt
+++ b/json/Item_Stack_BodyPaint.txt
@@ -3035,118 +3035,118 @@
 		"jp_text": "シンプルチョーカーＭ　Ａ",
 		"tr_text": "Simple Choker M A",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＭ　Ａが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Simple Choker M A\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290469",
 		"jp_text": "シンプルチョーカーＭ　Ｂ",
 		"tr_text": "Simple Choker M B",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＭ　Ｂが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Simple Choker M B\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290470",
 		"jp_text": "シンプルチョーカーＭ　Ｃ",
 		"tr_text": "Simple Choker M C",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＭ　Ｃが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Simple Choker M C\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290471",
 		"jp_text": "シンプルチョーカーＭ　Ｄ",
 		"tr_text": "Simple Choker M D",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＭ　Ｄが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Simple Choker M D\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290472",
 		"jp_text": "シンプルチョーカーＦ　Ａ",
 		"tr_text": "Simple Choker F A",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＦ　Ａが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Simple Choker F A\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290473",
 		"jp_text": "シンプルチョーカーＦ　Ｂ",
 		"tr_text": "Simple Choker F B",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＦ　Ｂが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Simple Choker F B\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290474",
 		"jp_text": "シンプルチョーカーＦ　Ｃ",
 		"tr_text": "Simple Choker F C",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＦ　Ｃが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Simple Choker F C\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290475",
 		"jp_text": "シンプルチョーカーＦ　Ｄ",
 		"tr_text": "Simple Choker F D",
 		"jp_explain": "チケットを使用すると、ボディペイント\nシンプルチョーカーＦ　Ｄが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Simple Choker F D\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290476",
 		"jp_text": "エレメンタルボディ炎Ｍ",
 		"tr_text": "Elemental Body Fire M",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ炎Ｍが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Elemental Body Fire M\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290477",
 		"jp_text": "エレメンタルボディ水Ｍ",
 		"tr_text": "Elemental Body Ice M",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ水Ｍが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Elemental Body Ice M\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290478",
 		"jp_text": "エレメンタルボディ風Ｍ",
 		"tr_text": "Elemental Body Wind M",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ風Ｍが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Elemental Body Wind M\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290479",
 		"jp_text": "エレメンタルボディ炎Ｆ",
 		"tr_text": "Elemental Body Fire F",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ炎Ｆが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Elemental Body Fire F\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290480",
 		"jp_text": "エレメンタルボディ水Ｆ",
 		"tr_text": "Elemental Body Ice F",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ水Ｆが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Elemental Body Ice F\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290481",
 		"jp_text": "エレメンタルボディ風Ｆ",
 		"tr_text": "Elemental Body Wind F",
 		"jp_explain": "チケットを使用すると、ボディペイント\nエレメンタルボディ風Ｆが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Elemental Body Wind F\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290482",
 		"jp_text": "しましまスーツＭ",
 		"tr_text": "Striped Suit M",
 		"jp_explain": "チケットを使用すると、ボディペイント\nしましまスーツＭが選択可能。\n男性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the male-only body paint\n\"Striped Suit M\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290483",
 		"jp_text": "しましまスーツＦ",
 		"tr_text": "Striped Suit F",
 		"jp_explain": "チケットを使用すると、ボディペイント\nしましまスーツＦが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Striped Suit F\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3290484",
 		"jp_text": "グラスラージュタイツ",
 		"tr_text": "Grassoulage Tights",
 		"jp_explain": "チケットを使用すると、ボディペイント\nグラスラージュタイツが選択可能。\n女性のみ使用可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the female-only body paint\n\"Grassoulage Tights\"\nfor use in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_EyeBrow.txt
+++ b/json/Item_Stack_EyeBrow.txt
@@ -128,9 +128,9 @@
 	{
 		"assign": "327018",
 		"jp_text": "スクナヒメまゆ",
-		"tr_text": "Sukuna-hime Eyebrows",
+		"tr_text": "Sukunahime Eyebrows",
 		"jp_explain": "チケットを使用すると、まゆ\nスクナヒメまゆが選択可能。",
-		"tr_explain": "Unlocks the eyebrows\n\"Sukuna-hime Eyebrows\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the eyebrows\n\"Sukunahime Eyebrows\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "327019",

--- a/json/Item_Stack_EyeBrow.txt
+++ b/json/Item_Stack_EyeBrow.txt
@@ -128,9 +128,9 @@
 	{
 		"assign": "327018",
 		"jp_text": "スクナヒメまゆ",
-		"tr_text": "Sukunahime Eyebrows",
+		"tr_text": "Sukuna-hime Eyebrows",
 		"jp_explain": "チケットを使用すると、まゆ\nスクナヒメまゆが選択可能。",
-		"tr_explain": "Unlocks the eyebrows\n\"Sukunahime Eyebrows\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the eyebrows\n\"Sukuna-hime Eyebrows\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "327019",

--- a/json/Item_Stack_FacePaint.txt
+++ b/json/Item_Stack_FacePaint.txt
@@ -632,9 +632,9 @@
 	{
 		"assign": "325091",
 		"jp_text": "スクナヒメメイク",
-		"tr_text": "Sukunahime Makeup",
+		"tr_text": "Sukuna-hime Makeup",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nスクナヒメメイクが選択可能。",
-		"tr_explain": "Unlocks the makeup\n\"Sukunahime Makeup\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the makeup\n\"Sukuna-hime Makeup\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "325092",

--- a/json/Item_Stack_FacePaint.txt
+++ b/json/Item_Stack_FacePaint.txt
@@ -1369,48 +1369,48 @@
 		"jp_text": "エレメンタルフェイス炎",
 		"tr_text": "Elemental Face Fire",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nエレメンタルフェイス炎が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Elemental Face Fire\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250213",
 		"jp_text": "エレメンタルフェイス水",
 		"tr_text": "Elemental Face Ice",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nエレメンタルフェイス水が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Elemental Face Ice\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250214",
 		"jp_text": "エレメンタルフェイス風",
 		"tr_text": "Elemental Face Wind",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nエレメンタルフェイス風が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Elemental Face Wind\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250215",
 		"jp_text": "おでこメイク緑",
 		"tr_text": "Forehead Makeup Green",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nおでこメイク緑が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Forehead Makeup Green\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250216",
 		"jp_text": "おでこメイク白",
 		"tr_text": "Forehead Makeup White",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nおでこメイク白が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Forehead Makeup White\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250217",
 		"jp_text": "おでこメイク赤",
 		"tr_text": "Forehead Makeup Red",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nおでこメイク赤が選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Forehead Makeup Red\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3250218",
 		"jp_text": "シウニンシキテ",
 		"tr_text": "Siwnin Shikite",
 		"jp_explain": "チケットを使用すると、新しいメイクの\nシウニンシキテが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the makeup\n\"Siwnin Shikite\"\nfor use in the Beauty Salon."
 	}
 ]

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -1327,7 +1327,7 @@
 		"jp_text": "スクナヒメポニー",
 		"tr_text": "Sukuna-hime Pony",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nスクナヒメポニーが選択可能。\n女性のみ使用可能。",
-		"tr_explain": "Unlocks the female-only hairstyle\n\"Sukunahime Pony\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the female-only hairstyle\n\"Sukuna-hime Pony\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3150217",

--- a/json/Item_Stack_Hairstyle.txt
+++ b/json/Item_Stack_Hairstyle.txt
@@ -4078,28 +4078,28 @@
 		"jp_text": "カラカズラヘアー",
 		"tr_text": "Karakazura Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nカラカズラヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the hairstyle\n\"Karakazura Hair\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3150690",
 		"jp_text": "トイフェルノンネフード",
 		"tr_text": "Teufel Nonne Hood",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nトイフェルノンネフードが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the hairstyle\n\"Teufel Nonne Hood\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3150691",
 		"jp_text": "フレイランツェヘアー",
 		"tr_text": "Frei Lanze Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nフレイランツェヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the hairstyle\n\"Frei Lanze Hair\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3150692",
 		"jp_text": "ポップ・ラ・ヘアー",
 		"tr_text": "Pop La Hair",
 		"jp_explain": "チケットを使用すると、新しい髪型の\nポップ・ラ・ヘアーが選択可能。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the hairstyle\n\"Pop La Hair\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3150694",

--- a/json/Item_Stack_ItemBag.txt
+++ b/json/Item_Stack_ItemBag.txt
@@ -5595,44 +5595,44 @@
 	{
 		"assign": "3300996",
 		"jp_text": "少名比売神衣セット",
-		"tr_text": "Sukunahime Divine Wear Set",
+		"tr_text": "Sukuna-hime Divine Wear Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Wear]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Wear]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "3300997",
 		"jp_text": "少名比売神衣　影セット",
-		"tr_text": "Sukunahime Divine Shadow Set",
+		"tr_text": "Sukuna-hime D. Shadow Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　影」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Shadow]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Shadow]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "3300998",
 		"jp_text": "少名比売神衣　紅セット",
-		"tr_text": "Sukunahime Divine Crimson Set",
+		"tr_text": "Sukuna-hime D. Crimson Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　紅」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Crimson]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Crimson]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "3300999",
 		"jp_text": "少名比売神衣　海セット",
-		"tr_text": "Sukunahime Divine Sea Set",
+		"tr_text": "Sukuna-hime Divine Sea Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　海」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Sea]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Sea]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33001000",
 		"jp_text": "少名比売神衣　月セット",
-		"tr_text": "Sukunahime Divine Moon Set",
+		"tr_text": "Sukuna-hime Divine Moon Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　月」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Moon]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Moon]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33001001",
 		"jp_text": "少名比売神衣　鋼セット",
-		"tr_text": "Sukunahime Divine Steel Set",
+		"tr_text": "Sukuna-hime Divine Steel Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　鋼」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Steel]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Steel]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33001002",
@@ -5728,9 +5728,9 @@
 	{
 		"assign": "33001015",
 		"jp_text": "スクナヒメセット",
-		"tr_text": "Sukunahime Set",
+		"tr_text": "Sukuna-hime Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「神飾扇」「スクナヒメの角」\n「スクナヒメメイク」",
-		"tr_explain": "Use to receive the following items:\n[Divine Decorative Fans]\n[Sukuna-hime's Horn] [Sukunahime\nMakeup]"
+		"tr_explain": "Use to receive the following items:\n[Divine Decorative Fans]\n[Sukuna-hime's Horn] [Sukuna-hime\nMakeup]"
 	},
 	{
 		"assign": "33001016",
@@ -14310,9 +14310,9 @@
 	{
 		"assign": "33002245",
 		"jp_text": "少名比売神衣セットＢ",
-		"tr_text": "Sukunahime Divine Wear Set B",
+		"tr_text": "Sukuna-hime Divine Wear Set B",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣」\n「神飾扇」\n「スクナヒメの角」他一種",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Wear]\n[Divine Decorative Fans]\n[Sukuna-hime's Horn] +1 other"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Wear]\n[Divine Decorative Fans]\n[Sukuna-hime's Horn] +1 other"
 	},
 	{
 		"assign": "33002246",
@@ -23200,23 +23200,23 @@
 	{
 		"assign": "33003521",
 		"jp_text": "☆少名比売神衣　銀セット",
-		"tr_text": "☆Sukunahime Wear Silver Set",
+		"tr_text": "☆Sukuna-hime Divine Silver Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　銀」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Wear Silver]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Silver]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33003522",
 		"jp_text": "☆少名比売神衣　玄セット",
-		"tr_text": "☆Sukunahime Wear Mysterious Set",
+		"tr_text": "☆Sukuna-hime D. Myst. Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　玄」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Wear Mysterious]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Mysterious]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33003523",
 		"jp_text": "☆少名比売神衣　茜セット",
-		"tr_text": "☆Sukunahime Wear Madder Set",
+		"tr_text": "☆Sukuna-hime D. Madder Set",
 		"jp_explain": "以下のアイテムを獲得する。\n「少名比売神衣　茜」\n「スクナヒメポニー」",
-		"tr_explain": "Use to receive the following items:\n[Sukunahime Divine Wear Madder]\n[Sukuna-hime Pony]"
+		"tr_explain": "Use to receive the following items:\n[Sukuna-hime Divine Madder]\n[Sukuna-hime Pony]"
 	},
 	{
 		"assign": "33003524",

--- a/json/Item_Stack_LobbyAction.txt
+++ b/json/Item_Stack_LobbyAction.txt
@@ -2825,7 +2825,7 @@
 		"jp_text": "395「術をかける」",
 		"tr_text": "395 \"Magic Spell\"",
 		"jp_explain": "ロビアク『術をかける』\nを全キャラクターで使用可能になる。\n対応機能：リアクション",
-		"tr_explain": "Unlocks the new lobby action\n\"Magic Spell\".\nUse action buttons for extra actions."
+		"tr_explain": "Unlocks the new lobby action\n\"Magic Spell\".\nReaction has extra actions."
 	},
 	{
 		"assign": "3230410",
@@ -2916,14 +2916,14 @@
 		"jp_text": "411「いないいないばぁ」",
 		"tr_text": "411 \"Peek-a-Boo\"",
 		"jp_explain": "ロビアク『いないいないばぁ』\nを全キャラクターで使用可能になる。\n対応機能：ボタン派生",
-		"tr_explain": "Unlocks the new lobby action\n\"Peek-a-Boo\"."
+		"tr_explain": "Unlocks the new lobby action\n\"Peek-a-Boo\".\nUse action buttons for extra actions."
 	},
 	{
 		"assign": "3230426",
 		"jp_text": "412「ハイタッチ」",
 		"tr_text": "412 \"High Five\"",
 		"jp_explain": "ロビアク『ハイタッチ』\nを全キャラクターで使用可能になる。\n対応機能：リアクション",
-		"tr_explain": "Unlocks the new lobby action\n\"High Five\"."
+		"tr_explain": "Unlocks the new lobby action\n\"High Five\".\nReaction has extra actions."
 	},
 	{
 		"assign": "3230436",

--- a/json/Item_Stack_Roomgoods.txt
+++ b/json/Item_Stack_Roomgoods.txt
@@ -6701,9 +6701,9 @@
 	{
 		"assign": "3501055",
 		"jp_text": "スクナヒメポスター",
-		"tr_text": "Sukunahime Poster",
+		"tr_text": "Sukuna-hime Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nスクナヒメのグラビアポスター。",
-		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nSukunahime."
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nSukuna-hime."
 	},
 	{
 		"assign": "3501056",

--- a/json/Item_Stack_Roomgoods.txt
+++ b/json/Item_Stack_Roomgoods.txt
@@ -221,7 +221,7 @@
 		"jp_text": "ＤＪブース",
 		"tr_text": "DJ Booth",
 		"jp_explain": "クラブの雰囲気を再現する特殊な家具。\n室内のＢＧＭを、自分で所有する\nＢＧＭから自由に変更することが可能。",
-		"tr_explain": ""
+		"tr_explain": "Special furniture designed to create\na night club-like atmosphere. Can be\nused to change your room's BGM\nto any BGM you have registered."
 	},
 	{
 		"assign": "35037",
@@ -256,84 +256,84 @@
 		"jp_text": "グランドピアノ",
 		"tr_text": "Grand Piano",
 		"jp_explain": "マイルームに設置可能な鍵盤楽器。\n華麗な音色が部屋中に響き渡る。\n演奏曲「Our Fighting」",
-		"tr_explain": "A keyboard instrument for My Room.\nPlaying it causes brilliant music to\necho all over the room."
+		"tr_explain": "A keyboard instrument for My Room.\nPlaying it causes brilliant music to\necho all over the room.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35052",
 		"jp_text": "リズムギター",
 		"tr_text": "Rhythm Guitar",
 		"jp_explain": "マイルームに設置可能な弦楽器。\n温かな音色が好評だが値の張る一品。\n演奏曲「Our Fighting」",
-		"tr_explain": "A stringed instrument for My Room.\nA very expensive custom-built guitar\nthat outputs a heart warming sound."
+		"tr_explain": "A stringed instrument for My Room.\nA very expensive custom-built guitar\nthat outputs a heart warming sound.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35053",
 		"jp_text": "サイドギター",
 		"tr_text": "Side Guitar",
 		"jp_explain": "マイルームに設置可能な弦楽器。\nボディのＶ字形状が特徴的な一品。\n演奏曲「Our Fighting」",
-		"tr_explain": "A stringed instrument for My Room.\nIts V-shaped body may look like an\nunusual design, but it is liked by\nmany."
+		"tr_explain": "A stringed instrument for My Room.\nDistinctive for its V-shaped body.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35054",
 		"jp_text": "ベース",
 		"tr_text": "Bass",
 		"jp_explain": "マイルームに設置可能な弦楽器。\n場所を選ばず演奏を楽しめる一品。\n演奏曲「Our Fighting」",
-		"tr_explain": "A stringed instrument for My Room.\nA light guitar bought cheap from a\nWeekly Sale. Comes with its own\npower supply."
+		"tr_explain": "A stringed instrument for My Room.\nSelf-powered, letting you put on a\nshow anywhere you like.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35055",
 		"jp_text": "ドラムセット",
 		"tr_text": "Drum Set",
 		"jp_explain": "マイルームに設置可能な打楽器。\n腹の底に響き渡る重低音を轟かせる。\n演奏曲「Our Fighting」",
-		"tr_explain": "A set of percussion instruments for\nMy Room. The high performance and\nechoing sound of the bass can make\nanyone shake."
+		"tr_explain": "A set of percussion instruments for\nMy Room. The sound of the bass\nechoes in the pit of your stomach.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35056",
 		"jp_text": "ヴォーカルマイク",
 		"tr_text": "Vocal Mic",
 		"jp_explain": "マイルームに設置可能な音響機器。\n美しい声を響かせるマイク。\n演奏曲「Our Fighting」",
-		"tr_explain": "Audio equipment for My Room.\nMicrophone that enhances your voice.\nYou can use it to show off your\ntalent!"
+		"tr_explain": "Audio equipment for My Room.\nMicrophone that enhances your voice.\nUse it to show off your talent!\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35057",
 		"jp_text": "ヴァイオリン",
 		"tr_text": "Violin",
 		"jp_explain": "マイルームに設置可能な弦楽器。\n美しい高音域を弾く事ができる。\n演奏曲「Our Fighting」",
-		"tr_explain": "A stringed instrument for My Room.\nIt can play fascinating music for\npeople to hear."
+		"tr_explain": "A stringed instrument for My Room.\nIt can play fascinating music for\npeople to hear.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35058",
 		"jp_text": "コントラバス",
 		"tr_text": "Contrabass",
 		"jp_explain": "マイルームに設置可能な弦楽器。\n身体にしみる低音域を弾く事ができる。\n演奏曲「Our Fighting」",
-		"tr_explain": "A stringed instrument for My Room.\nAllows you to play low ranged sound\nthat can shake the hearts of\nlisteners."
+		"tr_explain": "A stringed instrument for My Room.\nAllows you to play a sound so deep\nthat you feel it in your entire body.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35059",
 		"jp_text": "フルート",
 		"tr_text": "Flute",
 		"jp_explain": "マイルームに設置可能な管楽器。\nかつて有名な奏者が所持していた一品。\n演奏曲「Our Fighting」",
-		"tr_explain": "A wind instrument for My Room.\nAn instrument said to have belonged\nto a famous musician."
+		"tr_explain": "A wind instrument for My Room.\nAn instrument said to have belonged\nto a famous musician.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35060",
 		"jp_text": "トランペット",
 		"tr_text": "Trumpet",
 		"jp_explain": "マイルームに設置可能な管楽器。\n進軍の際、吹き鳴らされたという一品。\n演奏曲「Our Fighting」",
-		"tr_explain": "A wind instrument for My Room.\nLong before even ARKS was formed,\nthis instrument was used during\nmarches."
+		"tr_explain": "A wind instrument for My Room.\nLong before ARKS was formed, this\ninstrument was used during marches.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35061",
 		"jp_text": "ティンパニ",
 		"tr_text": "Timpani",
 		"jp_explain": "マイルームに設置可能な打楽器。\n手軽に勇壮な音色を打ち鳴らせる。\n演奏曲「Our Fighting」",
-		"tr_explain": "A set of percussion instruments for\nMy Room.\nAn easy to play instrument, even for\nbeginners."
+		"tr_explain": "A set of percussion instruments for\nMy Room. An easy to play instrument,\neven for beginners.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35062",
 		"jp_text": "トライアングル",
 		"tr_text": "Triangle",
 		"jp_explain": "マイルームに設置可能な打楽器。\n初心者には扱いが難しいと噂される。\n演奏曲「Our Fighting」",
-		"tr_explain": "A percussion instrument for\nMy Room. Although rumored to be\nvery difficult for beginners, it's still\na mystery how hard it really is."
+		"tr_explain": "A percussion instrument for My Room.\nRumored to be very difficult for\nbeginners to handle.\nPlays the song \"Our Fighting\"."
 	},
 	{
 		"assign": "35063",
@@ -347,7 +347,7 @@
 		"jp_text": "グッジョブカウンター",
 		"tr_text": "Good Job Counter",
 		"jp_explain": "マイルームで利用可能な電子看板。\n来客に向けてメッセージを自動表示。\nメッセージを見た客は評価を送信可能。",
-		"tr_explain": "A digital signage for My Room.\nAutomatically displays a message to\nnearby visitors. Can also be used to\nsend you a Good Job."
+		"tr_explain": "Digital signage for My Room.\nAutomatically displays a message to\nnearby visitors. Can also be used to\nsend you a Good Job."
 	},
 	{
 		"assign": "35069",
@@ -410,7 +410,7 @@
 		"jp_text": "パスワード・ボックス",
 		"tr_text": "Password Box",
 		"jp_explain": "マイルームに設置可能な装飾品。\n貴重品を転送することなくリアルに\n保管するために作られた前時代の箱。",
-		"tr_explain": ""
+		"tr_explain": "A decoration for My Room.\nThe real thing was once used to\nstore valuable items."
 	},
 	{
 		"assign": "35081",
@@ -655,14 +655,14 @@
 		"jp_text": "マークⅢ",
 		"tr_text": "Mark III Console",
 		"jp_explain": "第三世代とも呼ばれる家庭用ゲーム機。\n高性能で拡張性があり、周辺機器も多く\nマニアには熱狂的に受け入れられた。",
-		"tr_explain": ""
+		"tr_explain": "A third-generation home video game\nconsole. Its most dedicated fans would\ncollect peripherals to augment its\nalready impressive performance."
 	},
 	{
 		"assign": "350116",
 		"jp_text": "マスターシステム",
 		"tr_text": "Master System Console",
 		"jp_explain": "マークⅢ後継８ビット家庭用ゲーム機。\n発売当時は連射機能やＦＭ音源が斬新で\nユーザーの支持を集めた。",
-		"tr_explain": "Successor to the Mark III 8-bit\nvideogame console. Known for its FM\nsound chip and rapid fire unit during\nrelease."
+		"tr_explain": "Successor to the Mark III 8-bit game\nconsole. Launched with an innovative\nFM sound chip and rapid-fire feature,\nwhich earned it a wide fanbase."
 	},
 	{
 		"assign": "350117",
@@ -697,7 +697,7 @@
 		"jp_text": "コタツ・ダイ",
 		"tr_text": "Kotatsu Dai",
 		"jp_explain": "マイルームに設置可能な暖房器具。\n震える寒さにさらされた後はすぐに\n駆け込み、心も体もぽかぽかに。",
-		"tr_explain": ""
+		"tr_explain": "Heating equipment for My Room.\nWhen you've just come in from the\ncold, run to the kotatsu, and feel its\nwarmth fill your entire body."
 	},
 	{
 		"assign": "350122",
@@ -746,14 +746,14 @@
 		"jp_text": "ブラックチェア",
 		"tr_text": "Black Chair",
 		"jp_explain": "マイルーム配置用の一人掛け椅子。\nシックな黒に渋めのデザインという\n玄人向けの調度品。",
-		"tr_explain": ""
+		"tr_explain": "A single chair for My Room.\nA chic, bitter-black design for\nprofessional use."
 	},
 	{
 		"assign": "350129",
 		"jp_text": "ストライプチェア",
 		"tr_text": "Striped Chair",
 		"jp_explain": "マイルーム配置用の一人掛け椅子。\nしましまのストライプ柄が特徴的な\nかわいらしい調度品。",
-		"tr_explain": "A single chair for My Room. A\npretty furniture with a characteristic\nstriped design."
+		"tr_explain": "A single chair for My Room.\nA pretty item with a characteristic\nstriped design."
 	},
 	{
 		"assign": "350130",
@@ -3028,7 +3028,7 @@
 		"jp_text": "囲炉裏",
 		"tr_text": "Sunken Hearth",
 		"jp_explain": "マイルームに設置可能な暖房器具。\nとある地域の伝統的な装置で、暖房の他\n煮炊きなどの調理にも利用された。",
-		"tr_explain": ""
+		"tr_explain": "Heating equipment for My Room.\nA traditional setup in certain regions,\nused for both heating and cooking."
 	},
 	{
 		"assign": "350472",
@@ -4708,7 +4708,7 @@
 		"jp_text": "Ｉ・カプリッチオポスター",
 		"tr_text": "Idol Capriccio Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nクーナの水着グラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA swimsuit gravure poster featuring\nQuna."
 	},
 	{
 		"assign": "350765",
@@ -6654,28 +6654,28 @@
 		"jp_text": "クーナポスター",
 		"tr_text": "Quna Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nクーナのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Quna."
 	},
 	{
 		"assign": "3501049",
 		"jp_text": "マトイポスター",
 		"tr_text": "Matoi Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nマトイのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Matoi."
 	},
 	{
 		"assign": "3501050",
 		"jp_text": "リサポスター",
 		"tr_text": "Lisa Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nリサのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Lisa."
 	},
 	{
 		"assign": "3501051",
 		"jp_text": "エコーポスター",
 		"tr_text": "Echo Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nエコーのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Echo."
 	},
 	{
 		"assign": "3501052",
@@ -6696,42 +6696,42 @@
 		"jp_text": "イオポスター",
 		"tr_text": "Io Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nイオのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Io."
 	},
 	{
 		"assign": "3501055",
 		"jp_text": "スクナヒメポスター",
 		"tr_text": "Sukunahime Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nスクナヒメのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nSukunahime." 
 	},
 	{
 		"assign": "3501056",
 		"jp_text": "イデアＣマトイポスター",
 		"tr_text": "Edea C Matoi Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nマトイのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Matoi."
 	},
 	{
 		"assign": "3501057",
 		"jp_text": "ウタヒメクーナポスター",
 		"tr_text": "Utahime Quna Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nクーナのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Quna."
 	},
 	{
 		"assign": "3501058",
 		"jp_text": "ヒロインズポスター",
 		"tr_text": "Heroines Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nヒロインたちのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring multiple\nheroines of PSO2."
 	},
 	{
 		"assign": "3501059",
 		"jp_text": "ヒロインズポスターＢ",
 		"tr_text": "Heroine Poster B",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nヒロインたちのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring multiple\nheroines of PSO2."
 	},
 	{
 		"assign": "3501060",
@@ -7529,7 +7529,7 @@
 		"jp_text": "ビンテージ火鉢",
 		"tr_text": "Vintage Hibachi",
 		"jp_explain": "マイルームに設置可能な暖房器具。\n灰を入れた中に炭火を置いて使う。\n湯茶を沸かすのにも用いられる。",
-		"tr_explain": ""
+		"tr_explain": "Heating equipment for My Room.\nBurns charcoal, which sits on a layer\nof ash. Can also be used to boil tea."
 	},
 	{
 		"assign": "3501199",
@@ -7746,14 +7746,14 @@
 		"jp_text": "丸型ストーブ",
 		"tr_text": "Round Stove",
 		"jp_explain": "マイルームに設置可能な暖房器具。\n円柱型の古き良き時代のストーブ。\n温かみのあるデザインが懐かしい。",
-		"tr_explain": ""
+		"tr_explain": "Heating equipment for My Room.\nA good old-fashioned cylindrical stove.\nA nostalgic design that fills one with\nwarmth."
 	},
 	{
 		"assign": "3501230",
 		"jp_text": "オイルヒーター",
 		"tr_text": "Oil Heater",
 		"jp_explain": "マイルームに設置可能な暖房器具。\n部屋が暖まるまで時間はかかるが\n燃焼しないため、とても安全。",
-		"tr_explain": ""
+		"tr_explain": "Heating equipment for My Room.\nTakes a little while to warm up the\nroom, but is very safe, due to not\nhaving any exposed flames."
 	},
 	{
 		"assign": "3501231",
@@ -8117,7 +8117,7 @@
 		"jp_text": "ＰＳＯ２ｅｓポスター",
 		"tr_text": "PSO2es Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\n『ＰＳＯ２ｅｓ』の大型ポスター。\n「リーダー、一緒に頑張りましょう！」",
-		"tr_explain": "A decoration for my room.\nLarge Poster of PSO2es.\n\"Leader, Let's do our best!\""
+		"tr_explain": "Wall decoration for My Room.\nLarge Poster of PSO2es.\n\"Leader, let's do our best!\""
 	},
 	{
 		"assign": "3501285",
@@ -8537,7 +8537,7 @@
 		"jp_text": "イオ水着ポスター",
 		"tr_text": "Io Swimsuit Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nイオの水着グラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA swimsuit gravure poster featuring\nIo."
 	},
 	{
 		"assign": "3501349",
@@ -8740,35 +8740,35 @@
 		"jp_text": "アイカポスター",
 		"tr_text": "Aika Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nアイカのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Aika."
 	},
 	{
 		"assign": "3501380",
 		"jp_text": "ナギサポスター",
 		"tr_text": "Nagisa Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nナギサのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Nagisa."
 	},
 	{
 		"assign": "3501381",
 		"jp_text": "リコポスター",
 		"tr_text": "Rico Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nリコのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Rico."
 	},
 	{
 		"assign": "3501382",
 		"jp_text": "イノセントＣマトイポスター",
 		"tr_text": "Innocent C. Matoi Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nマトイのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Matoi."
 	},
 	{
 		"assign": "3501383",
 		"jp_text": "ヒロインズポスターＣ",
 		"tr_text": "Heroines Poster C",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nヒロインたちのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring multiple\nheroines of Phantasy Star."
 	},
 	{
 		"assign": "3501384",
@@ -8992,7 +8992,7 @@
 		"jp_text": "NieR:Automataポスター",
 		"tr_text": "NieR:Automata Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\n自動歩兵人形「ヨルハ」部隊を描いた\n大判ポスター。",
-		"tr_explain": "A decorative wall item for My Room.\nLarge poster of \"YoRHa No. 2 Model\nB\" combat android."
+		"tr_explain": "Wall decoration for My Room.\nA large poster depicting the \""YoRHa\""\ncombat android unit."
 	},
 	{
 		"assign": "3501418",
@@ -9692,7 +9692,7 @@
 		"jp_text": "アヴェンジャーポスター",
 		"tr_text": "Avenger Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nアヴェンジャーのウェポノイドの\nグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nAvenger's Weaponoid."
 	},
 	{
 		"assign": "3501562",
@@ -9706,7 +9706,7 @@
 		"jp_text": "ブルージーＲポスター",
 		"tr_text": "Bluesy R Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nブルージーレクイエムの\nウェポノイドのグラビアポスター。",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Bluesy\nRequiem's Weaponoid."
 	},
 	{
 		"assign": "3501564",
@@ -9979,14 +9979,14 @@
 		"jp_text": "ジェネポスター",
 		"tr_text": "Gene Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nジェネのグラビアポスター。\n「気合を入れてみましたっ！」",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Gene.\n\"Let's give it everything we've got!\""
 	},
 	{
 		"assign": "3501603",
 		"jp_text": "デュナポスター",
 		"tr_text": "Duna Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nデュナのグラビアポスター。\n「でゅな、じぇねのそばにいる」",
-		"tr_explain": ""
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring Duna.\n\"Duna will stay by Gene's side.\""
 	},
 	{
 		"assign": "3501604",

--- a/json/Item_Stack_Roomgoods.txt
+++ b/json/Item_Stack_Roomgoods.txt
@@ -8992,7 +8992,7 @@
 		"jp_text": "NieR:Automataポスター",
 		"tr_text": "NieR:Automata Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\n自動歩兵人形「ヨルハ」部隊を描いた\n大判ポスター。",
-		"tr_explain": "Wall decoration for My Room.\nA large poster depicting the \""YoRHa\""\ncombat android unit."
+		"tr_explain": "Wall decoration for My Room.\nA large poster depicting the \"YoRHa\"\ncombat android unit."
 	},
 	{
 		"assign": "3501418",

--- a/json/Item_Stack_Roomgoods.txt
+++ b/json/Item_Stack_Roomgoods.txt
@@ -6703,7 +6703,7 @@
 		"jp_text": "スクナヒメポスター",
 		"tr_text": "Sukunahime Poster",
 		"jp_explain": "マイルームの壁に設置する装飾品。\nスクナヒメのグラビアポスター。",
-		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nSukunahime." 
+		"tr_explain": "Wall decoration for My Room.\nA gravure poster featuring\nSukunahime."
 	},
 	{
 		"assign": "3501056",

--- a/json/Item_Stack_Tool.txt
+++ b/json/Item_Stack_Tool.txt
@@ -408,7 +408,7 @@
 	{
 		"assign": "37070",
 		"jp_text": "レオンティーナ証書",
-		"tr_text": "Leontina Certificates",
+		"tr_text": "Leontina Certificate",
 		"jp_explain": "条件を達成した者に与えられる証書。\nゲートエリアのレオンティーナに渡すと\n強力な★13武器などを入手できる。",
 		"tr_explain": ""
 	}

--- a/json/Item_Stack_Voice.txt
+++ b/json/Item_Stack_Voice.txt
@@ -5625,7 +5625,7 @@
 		"jp_text": "男性共通オフィエルボイス",
 		"tr_text": "Male Ophiel Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n男性のみ使用可能。\nＣＶ子安 武人",
-		"tr_explain": "llows a new voice to be selected.\nMale characters only (all races).\nCV: Takehito Koyasu"
+		"tr_explain": "Allows a new voice to be selected.\nMale characters only (all races).\nCV: Takehito Koyasu"
 	},
 	{
 		"assign": "31801185",

--- a/json/Item_Stack_Voice.txt
+++ b/json/Item_Stack_Voice.txt
@@ -2354,7 +2354,7 @@
 	{
 		"assign": "3180389",
 		"jp_text": "女性共通スクナヒメボイス",
-		"tr_text": "Female Sukunahime Voice",
+		"tr_text": "Female Sukuna-hime Voice",
 		"jp_explain": "使用すると、新しいボイスが選択可能。\n女性のみ使用可能。\nＣＶ堀江 由衣",
 		"tr_explain": "Allows a new voice to be selected.\nFemale characters only (all races).\nCV: Yui Horie"
 	},

--- a/json/Name_Chip_SPArksName.txt
+++ b/json/Name_Chip_SPArksName.txt
@@ -392,12 +392,12 @@
 	{
 		"assign": "97",
 		"jp_text": "スクナヒメ",
-		"tr_text": "Sukunahime"
+		"tr_text": "Sukuna-hime"
 	},
 	{
 		"assign": "98",
 		"jp_text": "灰の神子 スクナヒメ",
-		"tr_text": "Ash Maiden Sukunahime"
+		"tr_text": "Ash Maiden Sukuna-hime"
 	},
 	{
 		"assign": "99",
@@ -612,12 +612,12 @@
 	{
 		"assign": "141",
 		"jp_text": "スクナヒメ[プレミアム]",
-		"tr_text": "Sukunahime [Premium]"
+		"tr_text": "Sukuna-hime [Premium]"
 	},
 	{
 		"assign": "142",
 		"jp_text": "スクナヒメ[Ｓプレミアム]",
-		"tr_text": "Sukunahime [S Premium]"
+		"tr_text": "Sukuna-hime [S Premium]"
 	},
 	{
 		"assign": "143",
@@ -902,12 +902,12 @@
 	{
 		"assign": "199",
 		"jp_text": "スクナヒメ[ブリリアント]",
-		"tr_text": "Sukunahime [Brilliant]"
+		"tr_text": "Sukuna-hime [Brilliant]"
 	},
 	{
 		"assign": "200",
 		"jp_text": "スクナヒメ[Ｓブリリアント]",
-		"tr_text": "Sukunahime [S Brilliant]"
+		"tr_text": "Sukuna-hime [S Brilliant]"
 	},
 	{
 		"assign": "201",

--- a/json/Name_UICharMake_CostumeName.txt
+++ b/json/Name_UICharMake_CostumeName.txt
@@ -13592,32 +13592,32 @@
 	{
 		"assign": "No12241",
 		"jp_text": "少名比売神衣",
-		"tr_text": "Sukunahime Divine Wear"
+		"tr_text": "Sukuna-hime Divine Wear"
 	},
 	{
 		"assign": "No12242",
 		"jp_text": "少名比売神衣　影",
-		"tr_text": "Sukunahime Divine Shadow"
+		"tr_text": "Sukuna-hime Divine Shadow"
 	},
 	{
 		"assign": "No12243",
 		"jp_text": "少名比売神衣　紅",
-		"tr_text": "Sukunahime Divine Crimson"
+		"tr_text": "Sukuna-hime Divine Crimson"
 	},
 	{
 		"assign": "No12244",
 		"jp_text": "少名比売神衣　海",
-		"tr_text": "Sukunahime Divine Sea"
+		"tr_text": "Sukuna-hime Divine Sea"
 	},
 	{
 		"assign": "No12245",
 		"jp_text": "少名比売神衣　月",
-		"tr_text": "Sukunahime Divine Moon"
+		"tr_text": "Sukuna-hime Divine Moon"
 	},
 	{
 		"assign": "No12246",
 		"jp_text": "少名比売神衣　鋼",
-		"tr_text": "Sukunahime Divine Steel"
+		"tr_text": "Sukuna-hime Divine Steel"
 	},
 	{
 		"assign": "No12620",
@@ -16982,7 +16982,7 @@
 	{
 		"assign": "No15030",
 		"jp_text": "少名比売神衣７１１",
-		"tr_text": "Sukunahime Divine Wear 711"
+		"tr_text": "Sukuna-hime Divine Wear 711"
 	},
 	{
 		"assign": "No14980",
@@ -18237,17 +18237,17 @@
 	{
 		"assign": "No15850",
 		"jp_text": "少名比売神衣　銀",
-		"tr_text": "Sukunahime Divine Wear Silver"
+		"tr_text": "Sukuna-hime Divine Wear Silver"
 	},
 	{
 		"assign": "No15851",
 		"jp_text": "少名比売神衣　玄",
-		"tr_text": "Sukunahime Divine Wear Mysterious"
+		"tr_text": "Sukuna-hime Divine Wear Mysterious"
 	},
 	{
 		"assign": "No15852",
 		"jp_text": "少名比売神衣　茜",
-		"tr_text": "Sukunahime Divine Wear Madder"
+		"tr_text": "Sukuna-hime Divine Wear Madder"
 	},
 	{
 		"assign": "No15860",

--- a/json/UI_QuestTips.txt
+++ b/json/UI_QuestTips.txt
@@ -32,7 +32,7 @@
 	{
 		"assign": "0006",
 		"jp_text": "<color=#f0df60>＜属性値について＞</color>\nバトル時はターゲット中のエネミーに対して\n最も有効な属性が自動で選択されます。\n属性値が高いほど、大ダメージを与えられますよ。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><About Element Values></color>\nWhen you attack, you automatically select\nthe most effective element to use against\nthe enemy you're targeting. The higher its\nvalue, the more damage you can deal."
 	},
 	{
 		"assign": "0007",
@@ -577,7 +577,7 @@
 	{
 		"assign": "0115",
 		"jp_text": "<color=#f0df60>＜緊急クエストへの再出撃＞</color>\n緊急クエストは、一度で目標のエネミーを倒せなくても\n前回のバトルで与えたダメージはそのままで\nクエストに再挑戦できます。\n何度もチャレンジして、目標の撃破をめざしましょう！",
-		"tr_text": "<color=#f0df60><Emergency Quests></color>\nDuring an Emergency Quest, you can rechallenge\nthe same quest until the enemy in\nquestion is defeated or you have ran out of OP.\nLet's do our best!"
+		"tr_text": "<color=#f0df60><Emergency Quests></color>\nDuring an Emergency Quest, you can rechallenge\nthe same quest until the enemy in\nquestion is defeated or you have run out of OP.\nLet's do our best!"
 	},
 	{
 		"assign": "0116",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -11492,7 +11492,7 @@
 	{
 		"assign": "wh_30_00",
 		"jp_text": "緊急クエストに「超級」が登場しました。\n緊急クエストの超級に出発するには「超級トリガー」が必要です。",
-		"tr_text": "\"SuperHard\" is now available\nin Emergency Quests.\nTo do them, you'll need a 'Super-Hard Trigger.'"
+		"tr_text": "\"Super Hard\" is now available\nin Emergency Quests.\nTo do them, you'll need a 'Super Hard Trigger.'"
 	},
 	{
 		"assign": "wh_30_01",
@@ -14322,102 +14322,102 @@
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-0",
 		"jp_text": "実績を{1}個達成 [{0} / {1}]",
-		"tr_text": "Number of Achievements: {1}"
+		"tr_text": " Clear {1} Achievements [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-1",
 		"jp_text": "合計{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat enemy {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-2",
 		"jp_text": "初級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Normal {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-3",
 		"jp_text": "中級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-4",
 		"jp_text": "上級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Very Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-5",
 		"jp_text": "救援を{1}回行う [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Join rescue {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-6",
 		"jp_text": "オペレーションスコア [{0} / {1}]",
-		"tr_text": "Operations Score [{0} / {1}]"
+		"tr_text": " Operations Score [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-8",
 		"jp_text": "タイプCを{1}回発見討伐 [{0} / {1}]",
-		"tr_text": "Encountered Type-C {1}-times [{0} / {1}]"
+		"tr_text": " Defeat Type-C {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-9",
 		"jp_text": "特異種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": "Encountered Exceptional {1}-times [{0} / {1}]"
+		"tr_text": " Defeat Exceptional {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-10",
 		"jp_text": "狂暴種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Violent {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-11",
 		"jp_text": "大型種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Large {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-12",
 		"jp_text": "小型種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Small  {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-17",
 		"jp_text": "未知種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Unknown {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-18",
 		"jp_text": "超級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Super Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-20",
 		"jp_text": "覇級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Extra Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-22",
 		"jp_text": "覇滅種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Superior {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-0",
 		"jp_text": "デイリー実績を{1}個達成 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Clear {1} Daily Achievements [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-2",
 		"jp_text": "初級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Normal {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-3",
 		"jp_text": "中級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-4",
 		"jp_text": "上級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": " Defeat Very Hard {1} times [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_list_00",
@@ -14437,12 +14437,12 @@
 	{
 		"assign": "RaidEvent_Achievement_dialog00",
 		"jp_text": "所持数あふれのため\n受け取れる報酬がありません。\nチップやアイテムなどの整理を行ってください。",
-		"tr_text": "Cannot Redeem Reward(s)\ndue to lack of space.\nPlease make room for chips or items."
+		"tr_text": "Cannot redeem reward(s)\ndue to lack of space.\nPlease make room for chips or items."
 	},
 	{
 		"assign": "RaidEvent_Achievement_dialog01",
 		"jp_text": "以下の報酬を受け取りました。\n<color=#f0df60>※一部、所持数あふれにより\n受け取れなかった報酬があります。</color>",
-		"tr_text": "I received the following rewards:"
+		"tr_text": "Received the following rewards:\n<color=#f0df60>※Some rewards could not be\nreceived due to lack of space.</color>"
 	},
 	{
 		"assign": "RaidEvent_Achievement_dialog02",
@@ -14702,7 +14702,7 @@
 	{
 		"assign": "menu_invite_reward_list_condition",
 		"jp_text": "入手条件： 招待を{1}人成立させる [{0} / {1}]",
-		"tr_text": ""
+		"tr_text": "Condition: Invite {1} people [{0} / {1}]"
 	},
 	{
 		"assign": "menu_invite_reward_list_receive",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -14327,27 +14327,27 @@
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-1",
 		"jp_text": "合計{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat enemy {1} times [{0}/{1}]"
+		"tr_text": " Defeat enemy {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-2",
 		"jp_text": "初級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Normal {1} times [{0}/{1}]"
+		"tr_text": " Defeat Normal {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-3",
 		"jp_text": "中級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-4",
 		"jp_text": "上級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Very Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Very Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-5",
 		"jp_text": "救援を{1}回行う [{0} / {1}]",
-		"tr_text": " Join rescue {1} times [{0}/{1}]"
+		"tr_text": " Join rescue {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-6",
@@ -14357,47 +14357,47 @@
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-8",
 		"jp_text": "タイプCを{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Type-C {1} times [{0}/{1}]"
+		"tr_text": " Defeat Type-C {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-9",
 		"jp_text": "特異種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Exceptional {1} times [{0}/{1}]"
+		"tr_text": " Defeat Exceptional {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-10",
 		"jp_text": "狂暴種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Violent {1} times [{0}/{1}]"
+		"tr_text": " Defeat Violent {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-11",
 		"jp_text": "大型種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Large {1} times [{0}/{1}]"
+		"tr_text": " Defeat Large {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-12",
 		"jp_text": "小型種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Small  {1} times [{0}/{1}]"
+		"tr_text": " Defeat Small {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-17",
 		"jp_text": "未知種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Unknown {1} times [{0}/{1}]"
+		"tr_text": " Defeat Unknown {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-18",
 		"jp_text": "超級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Super Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Super Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-20",
 		"jp_text": "覇級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Extra Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Extra Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_0-1-22",
 		"jp_text": "覇滅種を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Superior {1} times [{0}/{1}]"
+		"tr_text": " Defeat Superior {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-0",
@@ -14407,17 +14407,17 @@
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-2",
 		"jp_text": "初級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Normal {1} times [{0}/{1}]"
+		"tr_text": " Defeat Normal {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-3",
 		"jp_text": "中級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_Text_1-1-4",
 		"jp_text": "上級を{1}回発見討伐 [{0} / {1}]",
-		"tr_text": " Defeat Very Hard {1} times [{0}/{1}]"
+		"tr_text": " Defeat Very Hard {1} time(s) [{0}/{1}]"
 	},
 	{
 		"assign": "RaidEvent_Achievement_list_00",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -13792,7 +13792,7 @@
 	{
 		"assign": "raid_n_hp04",
 		"jp_text": "着々と目標の体力が減りつつあります。\nこの調子でがんばっていきましょう！",
-		"tr_text": "We're steadily lowering it's health.\nKeep up the good work!"
+		"tr_text": "We're steadily lowering its health.\nKeep up the good work!"
 	},
 	{
 		"assign": "raid_n_hp05",

--- a/json/UI_Weaponoid_BondsEffect.txt
+++ b/json/UI_Weaponoid_BondsEffect.txt
@@ -637,41 +637,41 @@
 	{
 		"assign": "126",
 		"jp_text": "発動率アップ",
-		"tr_text": ""
+		"tr_text": "Activ. Rate Up"
 	},
 	{
 		"assign": "124",
 		"jp_text": "効果発動変更",
-		"tr_text": ""
+		"tr_text": "Change Trigger"
 	},
 	{
 		"assign": "128",
 		"jp_text": "ボーナス属性",
-		"tr_text": ""
+		"tr_text": "Bonus Attr."
 	},
 	{
 		"assign": "115",
 		"jp_text": "発動率アップ",
-		"tr_text": ""
+		"tr_text": "Activ. Rate Up"
 	},
 	{
 		"assign": "125",
 		"jp_text": "チップコストダウン",
-		"tr_text": ""
+		"tr_text": "Chip Cost Down"
 	},
 	{
 		"assign": "80012",
 		"jp_text": "パラメータアップ",
-		"tr_text": ""
+		"tr_text": "Parameters Up"
 	},
 	{
 		"assign": "194",
 		"jp_text": "効果発動変更",
-		"tr_text": ""
+		"tr_text": "Change Trigger"
 	},
 	{
 		"assign": "217",
 		"jp_text": "ボーナス属性",
-		"tr_text": ""
+		"tr_text": "Bonus Attr."
 	}
 ]


### PR DESCRIPTION
- Translates all current EQ achievement conditions
- Translates exactly one loading screen tip
- Translates descriptions on all current cosmetics
- Translates some room goods descriptions and corrects a few others
- Translates the head riding rappy chick accessory since I've seen it in the wild
- Translates Sub/Weapons Barrier's description
- Translates missing weaponoid bond effect summaries
- Changes the description of scaling chip effects to be mathematically accurate
- Slightly changes the description of F-frame chip effects to distinguish them from E-frame
- Removes misleading [Chase] tag from counterattack chip effects
- Fixes the coverage check script to correctly consider that lines consisting only of numbers don't need translating
- Various other minor fixes