### PR TITLE
Avoiding name conflicts with Armor Visor

### DIFF
--- a/json/Name_UICharMake_AccessoryName.txt
+++ b/json/Name_UICharMake_AccessoryName.txt
@@ -17562,22 +17562,22 @@
 	{
 		"assign": "No21500",
 		"jp_text": "甲冑バイザー",
-		"tr_text": ""
+		"tr_text": "Armored Visor"
 	},
 	{
 		"assign": "No21501",
 		"jp_text": "甲冑バイザー　金",
-		"tr_text": ""
+		"tr_text": "Armored Visor Gold"
 	},
 	{
 		"assign": "No21502",
 		"jp_text": "甲冑バイザー　銀",
-		"tr_text": ""
+		"tr_text": "Armored Visor Silver"
 	},
 	{
 		"assign": "No21503",
 		"jp_text": "甲冑バイザー　黒",
-		"tr_text": ""
+		"tr_text": "Armored Visor Black"
 	},
 	{
 		"assign": "No21510",


### PR DESCRIPTION
Armor Visor exists in Kanji and Katakana