### PR TITLE
CO items

### DIFF
--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -165,7 +165,7 @@
 		"jp_text": "ヴォル・ドラゴンの牙",
 		"tr_text": "Vol Dragon Fangs",
 		"jp_explain": "ヴォル・ドラゴンから採れた牙。\n非常に硬く加工しづらい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ヴォル・ドラゴンから採れた牙。\n非常に硬く加工しづらい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Fangs from a Vol Dragon.\nVery difficult to process.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33024",
@@ -368,14 +368,14 @@
 		"jp_text": "黒い小さな実",
 		"tr_text": "Small Black Fruit",
 		"jp_explain": "リリーパで採取された実。\n黒い表皮は硬く、割りにくい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "リリーパで採取された実。\n黒い表皮は硬く、割りにくい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A fruit collected on Lillipa. Its black\nskin is tough and difficult to split.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33053",
 		"jp_text": "白い小さな実",
 		"tr_text": "Small White Fruit",
 		"jp_explain": "リリーパで採取された実。\n白い表皮は硬く、食べにくい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "リリーパで採取された実。\n白い表皮は硬く、食べにくい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A fruit collected on Lillipa. Its white\nskin is tough and difficult to eat.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33054",
@@ -396,7 +396,7 @@
 		"jp_text": "岩塩",
 		"tr_text": "Rock Salt",
 		"jp_explain": "リリーパで採取された石。\n塩分が結晶化したもの。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "リリーパで採取された石。\n塩分が結晶化したもの。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A rock collected on Lillipa.\nA crystal of pure salt.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33057",
@@ -445,42 +445,42 @@
 		"jp_text": "ガルフルの肉",
 		"tr_text": "Gulfur Meat",
 		"jp_explain": "ガルフルから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ガルフルから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Gulfur.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33064",
 		"jp_text": "ファンガルフルの肉",
 		"tr_text": "Fangulfur Meat",
 		"jp_explain": "ファンガルフルから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ファンガルフルから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Fangulfur.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33065",
 		"jp_text": "マルモスの肉",
 		"tr_text": "Malmoth Meat",
 		"jp_explain": "マルモスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "マルモスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Malmoth.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33066",
 		"jp_text": "デ・マルモスの肉",
 		"tr_text": "De Malmoth Meat",
 		"jp_explain": "デ・マルモスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "デ・マルモスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a De Malmoth.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33067",
 		"jp_text": "スノウバンサーの肉",
 		"tr_text": "Snow Banther Meat",
 		"jp_explain": "スノウバンサーから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "スノウバンサーから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Snow Banther.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33068",
 		"jp_text": "スノウバンシーの肉",
 		"tr_text": "Snow Banshee Meat",
 		"jp_explain": "スノウバンシーから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "スノウバンシーから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Snow Banshee.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33069",
@@ -576,30 +576,30 @@
 	{
 		"assign": "33082",
 		"jp_text": "フォンガルフの頭角",
-		"tr_text": "Fangulf Horns",
+		"tr_text": "Fangulf Horn",
 		"jp_explain": "フォンガルフの頭部より採れた角。\n\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "フォンガルフの頭部より採れた角。\n\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "Horn taken from a Fangulf's head.\n\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "33083",
 		"jp_text": "ガーディナンのパーツａ",
 		"tr_text": "Guardinane Parts a",
 		"jp_explain": "ガーディナンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>エコー<c>　再受注不可",
-		"tr_explain": "ガーディナンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Echo<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nGuardinane. Its purpose is unknown.\nClient: <c a1ff6d>Echo<c> (one-time order)"
 	},
 	{
 		"assign": "33084",
 		"jp_text": "ガーディンのフレーム",
 		"tr_text": "Guardine Frame",
 		"jp_explain": "ガーディンを構成する部品の一つ。\n強度の割に軽い素材で出来ている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ガーディンを構成する部品の一つ。\n強度の割に軽い素材で出来ている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "One of the parts that make up a\nGuardine. Light, yet strong.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33085",
 		"jp_text": "ギルナスの装甲",
 		"tr_text": "Gilnas Armor",
 		"jp_explain": "ギルナスを構成する部品の一つ。\nギルナスを覆う装甲。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ギルナスを構成する部品の一つ。\nギルナスを覆う装甲。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "One of the parts that make up a\nGilnas. Part of the Gilnas's armor.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33086",
@@ -613,7 +613,7 @@
 		"jp_text": "ガロンゴの背棘",
 		"tr_text": "Garongo Spine",
 		"jp_explain": "ガロンゴの背中から採れた棘。",
-		"tr_explain": "A thorny spine taken from a\nGarongo."
+		"tr_explain": "A thorny spine taken from a Garongo."
 	},
 	{
 		"assign": "33088",
@@ -641,7 +641,7 @@
 		"jp_text": "ファングバンサーの皮",
 		"tr_text": "Fang Banther Hide",
 		"jp_explain": "ファングバンサーから採れた皮。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ファングバンサーから採れた皮。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Leather harvested from a Fang\nBanther.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33092",
@@ -655,14 +655,14 @@
 		"jp_text": "ノーディランサの肉",
 		"tr_text": "Nordiransa Meat",
 		"jp_explain": "ノーディランサから採れた肉。\n\n依頼者：<c a1ff6d>アフィン<c>　再受注不可",
-		"tr_explain": "ノーディランサから採れた肉。\n\nClient: <c a1ff6d>Afin<c> (one-time order)"
+		"tr_explain": "Meat taken from a Nordiransa.\n\nClient: <c a1ff6d>Afin<c> (one-time order)"
 	},
 	{
 		"assign": "33094",
 		"jp_text": "フォードランサの肉",
 		"tr_text": "Fordoransa Meat",
 		"jp_explain": "フォードランサから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "フォードランサから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Fordoransa.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33095",
@@ -683,7 +683,7 @@
 		"jp_text": "キャタドランサの肉",
 		"tr_text": "Caterdransa Meat",
 		"jp_explain": "キャタドランサから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "キャタドランサから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Caterdransa.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33098",
@@ -2594,7 +2594,7 @@
 		"jp_text": "ソル・ディランダールの肉",
 		"tr_text": "Sol Dirandal Meat",
 		"jp_explain": "ソル・ディランダールから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ソル・ディランダールから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Sol Dirandal.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330382",
@@ -2713,7 +2713,7 @@
 		"jp_text": "トルボンの肉",
 		"tr_text": "Torbon Meat",
 		"jp_explain": "トルボンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "トルボンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Torbon.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330400",
@@ -3357,49 +3357,49 @@
 		"jp_text": "タグ・アクルプスの肉",
 		"tr_text": "Tag Aqulupus Meat",
 		"jp_explain": "タグ・アクルプスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "タグ・アクルプスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Tag Aqulupus.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330527",
 		"jp_text": "タロベッコの肉",
 		"tr_text": "Talobecko Meat",
 		"jp_explain": "タロベッコから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "タロベッコから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Talobecko.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330528",
 		"jp_text": "タグ・セヴァニアンの肉",
 		"tr_text": "Tag Sevanian Meat",
 		"jp_explain": "タグ・セヴァニアンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "タグ・セヴァニアンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Tag Sevanian.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330529",
 		"jp_text": "ファルカボネの肉",
 		"tr_text": "Falcabone Meat",
 		"jp_explain": "ファルカボネから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ファルカボネから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Falcabone.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330530",
 		"jp_text": "セヴァニアンの肉",
 		"tr_text": "Sevanian Meat",
 		"jp_explain": "セヴァニアンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "セヴァニアンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Sevanian.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330531",
 		"jp_text": "ヴィド・ギロスの肉",
 		"tr_text": "Vid Gilos Meat",
 		"jp_explain": "ヴィド・ギロスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ヴィド・ギロスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Vid Gilos.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330532",
 		"jp_text": "ビオル・メデューナの肉",
 		"tr_text": "Biol Meduna Meat",
 		"jp_explain": "ビオル・メデューナから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ビオル・メデューナから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Biol Meduna.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330533",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -4329,7 +4329,7 @@
 		"assign": "330677",
 		"jp_text": "鈍色の鱗",
 		"tr_text": "Dark Grey Scales",
-		"jp_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\n依頼者：<c a1ff6d>セラフィ<c>　　期間限定再受注可能",
+		"jp_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\n依頼者：<c a1ff6d>セラフィ<c>　期間限定再受注可能",
 		"tr_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\nClient: <c a1ff6d>Seraphy<c> (limited time)"
 	},
 	{
@@ -4343,7 +4343,7 @@
 		"assign": "330679",
 		"jp_text": "紫色の小さな花",
 		"tr_text": "Small Purple Flowers",
-		"jp_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\n依頼者：<c a1ff6d>シー<c>　　レイニー2015",
+		"jp_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\n依頼者：<c a1ff6d>シー<c>　レイニー2015",
 		"tr_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\nClient: <c a1ff6d>Xie<c> (Rainy 2015)"
 	},
 	{
@@ -4427,7 +4427,7 @@
 		"assign": "330697",
 		"jp_text": "小さなシュノーケル",
 		"tr_text": "Small Snorkels",
-		"jp_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\n依頼者：<c a1ff6d>シー<c>　　サマー2015",
+		"jp_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\n依頼者：<c a1ff6d>シー<c>　サマー2015",
 		"tr_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\nClient: <c a1ff6d>Xie<c> (Summer 2015)"
 	},
 	{

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -11,14 +11,14 @@
 		"jp_text": "アギニスの肉",
 		"tr_text": "Aginis Meat",
 		"jp_explain": "アギニスから採れた肉。\n脂身が少なくあっさりとしている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "アギニスから採れた肉。\n脂身が少なくあっさりとしている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from an Aginis. A low\namount of fat gives it a plain flavor.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "3302",
 		"jp_text": "アギニスの胸肉",
 		"tr_text": "Aginis Breast Meat",
 		"jp_explain": "アギニスから採れた胸部の肉。\n脂身が少なく、ヘルシー。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "アギニスから採れた胸部の肉。\n脂身が少なく、ヘルシー。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Breast meat taken from an Aginis.\nLean and healthy, with little fat.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "3303",
@@ -67,7 +67,7 @@
 		"jp_text": "クラーダの脚",
 		"tr_text": "Krahda Legs",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nクラーダの脚部。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A Krahda leg that remained intact\nwhen its owner was defeated.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A Krahda leg that remained intact\nafter the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (one-time order)"
 	},
 	{
 		"assign": "33010",
@@ -942,7 +942,7 @@
 		"jp_text": "スパルガンの不発弾",
 		"tr_text": "Spargun Grenades",
 		"jp_explain": "スパルガンが射出する榴弾。\n不発弾のようだが……？\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "スパルガンが射出する榴弾。\n不発弾のようだが……？\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "A grenade fired by a Spargun.\nSeems to be an unexploded bomb...?\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330135",
@@ -963,7 +963,7 @@
 		"jp_text": "バリドランの鱗",
 		"tr_text": "Baridran Scales",
 		"jp_explain": "バリドランから採れた鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "バリドランから採れた鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Scales taken from a Baridran.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330138",
@@ -3637,14 +3637,14 @@
 		"jp_text": "ゲームのギア",
 		"tr_text": "Game Gear",
 		"jp_explain": "アークスで流行っている\n携帯ゲーム機の部品。\n依頼者：<c a1ff6d>シー<c>　アークス共闘祭",
-		"tr_explain": "Parts of a portable gaming device,\nused by many ARKS.\nClient: <c a1ff6d>Xie<c>　(ARKS Unity Festival)"
+		"tr_explain": "Parts of a portable gaming device\nused by many ARKS.\nClient: <c a1ff6d>Xie<c> (ARKS Unity Festival)"
 	},
 	{
 		"assign": "330577",
 		"jp_text": "騎龍の角",
 		"tr_text": "Dragon Chariot Horns",
 		"jp_explain": "ソル・ディランダールや\nディランダールから採れる角。\n依頼者：<c a1ff6d>シー<c>　バレンタイン",
-		"tr_explain": "Horns from Dirandal and Sol Dirandal.\n\nClient: <c a1ff6d>Xie<c>　(Halloween)"
+		"tr_explain": "Horns from Dirandal and Sol Dirandal.\n\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330578",
@@ -3756,7 +3756,7 @@
 		"jp_text": "ラヴィ・ラッピーの羽根",
 		"tr_text": "Lovey Rappy Feathers",
 		"jp_explain": "ラヴィ・ラッピーの\n落としていった羽根。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": "Feathers dropped by a Lovey Rappy.\n\nClient: <c a1ff6d>Xie<c>　(White Day)"
+		"tr_explain": "Feathers dropped by a Lovey Rappy.\n\nClient: <c a1ff6d>Xie<c> (White Day)"
 	},
 	{
 		"assign": "330596",
@@ -4330,7 +4330,7 @@
 		"jp_text": "鈍色の鱗",
 		"tr_text": "Dark Grey Scales",
 		"jp_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\n依頼者：<c a1ff6d>セラフィ<c>　期間限定再受注可能",
-		"tr_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\nClient: <c a1ff6d>Seraphy<c> (limited time)"
+		"tr_explain": "Scales dropped by Dragonkin.\nThey carry a dull shine.\nClient: <c a1ff6d>Seraphy<c> (limited time)"
 	},
 	{
 		"assign": "330678",
@@ -4407,7 +4407,7 @@
 		"jp_text": "魂狩の大鎌",
 		"tr_text": "Spirit Scythe",
 		"jp_explain": "グアル・ジグモルデが持つ大きな鎌。\n魂をも刈り取りそうな形をしている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "グアル・ジグモルデが持つ大きな鎌。\n魂をも刈り取りそうな形をしている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Guar Zigmorde's giant scythe.\nShaped as if it reaps one's very soul.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330695",
@@ -4575,14 +4575,14 @@
 		"jp_text": "１５式戦車の主砲",
 		"tr_text": "Type-15 Tank Cannon",
 		"jp_explain": "１５式戦車の主砲。\n様々な種類の砲弾を発射できる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "１５式戦車の主砲。\n様々な種類の砲弾を発射できる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Main gun from a Type-15 Tank.\nCapable of firing many kinds of shell.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330722",
 		"jp_text": "トレインモーター",
-		"tr_text": "Train Mortar",
+		"tr_text": "Train Motor",
 		"jp_explain": "トレイン・ギドランのモーター。\n小型で軽量かつ省電力な設計。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "トレイン・ギドランのモーター。\n小型で軽量かつ省電力な設計。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Motor belonging to Train Ghidoran.\nA compact, energy-saving design.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330723",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -648,7 +648,7 @@
 		"jp_text": "ファングバンシーの柔毛",
 		"tr_text": "Fang Banshee Fur",
 		"jp_explain": "ファングバンシーの尻尾から\n採れたやわらかい毛。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ファングバンシーの尻尾から\n採れたやわらかい毛。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Soft fur taken from the tail of a\nFang Banshee.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33093",
@@ -2221,16 +2221,16 @@
 	{
 		"assign": "330317",
 		"jp_text": "キュクロナーダの右腕片",
-		"tr_text": "Kuklonahda Arms",
+		"tr_text": "Kuklonahda Arm",
 		"jp_explain": "キュクロナーダの鈍器状になっている\n右腕の欠片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "キュクロナーダの鈍器状になっている\n右腕の欠片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A piece of the blunt right arm of a\nKuklonahda.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330318",
 		"jp_text": "ゼッシュレイダの腕刃片",
-		"tr_text": "Zeshrayda Blades",
+		"tr_text": "Zeshrayda Blade",
 		"jp_explain": "ゼッシュレイダの上腕部にある\n刃状の物の欠片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ゼッシュレイダの上腕部にある\n刃状の物の欠片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A piece of the blade-like object on\nthe upper arm of a Zeshrayda.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330319",
@@ -2564,16 +2564,16 @@
 	{
 		"assign": "330377",
 		"jp_text": "ディガーラの鋭角",
-		"tr_text": "Deegalla Horns",
+		"tr_text": "Deegalla Horn",
 		"jp_explain": "ディガーラ頭部の鋭い角。\n岩石程度ならばやすやすと貫く。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ディガーラ頭部の鋭い角。\n岩石程度ならばやすやすと貫く。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "A horn from the head of a Deegalla.\nHard as rock, perfect for piercing.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330378",
 		"jp_text": "ソル・ディガーラの翼膜",
 		"tr_text": "Sol Deegalla Wings",
 		"jp_explain": "ソル・ディガーラの翼膜。\nとても軽く、伸縮性に優れる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ソル・ディガーラの翼膜。\nとても軽く、伸縮性に優れる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Wing membranes from a Sol Deegalla.\nVery light, with excellent elasticity.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330379",
@@ -2587,7 +2587,7 @@
 		"jp_text": "ディランダールの水晶片",
 		"tr_text": "Dirandal Crystal Fragments",
 		"jp_explain": "ディランダールの\n肩に埋め込まれた水晶の破片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ディランダールの\n肩に埋め込まれた水晶の破片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Fragments of the crystals embedded\nin the shoulder of a Dirandal.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330381",
@@ -2599,16 +2599,16 @@
 	{
 		"assign": "330382",
 		"jp_text": "ディガーラの爪",
-		"tr_text": "Deegalla Nails",
+		"tr_text": "Deegalla Claws",
 		"jp_explain": "ディガーラから採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Nails taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330383",
 		"jp_text": "ソル・ディガーラの爪",
-		"tr_text": "Sol Deegalla Nails",
+		"tr_text": "Sol Deegalla Claws",
 		"jp_explain": "ソル・ディガーラより採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ソル・ディガーラより採れた爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws taken from a Sol Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330384",
@@ -2823,7 +2823,7 @@
 	{
 		"assign": "330417",
 		"jp_text": "ガノンバルガーの大砲",
-		"tr_text": "Ganon Valger Cannons",
+		"tr_text": "Ganon Vargr Cannons",
 		"jp_explain": "ガノンバルガーに搭載された\nツインの大砲。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
 		"tr_explain": "ガノンバルガーに搭載された\nツインの大砲。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
@@ -2832,7 +2832,7 @@
 		"jp_text": "カストキンディッドの刃",
 		"tr_text": "Cust. Kindidd Blades",
 		"jp_explain": "カストキンディッドの内側に搭載された\n鋭い刃の付いたパーツ。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "カストキンディッドの内側に搭載された\n鋭い刃の付いたパーツ。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Sharp-edged parts mounted on the\ninside of a Custom Kindidd.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330419",
@@ -2844,30 +2844,30 @@
 	{
 		"assign": "330420",
 		"jp_text": "ヴィントバルガーの障壁",
-		"tr_text": "Vinto Vargr Barriers",
+		"tr_text": "Vinto Vargr Barrier",
 		"jp_explain": "ヴィントバルガーを中心に\n死角無く展開する鉄壁の防御機構。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ヴィントバルガーを中心に\n死角無く展開する鉄壁の防御機構。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Barrier generator mechanism from a\nVinto Vargr.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330421",
 		"jp_text": "カストガーディナンの動力",
-		"tr_text": "Cust. Guardinane Dynamos",
+		"tr_text": "Cust. Guardinane Dynamo",
 		"jp_explain": "本体サイズに見合わぬ高出力な\nカストガーディナンの動力。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "本体サイズに見合わぬ高出力な\nカストガーディナンの動力。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Dynamo from a Custom Guardinane.\nIts small size belies its high output.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330422",
 		"jp_text": "バトラガンのブースター",
-		"tr_text": "Batra Gun Boosters",
+		"tr_text": "Batra Gun Booster",
 		"jp_explain": "バトラガンの背負っている\nロケットブースター。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "バトラガンの背負っている\nロケットブースター。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Rocket booster mounted on the back\nof a Batra Gun.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330423",
 		"jp_text": "ヤクトディンゲールの剣刃",
-		"tr_text": "Jagd Dingell Blades",
+		"tr_text": "Jagd Dingell Blade",
 		"jp_explain": "ヤクトディンゲールが装備している\n巨大な大剣の刃部。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ヤクトディンゲールが装備している\n巨大な大剣の刃部。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Blade from the huge sword carried by\na Jagd Dingell.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330424",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -4526,14 +4526,14 @@
 		"jp_text": "極彩色のかけら",
 		"tr_text": "Rich-Colored Fragments",
 		"jp_explain": "不思議な色合いをした硬質のかけら。\n加工すれば装飾品に使えそう？\n依頼者：<c a1ff6d>シー<c>　クリスマス2015",
-		"tr_explain": "不思議な色合いをした硬質のかけら。\n加工すれば装飾品に使えそう？\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
+		"tr_explain": "A hard, strangely-colored fragment.\nCould it be made into a decoration?\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
 	},
 	{
 		"assign": "330712",
 		"jp_text": "ハッピーラッピーベル",
 		"tr_text": "Happy Rappy Bell",
 		"jp_explain": "セント・ラッピーが持つ小さなベル。\n澄んだ音色が夜の凍土に響きわたる。\n依頼者：<c a1ff6d>シー<c>　クリスマス2015",
-		"tr_explain": "セント・ラッピーが持つ小さなベル。\n澄んだ音色が夜の凍土に響きわたる。\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
+		"tr_explain": "Bell carried by a St. Rappy. Its clear\ntone echoes through the cold night.\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
 	},
 	{
 		"assign": "330713",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -970,7 +970,7 @@
 		"jp_text": "ウィンディラの鱗",
 		"tr_text": "Windira Scales",
 		"jp_explain": "ウィンディラから採れた頭部の鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ウィンディラから採れた頭部の鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Scales taken from the head of a Windira.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330139",
@@ -1159,7 +1159,7 @@
 		"jp_text": "フォンガルフの鋭い爪",
 		"tr_text": "Sharp Fangulf Claws",
 		"jp_explain": "フォンガルフの鋭利な爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォンガルフの鋭利な爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp claws taken from a Fangulf.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330166",
@@ -1243,7 +1243,7 @@
 		"jp_text": "ソル・ディーニアンの頭角",
 		"tr_text": "Sol Dinian Head Horns",
 		"jp_explain": "頭突きには使いにくそう。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "頭突きには使いにくそう。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Seem to be hardened for headbutts.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330178",
@@ -1467,7 +1467,7 @@
 		"jp_text": "シグノガンの肩部装甲",
 		"tr_text": "Signo Gun Shoulder Armor",
 		"jp_explain": "シグノガンの肩口を直接守る装甲。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノガンの肩口を直接守る装甲。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Armor that protects a Signo Gun's\ncollar.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330210",
@@ -1572,14 +1572,14 @@
 		"jp_text": "ブリアーダの前脚",
 		"tr_text": "Breeahda Forelegs",
 		"jp_explain": "ブリアーダの前脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの前脚と思われる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Breeahda parts that seem to be\nfront legs.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330225",
 		"jp_text": "ブリアーダの後脚",
 		"tr_text": "Breeahda Hindlegs",
 		"jp_explain": "ブリアーダの後脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの後脚と思われる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Breeahda parts that seem to be\nback legs.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330226",
@@ -1642,7 +1642,7 @@
 		"jp_text": "キングイエーデの尾骨",
 		"tr_text": "King Yede Coccyx",
 		"jp_explain": "キングイエーデの尾骨。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "キングイエーデの尾骨。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "The tailbone of a King Yede.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330235",
@@ -1684,14 +1684,14 @@
 		"jp_text": "ファンガルフルの鋭い爪",
 		"tr_text": "Fangulfur Sharp Claws",
 		"jp_explain": "ファンガルフルの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ファンガルフルの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp claws taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330241",
 		"jp_text": "ファンガルフルの鋭い牙",
 		"tr_text": "Fangulfur Sharp Fangs",
 		"jp_explain": "ファンガルフルの牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ファンガルフルの牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp fangs taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330242",
@@ -2153,7 +2153,7 @@
 		"jp_text": "ディッグの脚角",
 		"tr_text": "Digg Leg Horns",
 		"jp_explain": "ディッグの脚部に生えている角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ディッグの脚部に生えている角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Leg horns taken from a Digg.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330308",
@@ -2174,7 +2174,7 @@
 		"jp_text": "ギルナッチの胸部装甲",
 		"tr_text": "Gilnach Chest Armor",
 		"jp_explain": "ギルナッチの胸部を覆う装甲。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ギルナッチの胸部を覆う装甲。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Armor that covers the chest of a\nGilnach.\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330311",
@@ -2244,7 +2244,7 @@
 		"jp_text": "サイクロネーダの角",
 		"tr_text": "Cyclonehda Horns",
 		"jp_explain": "サイクロネーダの頭部にある角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "サイクロネーダの頭部にある角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Horns from the head of a Cyclonehda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330321",
@@ -2580,7 +2580,7 @@
 		"jp_text": "ペンドランの尾肉",
 		"tr_text": "Pendran Tails",
 		"jp_explain": "ペンドランの尾の肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ペンドランの尾の肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Tail meat taken from a Pendran.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330380",
@@ -2748,7 +2748,7 @@
 		"jp_text": "バル・ロドスの光鱗",
 		"tr_text": "Bal Rodos Scales",
 		"jp_explain": "バル・ロドスから採れた鱗。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "バル・ロドスから採れた鱗。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Scales taken from a Bal Rodos.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330407",
@@ -2839,7 +2839,7 @@
 		"jp_text": "シュタークガンの足パーツ",
 		"tr_text": "Stark Gun Leg Parts",
 		"jp_explain": "シュタークガンを構成する足パーツ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "シュタークガンを構成する足パーツ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Leg parts used in a Stark Gun.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330420",
@@ -2881,7 +2881,7 @@
 		"jp_text": "老成したアギニスの肉",
 		"tr_text": "Mature Aginis Meat",
 		"jp_explain": "老成したアギニスより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "老成したアギニスより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a mature Aginis.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330426",
@@ -2902,7 +2902,7 @@
 		"jp_text": "老成したデ・マルモスの肉",
 		"tr_text": "Mature De Malmoth Meat",
 		"jp_explain": "老成したデ・マルモスより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "老成したデ・マルモスより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a mature\nDe Malmoth.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330429",
@@ -2916,28 +2916,28 @@
 		"jp_text": "老成したバリドランの肉",
 		"tr_text": "Mature Baridran Meat",
 		"jp_explain": "老成したバリドランより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "老成したバリドランより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a mature Baridran.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330431",
 		"jp_text": "グウォンダの大盾の破片",
 		"tr_text": "Gu Wonda Shield Fragments",
 		"jp_explain": "グウォンダの所持している盾の破片。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "グウォンダの所持している盾の破片。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Fragments of a Gu Wonda's shield.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330432",
 		"jp_text": "活発なペンドランの肉",
 		"tr_text": "Healthy Pendran Meat",
 		"jp_explain": "活きのいいペンドランの肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "活きのいいペンドランの肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Pleasant-tasting Pendran meat.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330433",
 		"jp_text": "活発なアクルプスの肉",
 		"tr_text": "Healthy Aqulupus Meat",
 		"jp_explain": "活きのいいアクルプスの肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "活きのいいアクルプスの肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Pleasant-tasting Aqulupus meat.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330434",
@@ -4041,9 +4041,9 @@
 	{
 		"assign": "330636",
 		"jp_text": "ランズ・ヴァレーダの尾刃",
-		"tr_text": "Lanz Vareda Tail Blades",
+		"tr_text": "Lanz Vareda Tail Blade",
 		"jp_explain": "ランズ・ヴァレーダの尾にある刃。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ランズ・ヴァレーダの尾にある刃。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Blade from the tail of a Lanz Vareda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330637",
@@ -4386,7 +4386,7 @@
 		"jp_text": "イタギザクリの鋭爪",
 		"tr_text": "Itagi-zakri Claws",
 		"jp_explain": "イタギザクリの鋭い爪。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "イタギザクリの鋭い爪。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Sharp claws from an Itagi-zakri.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330692",
@@ -4428,21 +4428,21 @@
 		"jp_text": "小さなシュノーケル",
 		"tr_text": "Small Snorkels",
 		"jp_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\n依頼者：<c a1ff6d>シー<c>　サマー2015",
-		"tr_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\nClient: <c a1ff6d>Xie<c> (Summer 2015)"
+		"tr_explain": "A rather elaborate snorkel worn by a\nSummer Rappy.\nClient: <c a1ff6d>Xie<c> (Summer 2015)"
 	},
 	{
 		"assign": "330698",
 		"jp_text": "コドニアガリの鈴",
-		"tr_text": "Godoni-agari Bells",
+		"tr_text": "Godoni-agari Bell",
 		"jp_explain": "コドニアガリに付いている鈴。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "コドニアガリに付いている鈴。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Bell attached to a Godoni-agari.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330699",
 		"jp_text": "オガキバルの紋",
-		"tr_text": "Ogaki-baru Crests",
+		"tr_text": "Ogaki-baru Crest",
 		"jp_explain": "オガキバルたちが身に着けている紋。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "オガキバルたちが身に着けている紋。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Crest worn by an Ogaki-baru.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330700",
@@ -4596,14 +4596,14 @@
 		"jp_text": "ゾンビのネクタイ",
 		"tr_text": "Zombie Necktie",
 		"jp_explain": "ゾンビたちが身に着けているネクタイ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ゾンビたちが身に着けているネクタイ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "A necktie worn by a zombie.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330725",
 		"jp_text": "ロードローラーのローラー",
 		"tr_text": "Road Roller Roller",
 		"jp_explain": "ロードローラーの大きなローラー。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ロードローラーの大きなローラー。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Large roller from a Road Roller\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330726",
@@ -4645,7 +4645,7 @@
 		"jp_text": "トラックマフラー",
 		"tr_text": "Truck Muffler",
 		"jp_explain": "デビルズトレーラーの円筒型マフラー。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "デビルズトレーラーの円筒型マフラー。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Cylindrical muffler from a Devil's\nTrailer.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330732",
@@ -4659,14 +4659,14 @@
 		"jp_text": "ネオン管",
 		"tr_text": "Neon Tube",
 		"jp_explain": "どことなくレトロさを感じるネオン管。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "どことなくレトロさを感じるネオン管。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "A slightly retro neon tube.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330734",
 		"jp_text": "デュラハンライダーの側車",
 		"tr_text": "Dullahan Side Car",
 		"jp_explain": "デュラハンライダーのサイドカー。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "デュラハンライダーのサイドカー。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Side car from a Dullahan Rider.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330735",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -11,14 +11,14 @@
 		"jp_text": "アギニスの肉",
 		"tr_text": "Aginis Meat",
 		"jp_explain": "アギニスから採れた肉。\n脂身が少なくあっさりとしている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "アギニスから採れた肉。\n脂身が少なくあっさりとしている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "3302",
 		"jp_text": "アギニスの胸肉",
 		"tr_text": "Aginis Breast Meat",
 		"jp_explain": "アギニスから採れた胸部の肉。\n脂身が少なく、ヘルシー。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "アギニスから採れた胸部の肉。\n脂身が少なく、ヘルシー。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "3303",
@@ -165,7 +165,7 @@
 		"jp_text": "ヴォル・ドラゴンの牙",
 		"tr_text": "Vol Dragon Fangs",
 		"jp_explain": "ヴォル・ドラゴンから採れた牙。\n非常に硬く加工しづらい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヴォル・ドラゴンから採れた牙。\n非常に硬く加工しづらい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33024",
@@ -368,14 +368,14 @@
 		"jp_text": "黒い小さな実",
 		"tr_text": "Small Black Fruit",
 		"jp_explain": "リリーパで採取された実。\n黒い表皮は硬く、割りにくい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "リリーパで採取された実。\n黒い表皮は硬く、割りにくい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33053",
 		"jp_text": "白い小さな実",
 		"tr_text": "Small White Fruit",
 		"jp_explain": "リリーパで採取された実。\n白い表皮は硬く、食べにくい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "リリーパで採取された実。\n白い表皮は硬く、食べにくい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33054",
@@ -396,7 +396,7 @@
 		"jp_text": "岩塩",
 		"tr_text": "Rock Salt",
 		"jp_explain": "リリーパで採取された石。\n塩分が結晶化したもの。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "リリーパで採取された石。\n塩分が結晶化したもの。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33057",
@@ -445,42 +445,42 @@
 		"jp_text": "ガルフルの肉",
 		"tr_text": "Gulfur Meat",
 		"jp_explain": "ガルフルから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガルフルから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33064",
 		"jp_text": "ファンガルフルの肉",
 		"tr_text": "Fangulfur Meat",
 		"jp_explain": "ファンガルフルから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33065",
 		"jp_text": "マルモスの肉",
 		"tr_text": "Malmoth Meat",
 		"jp_explain": "マルモスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "マルモスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33066",
 		"jp_text": "デ・マルモスの肉",
 		"tr_text": "De Malmoth Meat",
 		"jp_explain": "デ・マルモスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "デ・マルモスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33067",
 		"jp_text": "スノウバンサーの肉",
 		"tr_text": "Snow Banther Meat",
 		"jp_explain": "スノウバンサーから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スノウバンサーから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33068",
 		"jp_text": "スノウバンシーの肉",
 		"tr_text": "Snow Banshee Meat",
 		"jp_explain": "スノウバンシーから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スノウバンシーから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33069",
@@ -578,28 +578,28 @@
 		"jp_text": "フォンガルフの頭角",
 		"tr_text": "Fangulf Horns",
 		"jp_explain": "フォンガルフの頭部より採れた角。\n\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォンガルフの頭部より採れた角。\n\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "33083",
 		"jp_text": "ガーディナンのパーツａ",
 		"tr_text": "Guardinane Parts a",
 		"jp_explain": "ガーディナンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>エコー<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディナンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Echo<c> (one-time order)"
 	},
 	{
 		"assign": "33084",
 		"jp_text": "ガーディンのフレーム",
 		"tr_text": "Guardine Frame",
 		"jp_explain": "ガーディンを構成する部品の一つ。\n強度の割に軽い素材で出来ている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガーディンを構成する部品の一つ。\n強度の割に軽い素材で出来ている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33085",
 		"jp_text": "ギルナスの装甲",
 		"tr_text": "Gilnas Armor",
 		"jp_explain": "ギルナスを構成する部品の一つ。\nギルナスを覆う装甲。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ギルナスを構成する部品の一つ。\nギルナスを覆う装甲。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33086",
@@ -641,56 +641,56 @@
 		"jp_text": "ファングバンサーの皮",
 		"tr_text": "Fang Banther Hide",
 		"jp_explain": "ファングバンサーから採れた皮。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファングバンサーから採れた皮。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33092",
 		"jp_text": "ファングバンシーの柔毛",
 		"tr_text": "Fang Banshee Fur",
 		"jp_explain": "ファングバンシーの尻尾から\n採れたやわらかい毛。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファングバンシーの尻尾から\n採れたやわらかい毛。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33093",
 		"jp_text": "ノーディランサの肉",
 		"tr_text": "Nordiransa Meat",
 		"jp_explain": "ノーディランサから採れた肉。\n\n依頼者：<c a1ff6d>アフィン<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランサから採れた肉。\n\nClient: <c a1ff6d>Afin<c> (one-time order)"
 	},
 	{
 		"assign": "33094",
 		"jp_text": "フォードランサの肉",
 		"tr_text": "Fordoransa Meat",
 		"jp_explain": "フォードランサから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "フォードランサから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33095",
 		"jp_text": "バリドランの肉",
 		"tr_text": "Baridran Meat",
 		"jp_explain": "バリドランから採れた肉。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "バリドランから採れた肉。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33096",
 		"jp_text": "ウィンディラの翼角",
 		"tr_text": "Windira Wing Horns",
 		"jp_explain": "ウィンディラの翼から採れた角。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ウィンディラの翼から採れた角。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33097",
 		"jp_text": "キャタドランサの肉",
 		"tr_text": "Caterdransa Meat",
 		"jp_explain": "キャタドランサから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "キャタドランサから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33098",
 		"jp_text": "クォーツ・ドラゴンの鱗",
 		"tr_text": "Quartz Dragon Scales",
 		"jp_explain": "クォーツ・ドラゴンから採れた鱗。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "クォーツ・ドラゴンから採れた鱗。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33099",
@@ -746,203 +746,203 @@
 		"jp_text": "破損したダーカーコアａ",
 		"tr_text": "Damaged Darker Core a",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や衝撃によって破損している。\n依頼者：<c a1ff6d>オーザ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーから採取されたコア。\n斬撃や衝撃によって破損している。\nClient: <c a1ff6d>Ohza<c> (one-time order)"
 	},
 	{
 		"assign": "330107",
 		"jp_text": "破損したダーカーコアｂ",
 		"tr_text": "Damaged Darker Core b",
 		"jp_explain": "ダーカーから採取されたコア。\n銃撃や砲撃によって破損している。\n依頼者：<c a1ff6d>リサ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーから採取されたコア。\n銃撃や砲撃によって破損している。\nClient: <c a1ff6d>Lisa<c> (one-time order)"
 	},
 	{
 		"assign": "330108",
 		"jp_text": "破損したダーカーコアｃ",
 		"tr_text": "Damaged Darker Core c",
 		"jp_explain": "ダーカーから採取されたコア。\n法撃や打撃によって破損している。\n依頼者：<c a1ff6d>マールー<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーから採取されたコア。\n法撃や打撃によって破損している。\nClient: <c a1ff6d>Marlu<c> (one-time order)"
 	},
 	{
 		"assign": "330109",
 		"jp_text": "アギニスのかぎ爪",
 		"tr_text": "Aginis Talon",
 		"jp_explain": "アギニスから採れたかぎ爪。\n\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "アギニスから採れたかぎ爪。\n\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330110",
 		"jp_text": "硬皮の植物",
 		"tr_text": "Hard Melon Skin",
 		"jp_explain": "瓜のような植物。\n外皮が硬く調理しづらい。\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "瓜のような植物。\n外皮が硬く調理しづらい。\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330111",
 		"jp_text": "ノーディランの上質角",
 		"tr_text": "Nordiran Piercing Horn",
 		"jp_explain": "ノーディランから採れた上質な角。\nかなり尖っている。\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "ノーディランから採れた上質な角。\nかなり尖っている。\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330112",
 		"jp_text": "紫色のとんがり帽子",
 		"tr_text": "Pointy Purple Hat",
 		"jp_explain": "ラタン・ラッピーが\n身に着けている帽子。\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "ラタン・ラッピーが\n身に着けている帽子。\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330113",
 		"jp_text": "ナヴ・ラッピーの羽毛",
 		"tr_text": "Nab Rappy Feathers",
 		"jp_explain": "ナヴ・ラッピーから採れた羽毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーから採れた羽毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330114",
 		"jp_text": "ウーダンの毛",
 		"tr_text": "Oodan Fur",
 		"jp_explain": "ウーダンから採れた毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ウーダンから採れた毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330115",
 		"jp_text": "ザウーダンの棘",
 		"tr_text": "Za Oodan Thorns",
 		"jp_explain": "ザウーダンから採れた上腕部の棘。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ザウーダンから採れた上腕部の棘。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330116",
 		"jp_text": "ガルフの牙",
 		"tr_text": "Gulf Fangs",
 		"jp_explain": "ガルフから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガルフから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330117",
 		"jp_text": "フォードランのたてがみ",
 		"tr_text": "Fordoran Manes",
 		"jp_explain": "フォードランから採れたたてがみ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "フォードランから採れたたてがみ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330118",
 		"jp_text": "ノーディランの尻尾",
 		"tr_text": "Nordiran Tails",
 		"jp_explain": "ノーディランから採れた尻尾。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ノーディランから採れた尻尾。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330119",
 		"jp_text": "シル・ディーニアンの鱗",
 		"tr_text": "Sil Dinian Scales",
 		"jp_explain": "シル・ディーニアンから採れた鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "シル・ディーニアンから採れた鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330120",
 		"jp_text": "ソル・ディーニアンの牙",
 		"tr_text": "Sol Dinian Fangs",
 		"jp_explain": "ソル・ディーニアンから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディーニアンから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330121",
 		"jp_text": "ディーニアンの背びれ",
 		"tr_text": "Dinian Fins",
 		"jp_explain": "ディーニアンから採れた背びれの一部。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ディーニアンから採れた背びれの一部。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330122",
 		"jp_text": "フォンガルフの爪",
 		"tr_text": "Fangulf Claws",
 		"jp_explain": "フォンガルフから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "フォンガルフから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330123",
 		"jp_text": "ガロンゴの臼歯",
 		"tr_text": "Garongo Molars",
 		"jp_explain": "ガロンゴから採れた臼歯。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴから採れた臼歯。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330124",
 		"jp_text": "ダガンの甲殻",
 		"tr_text": "Dagan Carapaces",
 		"jp_explain": "ダガンから採れた甲殻。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ダガンから採れた甲殻。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330125",
 		"jp_text": "カルターゴの脚",
 		"tr_text": "Kartargot Legs",
 		"jp_explain": "カルターゴから採れた脚。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "カルターゴから採れた脚。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330126",
 		"jp_text": "ヴォル・ドラゴンの爪",
 		"tr_text": "Vol Dragon Claw",
 		"jp_explain": "ヴォル・ドラゴンから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヴォル・ドラゴンから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330127",
 		"jp_text": "クラーダの大あご",
 		"tr_text": "Krahda Mandibles",
 		"jp_explain": "クラーダから採れた大あご。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "クラーダから採れた大あご。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330128",
 		"jp_text": "エル・アーダの羽",
 		"tr_text": "El Ahda Wings",
 		"jp_explain": "エル・アーダから採れた羽。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダから採れた羽。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330129",
 		"jp_text": "シグノガンの砲身",
 		"tr_text": "Signo Gun Barrels",
 		"jp_explain": "シグノガンを構成する部品の一つ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "シグノガンを構成する部品の一つ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330130",
 		"jp_text": "グワナーダの甲殻",
 		"tr_text": "Gwanahda Carapaces",
 		"jp_explain": "グワナーダから採れた甲殻。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "グワナーダから採れた甲殻。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330131",
 		"jp_text": "イエーデの毛",
 		"tr_text": "Yede Fur",
 		"jp_explain": "イエーデから採れた毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "イエーデから採れた毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330132",
 		"jp_text": "マルモスのひづめ",
 		"tr_text": "Malmoth Hooves",
 		"jp_explain": "マルモスから採れたひづめ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "マルモスから採れたひづめ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330133",
 		"jp_text": "スノウバンサーの爪",
 		"tr_text": "Snow Banther Claws",
 		"jp_explain": "スノウバンサーから採れた爪。\n刃のように長く、鋭い。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スノウバンサーから採れた爪。\n刃のように長く、鋭い。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330134",
 		"jp_text": "スパルガンの不発弾",
 		"tr_text": "Spargun Grenades",
 		"jp_explain": "スパルガンが射出する榴弾。\n不発弾のようだが……？\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スパルガンが射出する榴弾。\n不発弾のようだが……？\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330135",
@@ -956,1232 +956,1232 @@
 		"jp_text": "サディニアンの剣の破片",
 		"tr_text": "Sadinian Dagger Pieces",
 		"jp_explain": "セト・サディニアンの\n所持していた剣の破片。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "セト・サディニアンの\n所持していた剣の破片。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330137",
 		"jp_text": "バリドランの鱗",
 		"tr_text": "Baridran Scales",
 		"jp_explain": "バリドランから採れた鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "バリドランから採れた鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330138",
 		"jp_text": "ウィンディラの鱗",
 		"tr_text": "Windira Scales",
 		"jp_explain": "ウィンディラから採れた頭部の鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ウィンディラから採れた頭部の鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330139",
 		"jp_text": "キャタドランサの牙",
 		"tr_text": "Caterdransa Fangs",
 		"jp_explain": "キャタドランサから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "キャタドランサから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330140",
 		"jp_text": "アギニスの小爪",
 		"tr_text": "Aginis Wing Claw",
 		"jp_explain": "アギニスの翼から生える爪。\nあまり役に立っていない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "アギニスの翼から生える爪。\nあまり役に立っていない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330141",
 		"jp_text": "アギニスの鋭いくちばし",
 		"tr_text": "Aginis Sharp Beak",
 		"jp_explain": "アギニスのくちばし。\n鋭く獲物を攻撃する。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "アギニスのくちばし。\n鋭く獲物を攻撃する。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330142",
 		"jp_text": "アギニスの朱い羽根",
 		"tr_text": "Aginis Scarlet Feathers",
 		"jp_explain": "アギニスの朱い羽根。\nきれいに生えそろっていて美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "アギニスの朱い羽根。\nきれいに生えそろっていて美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330143",
 		"jp_text": "ウーダンの角",
 		"tr_text": "Oodan Horns",
 		"jp_explain": "ウーダンの頭に生える角。\n攻撃的な曲線を描く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウーダンの頭に生える角。\n攻撃的な曲線を描く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330144",
 		"jp_text": "ウーダンの爪",
 		"tr_text": "Woodan Nails",
 		"jp_explain": "ウーダンの爪。\nひっかいたり、地面を掴むのに使う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウーダンの爪。\nひっかいたり、地面を掴むのに使う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330145",
 		"jp_text": "ウーダンの鋭い爪",
 		"tr_text": "Oodan Sharp Claws",
 		"jp_explain": "ウーダンの爪。\nひっかかれると痛そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウーダンの爪。\nひっかかれると痛そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330146",
 		"jp_text": "ガルフの棘",
 		"tr_text": "Gulf Spines",
 		"jp_explain": "ガルフの背中の棘。\n気軽になでることを許さない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガルフの背中の棘。\n気軽になでることを許さない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330147",
 		"jp_text": "ガルフの鋭い牙",
 		"tr_text": "Gulf Sharp Fangs",
 		"jp_explain": "ガルフの牙。\nかみつき攻撃に注意。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガルフの牙。\nかみつき攻撃に注意。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330148",
 		"jp_text": "ガルフの鋭い爪",
 		"tr_text": "Gulf Sharp Claws",
 		"jp_explain": "ガルフの爪。\n飛びかかりながらのひっかきは脅威。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガルフの爪。\n飛びかかりながらのひっかきは脅威。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330149",
 		"jp_text": "ガロンゴの足",
 		"tr_text": "Garongo Legs",
 		"jp_explain": "ガロンゴの足。\n意外と小回りが利く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴの足。\n意外と小回りが利く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330150",
 		"jp_text": "ガロンゴの尾の殻",
 		"tr_text": "Garongo Tail Shell",
 		"jp_explain": "ガロンゴの尻尾の大きな殻。\n回転攻撃の勢いに貢献している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴの尻尾の大きな殻。\n回転攻撃の勢いに貢献している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330151",
 		"jp_text": "ガロンゴの頭の殻",
 		"tr_text": "Garongo Head Shell",
 		"jp_explain": "ガロンゴの頭部の大きな殻。\n回転攻撃の時、実は隠れている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴの頭部の大きな殻。\n回転攻撃の時、実は隠れている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330152",
 		"jp_text": "ザウーダンの爪",
 		"tr_text": "Za Oodan Claws",
 		"jp_explain": "ザウーダンの爪。\n器用に岩を掘り起こす。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ザウーダンの爪。\n器用に岩を掘り起こす。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330153",
 		"jp_text": "ザウーダンの角",
 		"tr_text": "Za Oodan Horns",
 		"jp_explain": "ザウーダンの立派な角。\nでも攻撃には使わない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ザウーダンの立派な角。\nでも攻撃には使わない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330154",
 		"jp_text": "ザウーダンの牙",
 		"tr_text": "Za Oodan Fangs",
 		"jp_explain": "ザウーダンの牙。\nなんでも噛みちぎる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ザウーダンの牙。\nなんでも噛みちぎる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330155",
 		"jp_text": "黒い小片",
 		"tr_text": "Black Pieces",
 		"jp_explain": "ダーカーの体の小片。\n小さくて部位はわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の小片。\n小さくて部位はわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330156",
 		"jp_text": "赤い小片",
 		"tr_text": "Red Pieces",
 		"jp_explain": "ダーカーの体の小片。\n赤い部位と言うことしかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の小片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330157",
 		"jp_text": "赤い欠片",
 		"tr_text": "Red Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n赤い部位と言うことしかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の欠片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330158",
 		"jp_text": "ダガンの爪",
 		"tr_text": "Dagan Claws",
 		"jp_explain": "ダガンの脚先の爪。\n刺されると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの脚先の爪。\n刺されると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330159",
 		"jp_text": "ダガンの薄羽",
 		"tr_text": "Dagan Thin Wings",
 		"jp_explain": "ダガンの頭部に生える薄羽。\n何のためにあるか謎の器官。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの頭部に生える薄羽。\n何のためにあるか謎の器官。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330160",
 		"jp_text": "ダガンの鋭い針",
 		"tr_text": "Dagan Sharp Stinger",
 		"jp_explain": "ダガンの頭部に生える針。\n攻撃に使うと痛そうだが使用しない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの頭部に生える針。\n攻撃に使うと痛そうだが使用しない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330161",
 		"jp_text": "ナヴ・ラッピーの触角",
 		"tr_text": "Nab Rappy Antennas",
 		"jp_explain": "ナヴ・ラッピーに生える触角。\n周囲の状況把握に役立っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーに生える触角。\n周囲の状況把握に役立っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330162",
 		"jp_text": "ナヴ・ラッピーのかぎ爪",
 		"tr_text": "Nab Rappy Claws",
 		"jp_explain": "ナヴ・ラッピーのかぎ爪。\nしっかりと地面を掴む。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーのかぎ爪。\nしっかりと地面を掴む。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330163",
 		"jp_text": "ナヴ・ラッピーの小爪",
 		"tr_text": "Nab Rappy Wing Claw",
 		"jp_explain": "ナヴ・ラッピーの翼に生える爪。\nかわいい外見に違わずあまり痛くない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーの翼に生える爪。\nかわいい外見に違わずあまり痛くない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330164",
 		"jp_text": "フォンガルフの鋭い牙",
 		"tr_text": "Sharp Fangulf Fangs",
 		"jp_explain": "フォンガルフの牙。\nかまれると非常に痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォンガルフの牙。\nかまれると非常に痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330165",
 		"jp_text": "フォンガルフの鋭い爪",
 		"tr_text": "Sharp Fangulf Claws",
 		"jp_explain": "フォンガルフの鋭利な爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォンガルフの鋭利な爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330166",
 		"jp_text": "フォンガルフの脚の角",
 		"tr_text": "Fangulf Leg Horns",
 		"jp_explain": "フォンガルフの脚に生える角。\n体を休める時に邪魔になりそう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォンガルフの脚に生える角。\n体を休める時に邪魔になりそう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330167",
 		"jp_text": "侵食核の欠片ａ",
 		"tr_text": "Tainted Core Fragments A",
 		"jp_explain": "原生種にとりついた侵食核。\n原生種の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "原生種にとりついた侵食核。\n原生種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330168",
 		"jp_text": "侵食核の欠片ｂ",
 		"tr_text": "Tainted Core Fragments B",
 		"jp_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330169",
 		"jp_text": "侵食核の欠片ｃ",
 		"tr_text": "Tainted Core Fragments C",
 		"jp_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330170",
 		"jp_text": "カルターゴの紫羽",
 		"tr_text": "Kartagot Purple Wings",
 		"jp_explain": "カルターゴの頭部から生える羽の\n紫色の部分。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの頭部から生える羽の\n紫色の部分。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330171",
 		"jp_text": "カルターゴの丈夫な殻",
 		"tr_text": "Kartagot Rear Shell",
 		"jp_explain": "カルターゴのお尻の殻。\n上に乗ってもびくともしない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴのお尻の殻。\n上に乗ってもびくともしない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330172",
 		"jp_text": "カルターゴの牙",
 		"tr_text": "Kartagot Fangs",
 		"jp_explain": "カルターゴの体型からどう使うのか\n謎の部位。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの体型からどう使うのか\n謎の部位。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330173",
 		"jp_text": "シル・ディーニアンの肩甲",
 		"tr_text": "Sil Dinian Shoulder Blades",
 		"jp_explain": "シル・ディーニアンの肩当て。\n意外と自在に動く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シル・ディーニアンの肩当て。\n意外と自在に動く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330174",
 		"jp_text": "シル・ディーニアンの盾角",
 		"tr_text": "Sil Dinian Shield Edges",
 		"jp_explain": "シル・ディーニアンの盾の角。\n殴られると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シル・ディーニアンの盾の角。\n殴られると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330175",
 		"jp_text": "シル・ディーニアンの頭角",
 		"tr_text": "Sil Dinian Head Horns",
 		"jp_explain": "シル・ディーニアンの頭に生える角。\n頭突きには使いにくそう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シル・ディーニアンの頭に生える角。\n頭突きには使いにくそう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330176",
 		"jp_text": "ソル・ディーニアンの肩甲",
 		"tr_text": "Sol Dinian Shoulder Blades",
 		"jp_explain": "ソル・ディーニアンの肩当て。\n腕を動かしても邪魔にならない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディーニアンの肩当て。\n腕を動かしても邪魔にならない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330177",
 		"jp_text": "ソル・ディーニアンの頭角",
 		"tr_text": "Sol Dinian Head Horns",
 		"jp_explain": "頭突きには使いにくそう。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "頭突きには使いにくそう。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330178",
 		"jp_text": "ソル・ディーニアンの銃晶",
 		"tr_text": "Sol Dinian Gun Crystals",
 		"jp_explain": "ソル・ディーニアンの銃のクリスタル。\n銃撃の威力をアップさせているらしい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディーニアンの銃のクリスタル。\n銃撃の威力をアップさせているらしい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330179",
 		"jp_text": "熱を持った黒い欠片",
 		"tr_text": "Heated Black Pieces",
 		"jp_explain": "ダーカーの体の一部。\n火山熱によって熱くなっている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の一部。\n火山熱によって熱くなっている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330180",
 		"jp_text": "黒い欠片",
 		"tr_text": "Black Fragments",
 		"jp_explain": "ダーカーの体の一部。\nどこの部位かはよくわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の一部。\nどこの部位かはよくわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330181",
 		"jp_text": "大きく赤い欠片",
 		"tr_text": "Large Red Fragments",
 		"jp_explain": "ダーカーの体の赤い部位の欠片。\n比較的大きいものがとれた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の赤い部位の欠片。\n比較的大きいものがとれた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330182",
 		"jp_text": "ダガンの角",
 		"tr_text": "Dagan Horns",
 		"jp_explain": "ダガンの頭の角。\n先に薄羽が生えている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの頭の角。\n先に薄羽が生えている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330183",
 		"jp_text": "ダガンの脚関節",
 		"tr_text": "Dagan Leg Joints",
 		"jp_explain": "ダガンの脚の関節。\nなめらかに動く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの脚の関節。\nなめらかに動く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330184",
 		"jp_text": "ダガンの鋭い爪",
 		"tr_text": "Dagan Sharp Claws",
 		"jp_explain": "ダガンの爪。\n鋭く刺されるため非常に痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの爪。\n鋭く刺されるため非常に痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330185",
 		"jp_text": "ディーニアンの肩甲",
 		"tr_text": "Dinian Shoulder Blades",
 		"jp_explain": "ディーニアンの肩当て。\n肩周りをしっかりガード。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディーニアンの肩当て。\n肩周りをしっかりガード。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330186",
 		"jp_text": "ディーニアンの頭角",
 		"tr_text": "Dinian Head Horns",
 		"jp_explain": "ディーニアンの頭から首にかけての角。\n威圧感を増している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディーニアンの頭から首にかけての角。\n威圧感を増している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330187",
 		"jp_text": "ディーニアンの杖水晶",
 		"tr_text": "Dinian Wand Crystals",
 		"jp_explain": "ディーニアンの杖のクリスタル。\n法撃の威力をアップさせている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディーニアンの杖のクリスタル。\n法撃の威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330188",
 		"jp_text": "ディッグの尻尾",
 		"tr_text": "Digg Tails",
 		"jp_explain": "ディッグの尻尾。\n小柄な体型の割に、太めの尻尾。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディッグの尻尾。\n小柄な体型の割に、太めの尻尾。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330189",
 		"jp_text": "ディッグの頭角",
 		"tr_text": "Digg Head Horns",
 		"jp_explain": "ディッグの頭頂部の角。\n頭をなでることをよしとしない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディッグの頭頂部の角。\n頭をなでることをよしとしない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330190",
 		"jp_text": "ディッグの羽",
 		"tr_text": "Digg Wings",
 		"jp_explain": "ディッグの背にある小さな羽。\n小さすぎて飛ぶことはできない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディッグの背にある小さな羽。\n小さすぎて飛ぶことはできない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330191",
 		"jp_text": "ノーディランの連角",
 		"tr_text": "Nordiran Horn Joints",
 		"jp_explain": "ノーディランの腰に連なる角。\n背後から襲われた時に役に立つ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランの腰に連なる角。\n背後から襲われた時に役に立つ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330192",
 		"jp_text": "ノーディランの背水晶",
 		"tr_text": "Nordiran Back Crystals",
 		"jp_explain": "ノーディランの背に生えるクリスタル。\n大きくなるのに相応の年月が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランの背に生えるクリスタル。\n大きくなるのに相応の年月が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330193",
 		"jp_text": "ノーディランの腹水晶",
 		"tr_text": "Nordiran Belly Crystals",
 		"jp_explain": "ノーディランの腹に生えるクリスタル。\n小ぶりだが量があるため迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランの腹に生えるクリスタル。\n小ぶりだが量があるため迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330194",
 		"jp_text": "フォードランの連角",
 		"tr_text": "Fordoran Horn Joints",
 		"jp_explain": "フォードランの腰に連なる角。\n後ろから見ても迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォードランの腰に連なる角。\n後ろから見ても迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330195",
 		"jp_text": "フォードランの背水晶",
 		"tr_text": "Fordoran Back Crystals",
 		"jp_explain": "フォードランの背に生えるクリスタル。\nこれのおかげで乗ることは難しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォードランの背に生えるクリスタル。\nこれのおかげで乗ることは難しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330196",
 		"jp_text": "フォードランの腹水晶",
 		"tr_text": "Fordoran Belly Crystals",
 		"jp_explain": "フォードランの腹に生えるクリスタル。\n乗られるとミンチになってしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォードランの腹に生えるクリスタル。\n乗られるとミンチになってしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330197",
 		"jp_text": "熱を持った侵食核の欠片ａ",
 		"tr_text": "Heated Tainted Core Fragments A",
 		"jp_explain": "龍族にとりついた侵食核。\n龍族の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "龍族にとりついた侵食核。\n龍族の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330198",
 		"jp_text": "熱を持った侵食核の欠片ｂ",
 		"tr_text": "Heated Tainted Core Fragments B",
 		"jp_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330199",
 		"jp_text": "熱を持った侵食核の欠片ｃ",
 		"tr_text": "Heated Tainted Core Fragments C",
 		"jp_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330200",
 		"jp_text": "エル・アーダのあご",
 		"tr_text": "El Ahda Jaws",
 		"jp_explain": "エル・アーダのあご。\nかみつかれると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダのあご。\nかみつかれると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330201",
 		"jp_text": "エル・アーダの触角",
 		"tr_text": "El Ahda Antennae",
 		"jp_explain": "エル・アーダの触角。\n節くれ立って大きい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダの触角。\n節くれ立って大きい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330202",
 		"jp_text": "エル・アーダの尻尾",
 		"tr_text": "El Ahda Tail",
 		"jp_explain": "エル・アーダの尻尾。\n鋭い針が内蔵されている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダの尻尾。\n鋭い針が内蔵されている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330203",
 		"jp_text": "カルターゴの角",
 		"tr_text": "Kartagot Horns",
 		"jp_explain": "カルターゴの角。\n冠のようにも見える。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの角。\n冠のようにも見える。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330204",
 		"jp_text": "カルターゴの黒羽",
 		"tr_text": "Kartagot Black Wings",
 		"jp_explain": "カルターゴの黒羽。\n胴体をカバーするのに使う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの黒羽。\n胴体をカバーするのに使う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330205",
 		"jp_text": "カルターゴの腰殻",
 		"tr_text": "Kartagot Waist Carapace",
 		"jp_explain": "カルターゴの腰を覆う殻。\nこれにより前面はしっかり守られている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの腰を覆う殻。\nこれにより前面はしっかり守られている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330206",
 		"jp_text": "クラーダの尾羽",
 		"tr_text": "Krahda Tail",
 		"jp_explain": "クラーダの尾羽。\n体格の割に立派なものを持っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの尾羽。\n体格の割に立派なものを持っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330207",
 		"jp_text": "クラーダの鎌",
 		"tr_text": "Krahda Sickle",
 		"jp_explain": "クラーダの鎌。\n左右の鎌による同時攻撃は注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの鎌。\n左右の鎌による同時攻撃は注意が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330208",
 		"jp_text": "クラーダの頭殻",
 		"tr_text": "Krahda Head Carapace",
 		"jp_explain": "クラーダの頭を守る殻。\n弱い攻撃ははじかれてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの頭を守る殻。\n弱い攻撃ははじかれてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330209",
 		"jp_text": "シグノガンの肩部装甲",
 		"tr_text": "Signo Gun Shoulder Armor",
 		"jp_explain": "シグノガンの肩口を直接守る装甲。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノガンの肩口を直接守る装甲。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330210",
 		"jp_text": "シグノガンの脚部装甲",
 		"tr_text": "Signo Gun Leg Armor",
 		"jp_explain": "シグノガンの左脚を守る装甲。\n左脚だけなのはスムーズに構えるため。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノガンの左脚を守る装甲。\n左脚だけなのはスムーズに構えるため。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330211",
 		"jp_text": "シグノガンの砲弾",
 		"tr_text": "Signogun Cannon Shells",
 		"jp_explain": "シグノガンの砲弾。\n火力が高いので、要注意。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノガンの砲弾。\n火力が高いので、要注意。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330212",
 		"jp_text": "スパルガンのパーツｆ",
 		"tr_text": "Spargun Parts f",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330213",
 		"jp_text": "スパルガンのパーツｇ",
 		"tr_text": "Spargun Parts g",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330214",
 		"jp_text": "スパルガンのパーツｉ",
 		"tr_text": "Spargun Parts i",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330215",
 		"jp_text": "スパルダンＡのパーツｆ",
 		"tr_text": "Spardan A Parts f",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330216",
 		"jp_text": "スパルダンＡのパーツｇ",
 		"tr_text": "Spardan A Parts g",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330217",
 		"jp_text": "スパルダンＡのパーツｉ",
 		"tr_text": "Spardan A Parts i",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330218",
 		"jp_text": "乾いた黒い欠片",
 		"tr_text": "Dried Black Pieces",
 		"jp_explain": "ダーカーの体の黒い欠片。\n砂漠の影響で乾燥している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の黒い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330219",
 		"jp_text": "乾いた赤い欠片",
 		"tr_text": "Dried Red Fragments",
 		"jp_explain": "ダーカーの体の赤い欠片。\n砂漠の影響で乾燥している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の赤い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330220",
 		"jp_text": "黒い塊",
 		"tr_text": "Black Lump",
 		"jp_explain": "ダーカーの体の黒い部分の塊。\n禍々しい雰囲気を醸し出している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の黒い部分の塊。\n禍々しい雰囲気を醸し出している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330221",
 		"jp_text": "ダガンの脚甲",
 		"tr_text": "Dagan Leg Carapaces",
 		"jp_explain": "ダガンの脚を守る甲殻。\nそこそこの防御力を持つ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの脚を守る甲殻。\nそこそこの防御力を持つ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330222",
 		"jp_text": "ダガンの堅い甲殻",
 		"tr_text": "Dagan Hard Shell",
 		"jp_explain": "ダガンの甲殻のうち特に堅い部位。\nここ以外を狙えると戦いやすい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの甲殻のうち特に堅い部位。\nここ以外を狙えると戦いやすい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330223",
 		"jp_text": "ダガンのきれいな薄羽",
 		"tr_text": "Odd Dagan Wing",
 		"jp_explain": "ダガンの頭部から生える薄羽。\n激しい戦闘の中破損状況が軽微なもの。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの頭部から生える薄羽。\n激しい戦闘の中破損状況が軽微なもの。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330224",
 		"jp_text": "ブリアーダの前脚",
 		"tr_text": "Breeahda Forelegs",
 		"jp_explain": "ブリアーダの前脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの前脚と思われる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330225",
 		"jp_text": "ブリアーダの後脚",
 		"tr_text": "Breeahda Hindlegs",
 		"jp_explain": "ブリアーダの後脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの後脚と思われる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330226",
 		"jp_text": "ブリアーダの肩角",
 		"tr_text": "Breeahda Shoulder Blades",
 		"jp_explain": "ブリアーダの前脚をつなぐ肩の角。\n威嚇用の飾りと思われる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの前脚をつなぐ肩の角。\n威嚇用の飾りと思われる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330227",
 		"jp_text": "乾いた侵食核の欠片ａ",
 		"tr_text": "Dried Tainted Core Fragment A",
 		"jp_explain": "機甲種にとりついた侵食核。\n機甲種の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "機甲種にとりついた侵食核。\n機甲種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330228",
 		"jp_text": "乾いた侵食核の欠片ｂ",
 		"tr_text": "Dried Tainted Core Fragment B",
 		"jp_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330229",
 		"jp_text": "乾いた侵食核の欠片ｃ",
 		"tr_text": "Dried Tainted Core Fragment C",
 		"jp_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330230",
 		"jp_text": "イエーデの足爪",
 		"tr_text": "Yede Foot Nails",
 		"jp_explain": "イエーデの足に生えるごつい爪。\n雪の中でも地面を踏みしめられる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "イエーデの足に生えるごつい爪。\n雪の中でも地面を踏みしめられる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330231",
 		"jp_text": "イエーデの尾骨",
 		"tr_text": "Yede Tailbone",
 		"jp_explain": "イエーデの岩のような尾骨。\n毛皮にも覆われず、堂々としたもの。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "イエーデの岩のような尾骨。\n毛皮にも覆われず、堂々としたもの。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330232",
 		"jp_text": "ガルフルの鋭い爪",
 		"tr_text": "Gulfur Sharp Claws",
 		"jp_explain": "ガルフルの爪。\nその鋭さは傷を重傷化させてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガルフルの爪。\nその鋭さは傷を重傷化させてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330233",
 		"jp_text": "ガルフルの鋭い牙",
 		"tr_text": "Gulfur Sharp Fangs",
 		"jp_explain": "ガルフルの牙。\nその鋭さはなんでもかみ砕いてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガルフルの牙。\nその鋭さはなんでもかみ砕いてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330234",
 		"jp_text": "キングイエーデの尾骨",
 		"tr_text": "King Yede Coccyx",
 		"jp_explain": "キングイエーデの尾骨。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "キングイエーデの尾骨。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330235",
 		"jp_text": "キングイエーデの頭骨",
 		"tr_text": "King Yede Skull",
 		"jp_explain": "キングイエーデの岩のような頭骨。\n非常に堅い、まさに石頭。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "キングイエーデの岩のような頭骨。\n非常に堅い、まさに石頭。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330236",
 		"jp_text": "凍った赤い欠片",
 		"tr_text": "Frozen Red Fragments",
 		"jp_explain": "ダーカーの赤い体の欠片。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの赤い体の欠片。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330237",
 		"jp_text": "大きく黒い塊",
 		"tr_text": "Large Black Lump",
 		"jp_explain": "ダーカーの黒い体の塊。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの黒い体の塊。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330238",
 		"jp_text": "ナヴ・ラッピーの凍った爪",
 		"tr_text": "Frozen Nab Rappy Claw",
 		"jp_explain": "ナヴ・ラッピーの爪。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーの爪。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330239",
 		"jp_text": "ナヴ・ラッピーの氷結片",
 		"tr_text": "Frozen Nab Rappy Beak",
 		"jp_explain": "ナヴ・ラッピーのくちばし。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナヴ・ラッピーのくちばし。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330240",
 		"jp_text": "ファンガルフルの鋭い爪",
 		"tr_text": "Fangulfur Sharp Claws",
 		"jp_explain": "ファンガルフルの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330241",
 		"jp_text": "ファンガルフルの鋭い牙",
 		"tr_text": "Fangulfur Sharp Fangs",
 		"jp_explain": "ファンガルフルの牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルの牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330242",
 		"jp_text": "マルモスの鼻",
 		"tr_text": "Malmoth Trunk",
 		"jp_explain": "マルモスの長い鼻。\n非常に器用に動かすことができる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "マルモスの長い鼻。\n非常に器用に動かすことができる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330243",
 		"jp_text": "マルモスの剛毛",
 		"tr_text": "Malmoth Bristles",
 		"jp_explain": "マルモスの剛毛。\nタフな体力と相まって倒しにくい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "マルモスの剛毛。\nタフな体力と相まって倒しにくい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330244",
 		"jp_text": "ミクダの堅い甲羅",
 		"tr_text": "Micda Hard Shell",
 		"jp_explain": "ミクダの堅い甲羅。\n正面から戦うのは愚策。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ミクダの堅い甲羅。\n正面から戦うのは愚策。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330245",
 		"jp_text": "ミクダのあご",
 		"tr_text": "Micda Jaws",
 		"jp_explain": "ミクダのあご。\n普段隠れていてほとんど目立たない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ミクダのあご。\n普段隠れていてほとんど目立たない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330246",
 		"jp_text": "凍った侵食核の欠片ａ",
 		"tr_text": "Frozen Tainted Core Fragment A",
 		"jp_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330247",
 		"jp_text": "凍った侵食核の欠片ｂ",
 		"tr_text": "Frozen Tainted Core Fragment B",
 		"jp_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330248",
 		"jp_text": "エル・アーダの爪",
 		"tr_text": "El Ahda Nails",
 		"jp_explain": "エル・アーダの腕の爪。\n豪快なひっかきは脅威。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダの腕の爪。\n豪快なひっかきは脅威。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330249",
 		"jp_text": "エル・アーダの角",
 		"tr_text": "El Ahda Horns",
 		"jp_explain": "エル・アーダの額の角。\n周囲の情報を敏感に察知する。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダの額の角。\n周囲の情報を敏感に察知する。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330250",
 		"jp_text": "ガーディナンの弾倉",
 		"tr_text": "Guardinane Magazine",
 		"jp_explain": "ガーディナンの弾倉。\n見た目より多くの弾を秘めている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディナンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330251",
 		"jp_text": "ガーディナンの脚部",
 		"tr_text": "Guardinane Leg",
 		"jp_explain": "ガーディナンの脚部パーツ。\nこれでの自立は無理そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディナンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330252",
 		"jp_text": "ガーディンの弾倉",
 		"tr_text": "Guardine Magazine",
 		"jp_explain": "ガーディンの弾倉。\n見た目より多くの弾を秘めている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330253",
 		"jp_text": "ガーディンの脚部",
 		"tr_text": "Guardine Leg",
 		"jp_explain": "ガーディンの脚部パーツ。\nこれでの自立は無理そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330254",
 		"jp_text": "カルターゴの脚節",
 		"tr_text": "Kartagot Leg Section",
 		"jp_explain": "カルターゴの脚節。\n短いががっしりしている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの脚節。\n短いががっしりしている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330255",
 		"jp_text": "カルターゴの脚角",
 		"tr_text": "Kartagot Leg Horns",
 		"jp_explain": "カルターゴの膝の角。\n連なって生える様は美しくもある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの膝の角。\n連なって生える様は美しくもある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330256",
 		"jp_text": "ギルナスの肩ボルト",
 		"tr_text": "Gilnas Shoulder Bolt",
 		"jp_explain": "ギルナスの肩にあるボルト。\n肩パーツをしっかりと固定している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ギルナスの肩にあるボルト。\n肩パーツをしっかりと固定している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330257",
 		"jp_text": "ギルナスのコアレンズ",
 		"tr_text": "Gilnas Core Lens",
 		"jp_explain": "ギルナス・コアのレンズ。\n攻撃を撃ち出す要のパーツ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ギルナス・コアのレンズ。\n攻撃を撃ち出す要のパーツ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330258",
 		"jp_text": "ギルナッチの肩部ランプ",
 		"tr_text": "Gilnach Shoulder Armor",
 		"jp_explain": "ギルナッチの肩に光るランプ。\nギルナッチの肩幅も一目瞭然。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ギルナッチの肩に光るランプ。\nギルナッチの肩幅も一目瞭然。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330259",
 		"jp_text": "ギルナッチの頭部ランプ",
 		"tr_text": "Gilnach Head Lamp",
 		"jp_explain": "ギルナッチの頭部で回転するランプ。\nどんな事態で点灯するかは不明である。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ギルナッチの頭部で回転するランプ。\nどんな事態で点灯するかは不明である。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330260",
 		"jp_text": "クラーダの後脚",
 		"tr_text": "Krahda Hind Legs",
 		"jp_explain": "クラーダの後脚。\n体長の倍の高さを飛ぶ驚異の跳躍力。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの後脚。\n体長の倍の高さを飛ぶ驚異の跳躍力。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330261",
 		"jp_text": "クラーダの鋭い鎌",
 		"tr_text": "Krahda Sharp Sickle",
 		"jp_explain": "クラーダの備える鎌。\n形は小さいが鋭く、斬られると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの備える鎌。\n形は小さいが鋭く、斬られると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330262",
 		"jp_text": "シグノビートの腕部装甲",
 		"tr_text": "Signo Beat Arm Armor",
 		"jp_explain": "シグノビートの腕を守る装甲。\n分厚い金属で覆われている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノビートの腕を守る装甲。\n分厚い金属で覆われている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330263",
 		"jp_text": "シグノビートの不発機雷",
 		"tr_text": "Signo Beat Unexploded Mine",
 		"jp_explain": "シグノビートの投げる機雷の不発弾。\nどんなきっかけで爆発するかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノビートの投げる機雷の不発弾。\nどんなきっかけで爆発するかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330264",
 		"jp_text": "スパルガンのパーツｈ",
 		"tr_text": "Spargun Parts h",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330265",
 		"jp_text": "スパルガンのパーツｊ",
 		"tr_text": "Spargun Parts j",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330266",
 		"jp_text": "スパルザイルのレンズ",
 		"tr_text": "Sparzyle Lens",
 		"jp_explain": "スパルザイルの頭部レンズ。\nあらゆる角度で獲物を狙う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルザイルの頭部レンズ。\nあらゆる角度で獲物を狙う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330267",
 		"jp_text": "スパルザイルの起爆剤",
 		"tr_text": "Sparzyle Explosives",
 		"jp_explain": "スパルザイルが自爆する際の起爆剤。\n取り扱いは丁重に。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルザイルが自爆する際の起爆剤。\n取り扱いは丁重に。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330268",
 		"jp_text": "スパルダンＡのパーツｈ",
 		"tr_text": "Spardan A Parts h",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330269",
 		"jp_text": "スパルダンＡのパーツｊ",
 		"tr_text": "Spardan A Parts j",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330270",
 		"jp_text": "大きく黒い欠片",
 		"tr_text": "Large Black Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n比較的大きい欠片だが、部位は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の欠片。\n比較的大きい欠片だが、部位は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330271",
 		"jp_text": "赤い塊",
 		"tr_text": "Red Lump",
 		"jp_explain": "ダーカーの体の赤い部位の塊。\n若干グロテスク。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の赤い部位の塊。\n若干グロテスク。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330272",
 		"jp_text": "ブリアーダの針",
 		"tr_text": "Breeahda Stinger",
 		"jp_explain": "ブリアーダのあごの針。\n鋭いので注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダのあごの針。\n鋭いので注意が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330273",
 		"jp_text": "ブリアーダのかぎ爪",
 		"tr_text": "Breeahda Claws",
 		"jp_explain": "ブリアーダの前脚のかぎ爪。\nこれでひっかかれたら痛そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの前脚のかぎ爪。\nこれでひっかかれたら痛そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330274",
 		"jp_text": "油まみれの侵食核の欠片ａ",
 		"tr_text": "Oil Covered Tainted Core A",
 		"jp_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330275",
 		"jp_text": "油まみれの侵食核の欠片ｂ",
 		"tr_text": "Oil Covered Tainted Core B",
 		"jp_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330276",
 		"jp_text": "ウィンディラの棘",
 		"tr_text": "Windira Spine",
 		"jp_explain": "ウィンディラの尾に連なる棘。\n掴むと刺さって痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウィンディラの尾に連なる棘。\n掴むと刺さって痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330277",
 		"jp_text": "ウィンディラの胸角",
 		"tr_text": "Windira Breast Horns",
 		"jp_explain": "ウィンディラの胸の角。\n突進をよけたつもりで引っかかる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウィンディラの胸の角。\n突進をよけたつもりで引っかかる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330278",
 		"jp_text": "オル・ミクダの甲羅",
 		"tr_text": "Ol Micda Carapaces",
 		"jp_explain": "オル・ミクダの甲羅。\n堅いため甲羅をよけて攻撃するべし。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "オル・ミクダの甲羅。\n堅いため甲羅をよけて攻撃するべし。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330279",
 		"jp_text": "オル・ミクダの二本角",
 		"tr_text": "Ol Micda Twin Horns",
 		"jp_explain": "オル・ミクダの二本の角。\n周囲の情報をチェックしている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "オル・ミクダの二本の角。\n周囲の情報をチェックしている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330280",
 		"jp_text": "ガウォンダの肩甲",
 		"tr_text": "Ga Wonda Shoulder Blades",
 		"jp_explain": "ガウォンダの肩を守る甲殻。\n守備範囲はあまり広くない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガウォンダの肩を守る甲殻。\n守備範囲はあまり広くない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330281",
 		"jp_text": "ガウォンダの脚甲",
 		"tr_text": "Ga Wonda Leg Armor",
 		"jp_explain": "ガウォンダの脚を覆う甲殻。\n脚のガードは堅い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガウォンダの脚を覆う甲殻。\n脚のガードは堅い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330282",
 		"jp_text": "サディニアンの頭角",
 		"tr_text": "Sadinian Head Horns",
 		"jp_explain": "サディニアンの頭の角。\n正面より横からのが迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "サディニアンの頭の角。\n正面より横からのが迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330283",
 		"jp_text": "サディニアンの杖水晶",
 		"tr_text": "Sadinian Wand Crystals",
 		"jp_explain": "サディニアンの杖のクリスタル。\n法撃の威力上昇に貢献している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "サディニアンの杖のクリスタル。\n法撃の威力上昇に貢献している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330284",
 		"jp_text": "シル・サディニアンの盾角",
 		"tr_text": "Sadinian Shield Edges",
 		"jp_explain": "シル・サディニアンの盾の角。\n防具だが打撃力が高い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シル・サディニアンの盾の角。\n防具だが打撃力が高い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330285",
 		"jp_text": "シル・サディニアンの頭角",
 		"tr_text": "Sil Sadinian Head Horns",
 		"jp_explain": "シル・サディニアンの頭の角。\n後頭部まで連なる様は、モヒカンの様。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シル・サディニアンの頭の角。\n後頭部まで連なる様は、モヒカンの様。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330286",
 		"jp_text": "セト・サディニアンの頭角",
 		"tr_text": "Set Sadinian Head Horns",
 		"jp_explain": "セト・サディニアンの頭の角。\n小柄な体格に似合わず立派な角。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "セト・サディニアンの頭の角。\n小柄な体格に似合わず立派な角。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330287",
 		"jp_text": "セト・サディニアンのひれ",
 		"tr_text": "Set Sadinian Fin",
 		"jp_explain": "セト・サディニアンの頭から\n足下まで伸びる長いひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "セト・サディニアンの頭から\n足下まで伸びる長いひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330288",
 		"jp_text": "ソル・サディニアンの頭角",
 		"tr_text": "Sol Sadinian Head Horns",
 		"jp_explain": "ソル・サディニアンの頭の角。\n威圧感を醸し出している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ソル・サディニアンの頭の角。\n威圧感を醸し出している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330289",
 		"jp_text": "ソル・サディニアンの銃晶",
 		"tr_text": "Sol Sadinian Gun Crystals",
 		"jp_explain": "ソル・サディニアンの銃のクリスタル。\n射撃威力をアップさせている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ソル・サディニアンの銃のクリスタル。\n射撃威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330290",
 		"jp_text": "固く黒い欠片",
 		"tr_text": "Hardened Black Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n固くて黒い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の欠片。\n固くて黒い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330291",
 		"jp_text": "赤い半球体",
 		"tr_text": "Red Hemisphere",
 		"jp_explain": "ダーカーの体の欠片。\n赤い半球体が丸ごと残った。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーの体の欠片。\n赤い半球体が丸ごと残った。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330292",
 		"jp_text": "ダーガッシュの牙",
 		"tr_text": "Dahgash Fangs",
 		"jp_explain": "ダーガッシュの牙。\n巨大な口に鋭い牙で、重傷必至。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーガッシュの牙。\n巨大な口に鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330293",
 		"jp_text": "ダーガッシュの背びれ",
 		"tr_text": "Dahgash Rear Fin",
 		"jp_explain": "ダーガッシュの背びれ。\n空中を進む推力を出力している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーガッシュの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330294",
 		"jp_text": "ダガッチャの牙",
 		"tr_text": "Dagacha Fangs",
 		"jp_explain": "ダガッチャの牙。\n小柄ながら鋭い牙で、重傷必至。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガッチャの牙。\n小柄ながら鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330295",
 		"jp_text": "ダガッチャの背びれ",
 		"tr_text": "Dagacha Rear Fin",
 		"jp_explain": "ダガッチャの背びれ。\n空中を進む推力を出力している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガッチャの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330296",
 		"jp_text": "ノーディランサの背水晶",
 		"tr_text": "Nordiransa Back Crystals",
 		"jp_explain": "ノーディランサの背のクリスタル。\n青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランサの背のクリスタル。\n青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330297",
 		"jp_text": "ノーディランサの腹水晶",
 		"tr_text": "Nodiransa Belly Crystal",
 		"jp_explain": "ノーディランサの腹のクリスタル。\n不揃いだが、青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ノーディランサの腹のクリスタル。\n不揃いだが、青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330298",
 		"jp_text": "バリドランの腕角",
 		"tr_text": "Baridran Arm Horns",
 		"jp_explain": "バリドランの腕の角。\n普段の攻撃では使わない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "バリドランの腕の角。\n普段の攻撃では使わない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330299",
 		"jp_text": "バリドランの背びれ",
 		"tr_text": "Baridran Rear Fin",
 		"jp_explain": "バリドランの背中のひれ。\n脆いため、状態が良いものは貴重。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "バリドランの背中のひれ。\n脆いため、状態が良いものは貴重。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330300",
 		"jp_text": "フォードランサの背水晶",
 		"tr_text": "Fordoransa Back Crystals",
 		"jp_explain": "フォードランサの背のクリスタル。\n大きく青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォードランサの背のクリスタル。\n大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330301",
 		"jp_text": "フォードランサの腹水晶",
 		"tr_text": "Fordoransa Belly Crystal",
 		"jp_explain": "フォードランサの腹のクリスタル。\n不揃いだが、大きく青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "フォードランサの腹のクリスタル。\n不揃いだが、大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330302",
 		"jp_text": "ミクダの滑りやすい脚",
 		"tr_text": "Micda Slippery Legs",
 		"jp_explain": "ミクダの脚。\n滑らかな回転攻撃はこの脚有ればこそ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ミクダの脚。\n滑らかな回転攻撃はこの脚有ればこそ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330303",
 		"jp_text": "ミクダの蛇腹の首",
 		"tr_text": "Micda Serpentine Neck",
 		"jp_explain": "ミクダの蛇腹の首。\n回転攻撃時は内側に入り込んでいる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ミクダの蛇腹の首。\n回転攻撃時は内側に入り込んでいる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330304",
 		"jp_text": "軽い侵食核の欠片ａ",
 		"tr_text": "Light Tainted Core Fragments A",
 		"jp_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330305",
 		"jp_text": "軽い侵食核の欠片ｂ",
 		"tr_text": "Light Tainted Core Fragments B",
 		"jp_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330306",
 		"jp_text": "アギニスの尾羽根",
 		"tr_text": "Aginis Tail Feathers",
 		"jp_explain": "アギニスから採れた尾羽根。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "アギニスから採れた尾羽根。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330307",
 		"jp_text": "ディッグの脚角",
 		"tr_text": "Digg Leg Horns",
 		"jp_explain": "ディッグの脚部に生えている角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ディッグの脚部に生えている角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330308",
 		"jp_text": "ブリアーダの羽",
 		"tr_text": "Breeahda Wings",
 		"jp_explain": "ブリアーダから採れた羽。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダから採れた羽。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330309",
 		"jp_text": "ファンガルフルの爪",
 		"tr_text": "Fangulfur Claws",
 		"jp_explain": "ファンガルフルから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330310",
 		"jp_text": "ギルナッチの胸部装甲",
 		"tr_text": "Gilnach Chest Armor",
 		"jp_explain": "ギルナッチの胸部を覆う装甲。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ギルナッチの胸部を覆う装甲。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330311",
 		"jp_text": "クォーツ・ドラゴンの牙",
 		"tr_text": "Quartz Dragon Fangs",
 		"jp_explain": "クォーツ・ドラゴンから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "クォーツ・ドラゴンから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330312",
@@ -2209,28 +2209,28 @@
 		"jp_text": "遺跡機構の破片",
 		"tr_text": "Ruins Machine Fragments",
 		"jp_explain": "ナベリウスの奥地にある\n遺跡機構の破片。\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ナベリウスの奥地にある\n遺跡機構の破片。\nClient: <c a1ff6d>Philia<c> (one-time order)"
 	},
 	{
 		"assign": "330316",
 		"jp_text": "クラバーダの甲殻",
 		"tr_text": "Krabahda Shells",
 		"jp_explain": "クラバーダから採れた甲殻。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "クラバーダから採れた甲殻。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330317",
 		"jp_text": "キュクロナーダの右腕片",
 		"tr_text": "Kuklonahda Arms",
 		"jp_explain": "キュクロナーダの鈍器状になっている\n右腕の欠片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "キュクロナーダの鈍器状になっている\n右腕の欠片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330318",
 		"jp_text": "ゼッシュレイダの腕刃片",
 		"tr_text": "Zeshrayda Blades",
 		"jp_explain": "ゼッシュレイダの上腕部にある\n刃状の物の欠片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ゼッシュレイダの上腕部にある\n刃状の物の欠片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330319",
@@ -2244,175 +2244,175 @@
 		"jp_text": "サイクロネーダの角",
 		"tr_text": "Cyclonehda Horns",
 		"jp_explain": "サイクロネーダの頭部にある角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "サイクロネーダの頭部にある角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330321",
 		"jp_text": "ウォルガーダの腹牙",
 		"tr_text": "Wolgahda Belly Fangs",
 		"jp_explain": "ウォルガーダの腹部にある\n牙のようなもの。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ウォルガーダの腹部にある\n牙のようなもの。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330322",
 		"jp_text": "ファンガルフルの牙",
 		"tr_text": "Fangulfur Fang",
 		"jp_explain": "ファンガルフルより採れた牙。\n\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルより採れた牙。\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330323",
 		"jp_text": "マルモスの肩肉",
 		"tr_text": "Malmoth Shoulder Meat",
 		"jp_explain": "マルモスから採れた肉。\n脂肪分が少なく、とても美味しい。\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "マルモスから採れた肉。\n脂肪分が少なく、とても美味しい。\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330324",
 		"jp_text": "子供たちへのプレゼント",
 		"tr_text": "Presents for the Children",
 		"jp_explain": "子供たちが楽しみにしている\nクリスマスプレゼント。\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "子供たちが楽しみにしている\nクリスマスプレゼント。\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330325",
 		"jp_text": "上質なロウ",
 		"tr_text": "High-Quality Raw",
 		"jp_explain": "キャンドルを作るために必要なもの。\n\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "キャンドルを作るために必要なもの。\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330326",
 		"jp_text": "スノウバンサーの若角",
 		"tr_text": "Snow Banther Horns",
 		"jp_explain": "スノウバンサーの\n生え変わったばかりの柔らかい角。\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "スノウバンサーの\n生え変わったばかりの柔らかい角。\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330327",
 		"jp_text": "スノウバンシーの若角",
 		"tr_text": "Snow Banshee Horns",
 		"jp_explain": "スノウバンシーの\n生え変わったばかりの柔らかい角。\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "スノウバンシーの\n生え変わったばかりの柔らかい角。\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330328",
 		"jp_text": "ディーニアンの杖",
 		"tr_text": "Dinian Cane Piece",
 		"jp_explain": "ディーニアンの所持していた\n杖の柄部分。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディーニアンの所持していた\n杖の柄部分。\nClient: <c a1ff6d>Toro<c> (one-time order)"
 	},
 	{
 		"assign": "330329",
 		"jp_text": "ディッグの水晶石",
 		"tr_text": "Crystal Stone",
 		"jp_explain": "ディッグの頭部より迫り出した\n鉱石のようなものの破片。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディッグの頭部より迫り出した\n鉱石のようなものの破片。\nClient: <c a1ff6d>Toro<c> (one-time order)"
 	},
 	{
 		"assign": "330340",
 		"jp_text": "異質な侵食核",
 		"tr_text": "Foreign Tainted Core",
 		"jp_explain": "侵食核の残滓。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "侵食核の残滓。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330341",
 		"jp_text": "クラーダの牙",
 		"tr_text": "Krahda Fangs",
 		"jp_explain": "クラーダの二本の牙。\n攻撃にはあまり向かない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラーダの二本の牙。\n攻撃にはあまり向かない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330342",
 		"jp_text": "ダガンの腹部",
 		"tr_text": "Dagan Abdomen",
 		"jp_explain": "ダガンの四肢や頭部をつなげる腹部。\nコンパクトにまとまっている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガンの四肢や頭部をつなげる腹部。\nコンパクトにまとまっている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330343",
 		"jp_text": "エル・アーダの後脚",
 		"tr_text": "El Ahda Hind-leg",
 		"jp_explain": "エル・アーダの後脚。\n空中での姿勢制御に使われる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "エル・アーダの後脚。\n空中での姿勢制御に使われる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330344",
 		"jp_text": "カルターゴの蛇腹殻",
 		"tr_text": "Kartagot Belly Carapace",
 		"jp_explain": "カルターゴの蛇腹状の殻。\n柔軟に曲げることができる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カルターゴの蛇腹状の殻。\n柔軟に曲げることができる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330345",
 		"jp_text": "ブリアーダの背殻の欠片",
 		"tr_text": "Breeahda Rear Fin Fragment",
 		"jp_explain": "ブリアーダの巨大な背中の殻の欠片。\n中身を守るため、見た目以上に強固。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの巨大な背中の殻の欠片。\n中身を守るため、見た目以上に強固。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330346",
 		"jp_text": "ミクダの紋様殻",
 		"tr_text": "Micda Shell Patterns",
 		"jp_explain": "ミクダの甲羅の欠片。\n紋様に傷もなくきれいな状態。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ミクダの甲羅の欠片。\n紋様に傷もなくきれいな状態。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330347",
 		"jp_text": "オル・ミクダの紋様殻",
 		"tr_text": "Ol Micda Shell Patterns",
 		"jp_explain": "オル・ミクダの甲羅の欠片。\n紋様部分がきれいに残っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "オル・ミクダの甲羅の欠片。\n紋様部分がきれいに残っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330348",
 		"jp_text": "ダーガッシュの頭びれ",
 		"tr_text": "Dahgash Head Fin",
 		"jp_explain": "ダーガッシュの頭部にあるひれ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーガッシュの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330349",
 		"jp_text": "ダガッチャの頭びれ",
 		"tr_text": "Dagacha Head Fin",
 		"jp_explain": "ダガッチャの頭部にあるひれ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダガッチャの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330350",
 		"jp_text": "ガウォンダの腰甲",
 		"tr_text": "Ga Wonda Waist Armor",
 		"jp_explain": "ガウォンダの腰を守る甲殻。\n可動範囲が大きい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガウォンダの腰を守る甲殻。\n可動範囲が大きい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330351",
 		"jp_text": "グウォンダのひれ刀",
 		"tr_text": "Gu Wonda Sword Fin",
 		"jp_explain": "グウォンダの右腕のひれ刀。\n伸縮幅が大きく、間合いが広い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "グウォンダの右腕のひれ刀。\n伸縮幅が大きく、間合いが広い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330352",
 		"jp_text": "クラバーダの牙",
 		"tr_text": "Krabahda Fangs",
 		"jp_explain": "クラバーダの大口に生える牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "クラバーダの大口に生える牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330353",
 		"jp_text": "キュクロナーダの尻尾片",
 		"tr_text": "Kuklonahda Tail Piece",
 		"jp_explain": "キュクロナーダの尻尾の欠片。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "キュクロナーダの尻尾の欠片。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330354",
 		"jp_text": "サイクロネーダの星球片",
 		"tr_text": "Cyclonehda Spherical Piece",
 		"jp_explain": "サイクロネーダの右腕にある\n星球状部位の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "サイクロネーダの右腕にある\n星球状部位の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330355",
@@ -2538,84 +2538,84 @@
 		"jp_text": "サディニアンの杖の欠片",
 		"tr_text": "Sadinian Rod Fragment",
 		"jp_explain": "サディニアンの持つ杖の\n先端部分にある結晶の欠片。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": ""
+		"tr_explain": "サディニアンの持つ杖の\n先端部分にある結晶の欠片。\nClient: <c a1ff6d>Xie<c> (White Day)"
 	},
 	{
 		"assign": "330374",
 		"jp_text": "虹色の果実",
 		"tr_text": "Rainbow Fruit",
 		"jp_explain": "浮遊大陸で採れる果実。\n龍族も好んで食べるという。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": ""
+		"tr_explain": "浮遊大陸で採れる果実。\n龍族も好んで食べるという。\nClient: <c a1ff6d>Xie<c> (White Day)"
 	},
 	{
 		"assign": "330375",
 		"jp_text": "クォーツ・ドラゴンの尾片",
 		"tr_text": "Quartz Dragon Tail Fragment",
 		"jp_explain": "クォーツ・ドラゴンの\n尻尾の欠片。光をよく反射する。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": ""
+		"tr_explain": "クォーツ・ドラゴンの\n尻尾の欠片。光をよく反射する。\nClient: <c a1ff6d>Xie<c> (White Day)"
 	},
 	{
 		"assign": "330376",
 		"jp_text": "純白の小さな花",
 		"tr_text": "Small White Flower",
 		"jp_explain": "ラヴィ・ラッピーが愛する\n純白の美しい花。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": ""
+		"tr_explain": "ラヴィ・ラッピーが愛する\n純白の美しい花。\nClient: <c a1ff6d>Xie<c> (White Day)"
 	},
 	{
 		"assign": "330377",
 		"jp_text": "ディガーラの鋭角",
 		"tr_text": "Deegalla Horns",
 		"jp_explain": "ディガーラ頭部の鋭い角。\n岩石程度ならばやすやすと貫く。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ディガーラ頭部の鋭い角。\n岩石程度ならばやすやすと貫く。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330378",
 		"jp_text": "ソル・ディガーラの翼膜",
 		"tr_text": "Sol Deegalla Wings",
 		"jp_explain": "ソル・ディガーラの翼膜。\nとても軽く、伸縮性に優れる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディガーラの翼膜。\nとても軽く、伸縮性に優れる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330379",
 		"jp_text": "ペンドランの尾肉",
 		"tr_text": "Pendran Tails",
 		"jp_explain": "ペンドランの尾の肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ペンドランの尾の肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330380",
 		"jp_text": "ディランダールの水晶片",
 		"tr_text": "Dirandal Crystal Fragments",
 		"jp_explain": "ディランダールの\n肩に埋め込まれた水晶の破片。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ディランダールの\n肩に埋め込まれた水晶の破片。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330381",
 		"jp_text": "ソル・ディランダールの肉",
 		"tr_text": "Sol Dirandal Meat",
 		"jp_explain": "ソル・ディランダールから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディランダールから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330382",
 		"jp_text": "ディガーラの爪",
 		"tr_text": "Deegalla Nails",
 		"jp_explain": "ディガーラから採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディガーラから採れた爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330383",
 		"jp_text": "ソル・ディガーラの爪",
 		"tr_text": "Sol Deegalla Nails",
 		"jp_explain": "ソル・ディガーラより採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ソル・ディガーラより採れた爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330384",
 		"jp_text": "ペンドランの尻尾片",
 		"tr_text": "Pendran Tail Piece",
 		"jp_explain": "ペンドランから採れた\n尻尾の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ペンドランから採れた\n尻尾の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330385",
@@ -2713,77 +2713,77 @@
 		"jp_text": "トルボンの肉",
 		"tr_text": "Torbon Meat",
 		"jp_explain": "トルボンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "トルボンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330400",
 		"jp_text": "セグレズンのもも肉",
 		"tr_text": "Seglez'n Thigh Meat",
 		"jp_explain": "セグレズンから採れたもも肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "セグレズンから採れたもも肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330403",
 		"jp_text": "アクルプスの背びれ",
 		"tr_text": "Aqulupus Dorsal Fins",
 		"jp_explain": "アクルプスから採れた背びれ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "アクルプスから採れた背びれ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330404",
 		"jp_text": "ブルメガーラのうろこ",
 		"tr_text": "Blumegalla Scales",
 		"jp_explain": "ブルメガーラから採れたうろこ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ブルメガーラから採れたうろこ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330405",
 		"jp_text": "オルグブランの胸肉",
 		"tr_text": "Org Blan Breasts",
 		"jp_explain": "オルグブランから採れた胸肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "オルグブランから採れた胸肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330406",
 		"jp_text": "バル・ロドスの光鱗",
 		"tr_text": "Bal Rodos Scales",
 		"jp_explain": "バル・ロドスから採れた鱗。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "バル・ロドスから採れた鱗。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330407",
 		"jp_text": "セグレズンの蓄電袋",
 		"tr_text": "Seglez'n Pouch",
 		"jp_explain": "セグレズンから採れた蓄電袋。\n\n依頼者：<c a1ff6d>シー<c>　サマー",
-		"tr_explain": ""
+		"tr_explain": "セグレズンから採れた蓄電袋。\n\nClient: <c a1ff6d>Xie<c> (Summer)"
 	},
 	{
 		"assign": "330408",
 		"jp_text": "サマー・ラッピーの浮輪",
 		"tr_text": "Summer Rappy Inner Tube",
 		"jp_explain": "サマー・ラッピーのもつ浮輪。\n大きさに見合わない浮力を持つ。\n依頼者：<c a1ff6d>シー<c>　サマー",
-		"tr_explain": ""
+		"tr_explain": "サマー・ラッピーのもつ浮輪。\n大きさに見合わない浮力を持つ。\nClient: <c a1ff6d>Xie<c> (Summer)"
 	},
 	{
 		"assign": "330409",
 		"jp_text": "トルボンの殻",
 		"tr_text": "Torbon Shell",
 		"jp_explain": "トルボンの殻の破片。\n条件下で発光する珍しい素材。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "トルボンの殻の破片。\n条件下で発光する珍しい素材。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330410",
 		"jp_text": "セグレズンの帯電皮",
 		"tr_text": "Seglez'n Electric Hide",
 		"jp_explain": "セグレズンの皮膚。\n帯電性と伸縮性が高い素材。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "セグレズンの皮膚。\n帯電性と伸縮性が高い素材。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330411",
 		"jp_text": "ブルメッタの尻尾",
 		"tr_text": "Blumetta Tail",
 		"jp_explain": "ブルメッタの尻尾。\n毒をもった小さい種が含まれている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブルメッタの尻尾。\n毒をもった小さい種が含まれている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330412",
@@ -2811,539 +2811,539 @@
 		"jp_text": "バトラガンの脚部装甲",
 		"tr_text": "Batra Gun Leg Armor",
 		"jp_explain": "脚部を覆う分厚い装甲。\n背後からの攻撃を防ぐ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "脚部を覆う分厚い装甲。\n背後からの攻撃を防ぐ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330416",
 		"jp_text": "カストガーディナンの電銃",
 		"tr_text": "Cust. Guardinane Spark Gun",
 		"jp_explain": "カストガーディナンに搭載された\n強力なスタン銃。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "カストガーディナンに搭載された\n強力なスタン銃。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330417",
 		"jp_text": "ガノンバルガーの大砲",
 		"tr_text": "Ganon Valger Cannons",
 		"jp_explain": "ガノンバルガーに搭載された\nツインの大砲。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガノンバルガーに搭載された\nツインの大砲。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330418",
 		"jp_text": "カストキンディッドの刃",
 		"tr_text": "Cust. Kindidd Blades",
 		"jp_explain": "カストキンディッドの内側に搭載された\n鋭い刃の付いたパーツ。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "カストキンディッドの内側に搭載された\n鋭い刃の付いたパーツ。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330419",
 		"jp_text": "シュタークガンの足パーツ",
 		"tr_text": "Stark Gun Leg Parts",
 		"jp_explain": "シュタークガンを構成する足パーツ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "シュタークガンを構成する足パーツ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330420",
 		"jp_text": "ヴィントバルガーの障壁",
 		"tr_text": "Vinto Vargr Barriers",
 		"jp_explain": "ヴィントバルガーを中心に\n死角無く展開する鉄壁の防御機構。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヴィントバルガーを中心に\n死角無く展開する鉄壁の防御機構。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330421",
 		"jp_text": "カストガーディナンの動力",
 		"tr_text": "Cust. Guardinane Dynamos",
 		"jp_explain": "本体サイズに見合わぬ高出力な\nカストガーディナンの動力。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "本体サイズに見合わぬ高出力な\nカストガーディナンの動力。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330422",
 		"jp_text": "バトラガンのブースター",
 		"tr_text": "Batra Gun Boosters",
 		"jp_explain": "バトラガンの背負っている\nロケットブースター。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "バトラガンの背負っている\nロケットブースター。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330423",
 		"jp_text": "ヤクトディンゲールの剣刃",
 		"tr_text": "Jagd Dingell Blades",
 		"jp_explain": "ヤクトディンゲールが装備している\n巨大な大剣の刃部。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヤクトディンゲールが装備している\n巨大な大剣の刃部。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330424",
 		"jp_text": "ヴァーダーソーマ内燃機関",
 		"tr_text": "Vardha Soma Engines",
 		"jp_explain": "熱効率に優れた\nヴァーダーソーマの内燃機関。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "熱効率に優れた\nヴァーダーソーマの内燃機関。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330425",
 		"jp_text": "老成したアギニスの肉",
 		"tr_text": "Mature Aginis Meat",
 		"jp_explain": "老成したアギニスより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "老成したアギニスより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330426",
 		"jp_text": "高熱を帯びたディッグの肉",
 		"tr_text": "Feverish Digg Meat",
 		"jp_explain": "ディッグより採れた肉。\n採取後も熱を帯び続けている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ディッグより採れた肉。\n採取後も熱を帯び続けている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330427",
 		"jp_text": "スパルダンＡの脚パーツ",
 		"tr_text": "Spardan A Leg Parts",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スパルダンＡを構成する部品の一つ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330428",
 		"jp_text": "老成したデ・マルモスの肉",
 		"tr_text": "Mature De Malmoth Meat",
 		"jp_explain": "老成したデ・マルモスより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "老成したデ・マルモスより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330429",
 		"jp_text": "ギルナスの重装甲",
 		"tr_text": "Gilnas Heavy Armor",
 		"jp_explain": "ギルナスを構成する部品の一つ。\n装甲の一番厚い部分。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ギルナスを構成する部品の一つ。\n装甲の一番厚い部分。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330430",
 		"jp_text": "老成したバリドランの肉",
 		"tr_text": "Mature Baridran Meat",
 		"jp_explain": "老成したバリドランより採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "老成したバリドランより採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330431",
 		"jp_text": "グウォンダの大盾の破片",
 		"tr_text": "Gu Wonda Shield Fragments",
 		"jp_explain": "グウォンダの所持している盾の破片。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "グウォンダの所持している盾の破片。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330432",
 		"jp_text": "活発なペンドランの肉",
 		"tr_text": "Healthy Pendran Meat",
 		"jp_explain": "活きのいいペンドランの肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "活きのいいペンドランの肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330433",
 		"jp_text": "活発なアクルプスの肉",
 		"tr_text": "Healthy Aqulupus Meat",
 		"jp_explain": "活きのいいアクルプスの肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "活きのいいアクルプスの肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330434",
 		"jp_text": "ヤクトバルガーブースター",
 		"tr_text": "Jagd Vargr Boosters",
 		"jp_explain": "ヤクトバルガーを構成する部品の一つ。\n耐熱性が高い反面、再加工が困難。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヤクトバルガーを構成する部品の一つ。\n耐熱性が高い反面、再加工が困難。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330435",
 		"jp_text": "かぼちゃ型のパーツ",
 		"tr_text": "Pumpkin-like Parts",
 		"jp_explain": "かぼちゃに見えなくもないような\n造形をした金属製のパーツ。\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "かぼちゃに見えなくもないような\n造形をした金属製のパーツ。\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330436",
 		"jp_text": "クモのおもちゃ",
 		"tr_text": "Toy Spider",
 		"jp_explain": "ラタン・ラッピーの身に付けている装具。\n意外と精巧に出来ている。\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": ""
+		"tr_explain": "ラタン・ラッピーの身に付けている装具。\n意外と精巧に出来ている。\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330437",
 		"jp_text": "アギニスの美しい冠羽",
 		"tr_text": "Beautiful Aginis Crests",
 		"jp_explain": "美しいアギニスの冠羽。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "美しいアギニスの冠羽。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330438",
 		"jp_text": "ガロンゴの鋭利な爪",
 		"tr_text": "Sharp Garongo Claws",
 		"jp_explain": "ガロンゴの太い足先にある\n丈夫で分厚い爪。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴの太い足先にある\n丈夫で分厚い爪。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330439",
 		"jp_text": "ディーニアンの皮",
 		"tr_text": "Dinian Hide",
 		"jp_explain": "堅いうろこを持つディーニアンの皮。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "堅いうろこを持つディーニアンの皮。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330440",
 		"jp_text": "ディッグのまぶた",
 		"tr_text": "Digg Eyelids",
 		"jp_explain": "灼熱の溶岩の中でも耐えられるまぶた。\nディッグの皮膚では一番薄い部位。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "灼熱の溶岩の中でも耐えられるまぶた。\nディッグの皮膚では一番薄い部位。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330441",
 		"jp_text": "シグノチップ",
 		"tr_text": "Signo Chips",
 		"jp_explain": "シグノガンの俊敏な動きを制御する\n高度な技術で作られたチップパーツ。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "シグノガンの俊敏な動きを制御する\n高度な技術で作られたチップパーツ。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330442",
 		"jp_text": "スパルチップ",
 		"tr_text": "Spar Chips",
 		"jp_explain": "スパルガンの俊敏な動きを制御する\n高度な技術で作られたチップパーツ。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スパルガンの俊敏な動きを制御する\n高度な技術で作られたチップパーツ。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330443",
 		"jp_text": "ファンガルフルの頭角",
 		"tr_text": "Fangulfur Horns",
 		"jp_explain": "ファンガルフルの頭部より採れた角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファンガルフルの頭部より採れた角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330444",
 		"jp_text": "イエーデの拳骨",
 		"tr_text": "Yede Fists",
 		"jp_explain": "より硬質に進化したイエーデの拳骨。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "より硬質に進化したイエーデの拳骨。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330445",
 		"jp_text": "ギルナッチの腕",
 		"tr_text": "Gilnach Arms",
 		"jp_explain": "精密な作業が可能なギルナッチの腕。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "精密な作業が可能なギルナッチの腕。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330446",
 		"jp_text": "フォードランサの頭角",
 		"tr_text": "Fordoransa Horns",
 		"jp_explain": "湾曲したフォードランサの頭角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "湾曲したフォードランサの頭角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330447",
 		"jp_text": "ウォルガーダの膝甲",
 		"tr_text": "Wolgahda Kneecaps",
 		"jp_explain": "三重に重ねられた\nウォルガーダの膝甲。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "三重に重ねられた\nウォルガーダの膝甲。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330448",
 		"jp_text": "ディガーラの翼",
 		"tr_text": "Deegalla Wings",
 		"jp_explain": "虹色に輝くディガーラの翼。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "虹色に輝くディガーラの翼。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330449",
 		"jp_text": "ブルメガーラの花",
 		"tr_text": "Blumegalla Flowers",
 		"jp_explain": "美しく開花した\nブルメガーラの巨大な花。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "美しく開花した\nブルメガーラの巨大な花。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330450",
 		"jp_text": "ディンゲールの腕",
 		"tr_text": "Dingell Arms",
 		"jp_explain": "射撃以外にも様々な精密作業が可能な\nディンゲールの腕。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "射撃以外にも様々な精密作業が可能な\nディンゲールの腕。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330451",
 		"jp_text": "ウーダンの牙",
 		"tr_text": "Oodan Fang",
 		"jp_explain": "鋭く尖ったウーダンの牙。\n取り扱いには注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "鋭く尖ったウーダンの牙。\n取り扱いには注意が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330452",
 		"jp_text": "フォンガルフの毛皮",
 		"tr_text": "Fangulf Pelt",
 		"jp_explain": "ごわごわしたフォンガルフの毛皮。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ごわごわしたフォンガルフの毛皮。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330453",
 		"jp_text": "ガロンゴの歯",
 		"tr_text": "Garongo Tooth",
 		"jp_explain": "すりつぶすのに適したガロンゴの歯。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "すりつぶすのに適したガロンゴの歯。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330454",
 		"jp_text": "ディッグの灼熱角",
 		"tr_text": "Scorching Hot Digg Horn",
 		"jp_explain": "高熱を帯びたディッグの角。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "高熱を帯びたディッグの角。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330455",
 		"jp_text": "シル・ディーニアンのひれ",
 		"tr_text": "Sil Dinian Flipper",
 		"jp_explain": "頭頂から背まで続いている\nシル・ディーニアンのひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "頭頂から背まで続いている\nシル・ディーニアンのひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330456",
 		"jp_text": "フォードランの硬いたてがみ",
 		"tr_text": "Fordoran Tough Mane",
 		"jp_explain": "鋼のように硬い\n フォードランのたてがみ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "鋼のように硬い\n フォードランのたてがみ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330457",
 		"jp_text": "スパルガンのパーツｋ",
 		"tr_text": "Spargun Parts k",
 		"jp_explain": "スパルガンを構成するパーツ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "スパルガンを構成するパーツ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330458",
 		"jp_text": "シグノガンの脚部",
 		"tr_text": "Signo Gun Leg",
 		"jp_explain": "どんな地形でも大砲が撃てる\nバランスの良い二足脚部。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "どんな地形でも大砲が撃てる\nバランスの良い二足脚部。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330459",
 		"jp_text": "ブリアーダの強靭なかぎ爪",
 		"tr_text": "Breeahda Hard Claws",
 		"jp_explain": "ブリアーダの中でも強力な個体から\n採取した強靭なかぎ爪。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブリアーダの中でも強力な個体から\n採取した強靭なかぎ爪。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330460",
 		"jp_text": "ガルフルの強靭な爪",
 		"tr_text": "Gulfur Hard Claw",
 		"jp_explain": "硬い氷もなんなく穿ってみせる\n分厚く強靭な爪。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "硬い氷もなんなく穿ってみせる\n分厚く強靭な爪。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330461",
 		"jp_text": "マルモスの肩こぶ",
 		"tr_text": "Malmoth Shoulder Lump",
 		"jp_explain": "硬く分厚い氷壁をも破壊する\nマルモスの肩にある、こぶ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "硬く分厚い氷壁をも破壊する\nマルモスの肩にある、こぶ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330462",
 		"jp_text": "キングイエーデの拳骨",
 		"tr_text": "King Yede Fist",
 		"jp_explain": "砕けないものはないと言われる\nキングイエーデの巨大な拳骨。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "砕けないものはないと言われる\nキングイエーデの巨大な拳骨。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330463",
 		"jp_text": "ガーディンのレンズ",
 		"tr_text": "Guardine Lens",
 		"jp_explain": "ガーディンの内蔵カメラのレンズ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガーディンの内蔵カメラのレンズ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330464",
 		"jp_text": "シグノビートの左腕",
 		"tr_text": "Signo Beat Left Arm",
 		"jp_explain": "シグノビートの左腕。\n万力のような力をもつ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "シグノビートの左腕。\n万力のような力をもつ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330465",
 		"jp_text": "ギルナッチの脚部",
 		"tr_text": "Gilnach Leg",
 		"jp_explain": "ギルナッチを構成する脚部のパーツ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ギルナッチを構成する脚部のパーツ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330466",
 		"jp_text": "シル・サディニアンのひれ",
 		"tr_text": "Sil Sadinian Flipper",
 		"jp_explain": "頭頂から背まで続いている\nシル・サディニアンのひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "頭頂から背まで続いている\nシル・サディニアンのひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330467",
 		"jp_text": "バリドランのあご",
 		"tr_text": "Baridran Chin",
 		"jp_explain": "一度かぶりついたら離れない\nバリドランのあご。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "一度かぶりついたら離れない\nバリドランのあご。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330468",
 		"jp_text": "ウィンディラの翼膜",
 		"tr_text": "Windira Wings",
 		"jp_explain": "ウィンディラの翼から採れた翼膜。\n薄くて軽量ながら、伸縮性に優れる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ウィンディラの翼から採れた翼膜。\n薄くて軽量ながら、伸縮性に優れる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330469",
 		"jp_text": "ミクダの上質な紋様殻",
 		"tr_text": "Perfect Micda Husk",
 		"jp_explain": "個性的な柄をもつミクダの甲羅。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "個性的な柄をもつミクダの甲羅。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330470",
 		"jp_text": "ガウォンダのひれ刀",
 		"tr_text": "Ga Wonda Blade",
 		"jp_explain": "ガウォンダの左腕のひれ刀。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ガウォンダの左腕のひれ刀。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330471",
 		"jp_text": "キュクロナーダの武器片",
 		"tr_text": "Kuklonahda Arm Weapon",
 		"jp_explain": "キュクロナーダが振り回していた\n武器の破片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "キュクロナーダが振り回していた\n武器の破片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330472",
 		"jp_text": "ディガーラの皮",
 		"tr_text": "Deegalla Hide",
 		"jp_explain": "ディガーラから採れた皮。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディガーラから採れた皮。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330473",
 		"jp_text": "ペンドランの爪",
 		"tr_text": "Pendran Claw",
 		"jp_explain": "細長く鋭いペンドランの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "細長く鋭いペンドランの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330474",
 		"jp_text": "ディランダールの一角",
 		"tr_text": "Dirandal Horn",
 		"jp_explain": "ディランダールの\n頭頂部に生えた水晶角。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ディランダールの\n頭頂部に生えた水晶角。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330475",
 		"jp_text": "セグレズンのサンゴ",
 		"tr_text": "Seglez'n Coral",
 		"jp_explain": "セグレズンの放電現象の元となる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "セグレズンの放電現象の元となる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330476",
 		"jp_text": "ブルメガーラの爪",
 		"tr_text": "Blumegalla Claw",
 		"jp_explain": "ブルメガーラから採れた爪。\n少量だが毒性がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブルメガーラから採れた爪。\n少量だが毒性がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330477",
 		"jp_text": "オルグブランの爪",
 		"tr_text": "Org Blan Claw",
 		"jp_explain": "岩をも引き裂くオルグブランの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "岩をも引き裂くオルグブランの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330478",
 		"jp_text": "カストキンディッドの装甲",
 		"tr_text": "Custom Kindidd Armor",
 		"jp_explain": "攻撃時のみ開口する\nカストキンディッドの装甲。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "攻撃時のみ開口する\nカストキンディッドの装甲。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330479",
 		"jp_text": "ヴィントバルガーの装甲翼",
 		"tr_text": "Vinto Vargr Armored Wing",
 		"jp_explain": "ヴィントバルガーのもつ装甲翼。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ヴィントバルガーのもつ装甲翼。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330480",
 		"jp_text": "ヤクトディンゲールの右腕",
 		"tr_text": "Jagd Dingell's Right Arm",
 		"jp_explain": "ヒートブレードを振り回す\nヤクトディンゲールの右腕。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ヒートブレードを振り回す\nヤクトディンゲールの右腕。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330514",
 		"jp_text": "ブルトルボンの青い殻",
 		"tr_text": "Blutorbon Shells",
 		"jp_explain": "ブルトルボンの殻の下部を占める\n青色の部分の殻。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ブルトルボンの殻の下部を占める\n青色の部分の殻。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330515",
 		"jp_text": "ファルカボネの甲羅の破片",
 		"tr_text": "Falcabone Shell Fragments",
 		"jp_explain": "ファルカボネをおおう甲羅の破片。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファルカボネをおおう甲羅の破片。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330516",
 		"jp_text": "タグ・アクルプスの爪",
 		"tr_text": "Tag Aqulupus Claws",
 		"jp_explain": "タグ・アクルプスの足の爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タグ・アクルプスの足の爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330517",
 		"jp_text": "タロベッコのくちばし",
 		"tr_text": "Talobecko Beaks",
 		"jp_explain": "タロベッコから採れたくちばし。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タロベッコから採れたくちばし。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330518",
 		"jp_text": "ヴィド・ギロスの尾びれ",
 		"tr_text": "Vid Gilos Fins",
 		"jp_explain": "ヴィド・ギロスの尾にあるひれ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヴィド・ギロスの尾にあるひれ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330519",
 		"jp_text": "セヴァニアンの鱗",
 		"tr_text": "Sevanian Scales",
 		"jp_explain": "セヴァニアンの全身をおおう鱗。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "セヴァニアンの全身をおおう鱗。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330520",
 		"jp_text": "ファルカボネの角片",
 		"tr_text": "Falcabone Piece",
 		"jp_explain": "ファルカボネの頭部にある角の破片。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ファルカボネの頭部にある角の破片。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330521",
 		"jp_text": "タロベッコの腕角",
 		"tr_text": "Talobecko Arm",
 		"jp_explain": "タロベッコの腕部にある角状の突起。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "タロベッコの腕部にある角状の突起。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330522",
 		"jp_text": "ブルトルボンの殻の欠片",
 		"tr_text": "Blutorbon Piece",
 		"jp_explain": "ブルトルボンの殻の上部を占める\n突起状の部分の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ブルトルボンの殻の上部を占める\n突起状の部分の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330523",
 		"jp_text": "タグ・セヴァニアンのひれ",
 		"tr_text": "Tag Sevanian Fins",
 		"jp_explain": "タグ・セヴァニアンの頭部に\nはえているひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "タグ・セヴァニアンの頭部に\nはえているひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330524",
 		"jp_text": "タグ・アクルプスの牙",
 		"tr_text": "Tag Aqulupus Fangs",
 		"jp_explain": "タグ・アクルプスから採れた牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "タグ・アクルプスから採れた牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330525",
@@ -3357,49 +3357,49 @@
 		"jp_text": "タグ・アクルプスの肉",
 		"tr_text": "Tag Aqulupus Meat",
 		"jp_explain": "タグ・アクルプスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タグ・アクルプスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330527",
 		"jp_text": "タロベッコの肉",
 		"tr_text": "Talobecko Meat",
 		"jp_explain": "タロベッコから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タロベッコから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330528",
 		"jp_text": "タグ・セヴァニアンの肉",
 		"tr_text": "Tag Sevanian Meat",
 		"jp_explain": "タグ・セヴァニアンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タグ・セヴァニアンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330529",
 		"jp_text": "ファルカボネの肉",
 		"tr_text": "Falcabone Meat",
 		"jp_explain": "ファルカボネから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファルカボネから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330530",
 		"jp_text": "セヴァニアンの肉",
 		"tr_text": "Sevanian Meat",
 		"jp_explain": "セヴァニアンから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "セヴァニアンから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330531",
 		"jp_text": "ヴィド・ギロスの肉",
 		"tr_text": "Vid Gilos Meat",
 		"jp_explain": "ヴィド・ギロスから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ヴィド・ギロスから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330532",
 		"jp_text": "ビオル・メデューナの肉",
 		"tr_text": "Biol Meduna Meat",
 		"jp_explain": "ビオル・メデューナから採れた肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ビオル・メデューナから採れた肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330533",
@@ -3623,35 +3623,35 @@
 		"jp_text": "マルモスの霜降り肉",
 		"tr_text": "Broiled Malmoth Meat",
 		"jp_explain": "マルモスから採れたとても上質な肉。\n\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "マルモスから採れたとても上質な肉。\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330575",
 		"jp_text": "黄金色の鈴",
 		"tr_text": "Gold Bells",
 		"jp_explain": "セント・ラッピーが身につけている鈴。\n透き通った音色を奏でる。\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": ""
+		"tr_explain": "セント・ラッピーが身につけている鈴。\n透き通った音色を奏でる。\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330576",
 		"jp_text": "ゲームのギア",
 		"tr_text": "Game Gear",
 		"jp_explain": "アークスで流行っている\n携帯ゲーム機の部品。\n依頼者：<c a1ff6d>シー<c>　アークス共闘祭",
-		"tr_explain": "Parts of a portable gaming device,\nused by many ARKS."
+		"tr_explain": "Parts of a portable gaming device,\nused by many ARKS.\nClient: <c a1ff6d>Xie<c>　(ARKS Unity Festival)"
 	},
 	{
 		"assign": "330577",
 		"jp_text": "騎龍の角",
 		"tr_text": "Dragon Chariot Horns",
 		"jp_explain": "ソル・ディランダールや\nディランダールから採れる角。\n依頼者：<c a1ff6d>シー<c>　バレンタイン",
-		"tr_explain": "Parts of a portable gaming device,\nused by many ARKS."
+		"tr_explain": "Horns from Dirandal and Sol Dirandal.\n\nClient: <c a1ff6d>Xie<c>　(Halloween)"
 	},
 	{
 		"assign": "330578",
 		"jp_text": "海王種の霜降り肉",
 		"tr_text": "Sea King Marbled Meat",
 		"jp_explain": "海王種から採れる脂肪が細かく\n入った美味しい肉。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "海王種から採れる脂肪が細かく\n入った美味しい肉。\nClient: <c a1ff6d>Toro<c> (one-time order)"
 	},
 	{
 		"assign": "330579",
@@ -3756,35 +3756,35 @@
 		"jp_text": "ラヴィ・ラッピーの羽根",
 		"tr_text": "Lovey Rappy Feathers",
 		"jp_explain": "ラヴィ・ラッピーの\n落としていった羽根。\n依頼者：<c a1ff6d>シー<c>　ホワイトデー",
-		"tr_explain": "Parts of a portable gaming device,\nused by many ARKS."
+		"tr_explain": "Feathers dropped by a Lovey Rappy.\n\nClient: <c a1ff6d>Xie<c>　(White Day)"
 	},
 	{
 		"assign": "330596",
 		"jp_text": "タマゴ型のパーツ",
 		"tr_text": "Egg-shaped Parts",
 		"jp_explain": "この時期にだけ現れるラッピーが\n身に着けているタマゴ型のパーツ。\n依頼者：<c a1ff6d>シー<c>　スプリング",
-		"tr_explain": ""
+		"tr_explain": "この時期にだけ現れるラッピーが\n身に着けているタマゴ型のパーツ。\nClient: <c a1ff6d>Xie<c> (Spring)"
 	},
 	{
 		"assign": "330597",
 		"jp_text": "シンボル・エッグ",
 		"tr_text": "Symbol Egg",
 		"jp_explain": "イースターの目印。\n車輪が取り付けられている。\n依頼者：<c a1ff6d>シー<c>　スプリング",
-		"tr_explain": ""
+		"tr_explain": "イースターの目印。\n車輪が取り付けられている。\nClient: <c a1ff6d>Xie<c> (Spring)"
 	},
 	{
 		"assign": "330598",
 		"jp_text": "おまじないの人形",
 		"tr_text": "Charm of the Doll",
 		"jp_explain": "フログ・ラッピーが所持している人形。\n丸い物体に布を被せて作られている。\n依頼者：<c a1ff6d>シー<c>　スプリング",
-		"tr_explain": ""
+		"tr_explain": "フログ・ラッピーが所持している人形。\n丸い物体に布を被せて作られている。\nClient: <c a1ff6d>Xie<c> (Spring)"
 	},
 	{
 		"assign": "330599",
 		"jp_text": "ガロンゴの苔",
 		"tr_text": "Garongo Moss",
 		"jp_explain": "ガロンゴに付着している苔。\n意外にも手触りが良い。\n依頼者：<c a1ff6d>シー<c>　スプリング",
-		"tr_explain": ""
+		"tr_explain": "ガロンゴに付着している苔。\n意外にも手触りが良い。\nClient: <c a1ff6d>Xie<c> (Spring)"
 	},
 	{
 		"assign": "330600",
@@ -3847,56 +3847,56 @@
 		"jp_text": "蒼色の玉石",
 		"tr_text": "Blue Pebble",
 		"jp_explain": "龍族が所持している玉石。\n冷たい群青色をしている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "龍族が所持している玉石。\n冷たい群青色をしている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330609",
 		"jp_text": "琥珀色の玉石",
 		"tr_text": "Amber Pebble",
 		"jp_explain": "機甲種が所持している玉石。\n暖かな琥珀色をしている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "機甲種が所持している玉石。\n暖かな琥珀色をしている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330610",
 		"jp_text": "乳白色の玉石",
 		"tr_text": "Opal Pebble",
 		"jp_explain": "原生種が所持している玉石。\n柔らかな乳白色をしている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "原生種が所持している玉石。\n柔らかな乳白色をしている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330611",
 		"jp_text": "紅闇の玉石",
 		"tr_text": "Dark Crimson Pebble",
 		"jp_explain": "ダーカーが落とした玉石。\n侵食され暗紅色に変色している。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "ダーカーが落とした玉石。\n侵食され暗紅色に変色している。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330612",
 		"jp_text": "ナイトギアの破損した剣",
 		"tr_text": "Knight Gear Damaged Sword",
 		"jp_explain": "ナイトギアが持つ剣の破片。\n淡い紫の光を放っている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "ナイトギアが持つ剣の破片。\n淡い紫の光を放っている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330613",
 		"jp_text": "ナイトギアの破損した盾",
 		"tr_text": "Knight Gear Damaged Shield",
 		"jp_explain": "ナイトギアが持つ盾の破片。\n不思議な模様が描かれている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "ナイトギアが持つ盾の破片。\n不思議な模様が描かれている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330614",
 		"jp_text": "ナイトギアの破損した部品",
 		"tr_text": "Knight Gear Damaged Parts",
 		"jp_explain": "ナイトギアから入手した装甲の一部。\n不可思議な素材で作られている。\n依頼者：<c a1ff6d>シー<c>　2周年記念",
-		"tr_explain": ""
+		"tr_explain": "ナイトギアから入手した装甲の一部。\n不可思議な素材で作られている。\nClient: <c a1ff6d>Xie<c> (2nd Anniversary)"
 	},
 	{
 		"assign": "330615",
 		"jp_text": "ラッピーのゴムボート",
 		"tr_text": "Rappy Inflatable Boat",
 		"jp_explain": "サマー・ラッピーが乗っていた\nゴムボート。思ったより頑丈な作り。\n依頼者：<c a1ff6d>シー<c>　サマー",
-		"tr_explain": ""
+		"tr_explain": "サマー・ラッピーが乗っていた\nゴムボート。思ったより頑丈な作り。\nClient: <c a1ff6d>Xie<c> (Summer)"
 	},
 	{
 		"assign": "330616",
@@ -3910,35 +3910,35 @@
 		"jp_text": "アヌシザグリのお札",
 		"tr_text": "Anushi-zagri Notes",
 		"jp_explain": "アヌシザグリに付着しているお札。\n文字のようなものが記入されている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "アヌシザグリに付着しているお札。\n文字のようなものが記入されている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330618",
 		"jp_text": "パジギッリの帯の欠片",
 		"tr_text": "Paji-ghiry Sash Fragments",
 		"jp_explain": "パジギッリの纏う帯の欠片。\n緩やかなカーブを描いている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "パジギッリの纏う帯の欠片。\n緩やかなカーブを描いている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330619",
 		"jp_text": "ガンナガムの大角",
 		"tr_text": "Ganna-gam Horn",
 		"jp_explain": "ガンナガムに生えている大きな角。\nずっしりとした重みがある。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ガンナガムに生えている大きな角。\nずっしりとした重みがある。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330620",
 		"jp_text": "レランガムの風袋",
 		"tr_text": "Leran-gam Weights",
 		"jp_explain": "レランガムが持つ特殊な繊維で\n編まれた袋。開くと風があふれてくる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "レランガムが持つ特殊な繊維で\n編まれた袋。開くと風があふれてくる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330621",
 		"jp_text": "碧氷石",
 		"tr_text": "Azure Ice Stones",
 		"jp_explain": "ギグル・グンネガムが持っている石。\n触れてみるとわずかに冷たい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ギグル・グンネガムが持っている石。\n触れてみるとわずかに冷たい。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330622",
@@ -3959,35 +3959,35 @@
 		"jp_text": "イザオガルの角",
 		"tr_text": "Iza-ogar Horns",
 		"jp_explain": "イザオガルに生えている角。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "イザオガルに生えている角。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330625",
 		"jp_text": "ピッタ・ワッダの輪",
 		"tr_text": "Pitta Wadda Rings",
 		"jp_explain": "ピッタ・ワッダが持つ輪っか。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ピッタ・ワッダが持つ輪っか。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330626",
 		"jp_text": "ハルコタン観測素子ａ",
 		"tr_text": "Harkotan Observation Dev. a",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "330627",
 		"jp_text": "破損したダーカーコアｅ",
 		"tr_text": "Damaged Darker Core e",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や法撃によって破損している。\n依頼者：<c a1ff6d>カトリ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーから採取されたコア。\n斬撃や法撃によって破損している。\nClient: <c a1ff6d>Katori<c> (one-time order)"
 	},
 	{
 		"assign": "330628",
 		"jp_text": "破損したダーカーコアｄ",
 		"tr_text": "Corrupted Darker Core d",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や射撃によって破損している。\n依頼者：<c a1ff6d>アザナミ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "ダーカーから採取されたコア。\n斬撃や射撃によって破損している。\nClient: <c a1ff6d>Azanami<c> (one-time order)"
 	},
 	{
 		"assign": "330629",
@@ -4001,49 +4001,49 @@
 		"jp_text": "タルボルプスの刃片",
 		"tr_text": "Tarvolpus Blades",
 		"jp_explain": "タルボルプスの脚部にある刃の欠片。\n鋭利な刃物に似ている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "タルボルプスの脚部にある刃の欠片。\n鋭利な刃物に似ている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330631",
 		"jp_text": "ファルガルボンの貝殻",
 		"tr_text": "Falgarbon Shell",
 		"jp_explain": "ファルガルボンが背負っている貝殻。\n傾けると淡い青色に輝いている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ファルガルボンが背負っている貝殻。\n傾けると淡い青色に輝いている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330632",
 		"jp_text": "ネプト・キャサドーラの鱗",
 		"tr_text": "Nepto Cassadora Scale",
 		"jp_explain": "ネプト・キャサドーラが落とした鱗。\nぬらりとした輝きを放っている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ネプト・キャサドーラが落とした鱗。\nぬらりとした輝きを放っている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330633",
 		"jp_text": "レオマドゥラードの鋭棘",
 		"tr_text": "Rheo Madullard Spine",
 		"jp_explain": "レオマドゥラードの背中にある棘。\nほんのりと発光している。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "レオマドゥラードの背中にある棘。\nほんのりと発光している。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330634",
 		"jp_text": "魔法使いの帽子",
 		"tr_text": "Sorcerer Hat",
 		"jp_explain": "ラタン・ラッピーがかぶっている帽子。\nとんがり具合がとてもかわいらしい。\n依頼者：<c a1ff6d>シー<c>　オータム",
-		"tr_explain": ""
+		"tr_explain": "ラタン・ラッピーがかぶっている帽子。\nとんがり具合がとてもかわいらしい。\nClient: <c a1ff6d>Xie<c> (Autumn)"
 	},
 	{
 		"assign": "330635",
 		"jp_text": "シルト・グリミアンの殻",
 		"tr_text": "Schilt Grimian Shells",
 		"jp_explain": "シルト・グリミアンがまとう\n鮮やかな殻。\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "シルト・グリミアンがまとう\n鮮やかな殻。\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330636",
 		"jp_text": "ランズ・ヴァレーダの尾刃",
 		"tr_text": "Lanz Vareda Tail Blades",
 		"jp_explain": "ランズ・ヴァレーダの尾にある刃。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ランズ・ヴァレーダの尾にある刃。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330637",
@@ -4309,7 +4309,7 @@
 		"jp_text": "ワンダー・ボックス",
 		"tr_text": "Wonder Box",
 		"jp_explain": "ピッタ・ワッダとパラタ・ピコーダが\n落とした小箱。鮮やかでかわいらしい。\n依頼者：<c a1ff6d>シー<c>　アークス共闘祭2015",
-		"tr_explain": ""
+		"tr_explain": "ピッタ・ワッダとパラタ・ピコーダが\n落とした小箱。鮮やかでかわいらしい。\nClient: <c a1ff6d>Xie<c> (ARKS Festival 2015)"
 	},
 	{
 		"assign": "330675",
@@ -4323,14 +4323,14 @@
 		"jp_text": "タマゴのかけら",
 		"tr_text": "Egg Pieces",
 		"jp_explain": "エグ・ラッピーが身に着けている\nタマゴ型パーツのかけら。\n依頼者：<c a1ff6d>シー<c>　イースター2015",
-		"tr_explain": ""
+		"tr_explain": "エグ・ラッピーが身に着けている\nタマゴ型パーツのかけら。\nClient: <c a1ff6d>Xie<c> (Easter 2015)"
 	},
 	{
 		"assign": "330677",
 		"jp_text": "鈍色の鱗",
 		"tr_text": "Dark Grey Scales",
-		"jp_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\n依頼者：<c a1ff6d>セラフィ<c>　期間限定再受注可能",
-		"tr_explain": ""
+		"jp_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\n依頼者：<c a1ff6d>セラフィ<c>　　期間限定再受注可能",
+		"tr_explain": "龍族が落とした鱗。\n鈍く輝きを放っている。\nClient: <c a1ff6d>Seraphy<c> (limited time)"
 	},
 	{
 		"assign": "330678",
@@ -4343,8 +4343,8 @@
 		"assign": "330679",
 		"jp_text": "紫色の小さな花",
 		"tr_text": "Small Purple Flowers",
-		"jp_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\n依頼者：<c a1ff6d>シー<c>　レイニー2015",
-		"tr_explain": ""
+		"jp_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\n依頼者：<c a1ff6d>シー<c>　　レイニー2015",
+		"tr_explain": "フログ・ラッピーが持っていた花。\n雨に濡れてしっとりとしている。\nClient: <c a1ff6d>Xie<c> (Rainy 2015)"
 	},
 	{
 		"assign": "330680",
@@ -4365,49 +4365,49 @@
 		"jp_text": "ハルコタン観測素子ｂ",
 		"tr_text": "Harkotan Observation Dev. b",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "330689",
 		"jp_text": "パジゴワンの鼓",
 		"tr_text": "Paji-gowan Drums",
 		"jp_explain": "パジゴワンの持つ鼓。\n薄く柔らかいが、かなりの強度がある。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "パジゴワンの持つ鼓。\n薄く柔らかいが、かなりの強度がある。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330690",
 		"jp_text": "コドニアガリの種火",
 		"tr_text": "Godoni-agari Ember",
 		"jp_explain": "コドニアガリに灯されていた火の種。\n一度消えても着火剤として使える。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "コドニアガリに灯されていた火の種。\n一度消えても着火剤として使える。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330691",
 		"jp_text": "イタギザクリの鋭爪",
 		"tr_text": "Itagi-zakri Claws",
 		"jp_explain": "イタギザクリの鋭い爪。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "イタギザクリの鋭い爪。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330692",
 		"jp_text": "オロオガルの大斧",
 		"tr_text": "Oro-ogar Large Axe",
 		"jp_explain": "オロオガルの持つ大斧。\n使い古され、所々刃こぼれしている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "オロオガルの持つ大斧。\n使い古され、所々刃こぼれしている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330693",
 		"jp_text": "巨大な玩具の破片",
 		"tr_text": "Large Toy Part",
 		"jp_explain": "コドッタ・イーデッタの箱状の破片。\n中身は開けてみないとわからない。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "コドッタ・イーデッタの箱状の破片。\n中身は開けてみないとわからない。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330694",
 		"jp_text": "魂狩の大鎌",
 		"tr_text": "Spirit Scythe",
 		"jp_explain": "グアル・ジグモルデが持つ大きな鎌。\n魂をも刈り取りそうな形をしている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "グアル・ジグモルデが持つ大きな鎌。\n魂をも刈り取りそうな形をしている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330695",
@@ -4427,36 +4427,36 @@
 		"assign": "330697",
 		"jp_text": "小さなシュノーケル",
 		"tr_text": "Small Snorkels",
-		"jp_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\n依頼者：<c a1ff6d>シー<c>　サマー2015",
-		"tr_explain": ""
+		"jp_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\n依頼者：<c a1ff6d>シー<c>　　サマー2015",
+		"tr_explain": "サマー・ラッピーが身に着けている\n精巧な作りのシュノーケル。\nClient: <c a1ff6d>Xie<c> (Summer 2015)"
 	},
 	{
 		"assign": "330698",
 		"jp_text": "コドニアガリの鈴",
 		"tr_text": "Godoni-agari Bells",
 		"jp_explain": "コドニアガリに付いている鈴。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "コドニアガリに付いている鈴。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330699",
 		"jp_text": "オガキバルの紋",
 		"tr_text": "Ogaki-baru Crests",
 		"jp_explain": "オガキバルたちが身に着けている紋。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "オガキバルたちが身に着けている紋。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330700",
 		"jp_text": "プロジオーグルスの肉",
 		"tr_text": "Plosiorgles Meat",
 		"jp_explain": "プロジオーグルスから採れた肉。\nクセが強く、調理には工夫が必要。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "プロジオーグルスから採れた肉。\nクセが強く、調理には工夫が必要。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330701",
 		"jp_text": "ゼータ・グランゾの主砲",
 		"tr_text": "Zeta Guranz Cannon",
 		"jp_explain": "ゼータ・グランゾの腹部にある主砲。\n出力の制御はかなり難しい模様。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ゼータ・グランゾの腹部にある主砲。\n出力の制御はかなり難しい模様。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330702",
@@ -4491,14 +4491,14 @@
 		"jp_text": "カボチャのかぶりもの",
 		"tr_text": "Pumpkin Headgear",
 		"jp_explain": "ラタン・ラッピーの被っている\nカボチャ。意外と精巧に作られている。\n依頼者：<c a1ff6d>シー<c>　ハロウィン2015",
-		"tr_explain": ""
+		"tr_explain": "ラタン・ラッピーの被っている\nカボチャ。意外と精巧に作られている。\nClient: <c a1ff6d>Xie<c> (Halloween 2015)"
 	},
 	{
 		"assign": "330707",
 		"jp_text": "ぐるぐるロリポップ",
 		"tr_text": "Round Lolipop",
 		"jp_explain": "オロタ・ビケッタが持つ\n飴を模した巨大な杖。\n依頼者：<c a1ff6d>シー<c>　ハロウィン2015",
-		"tr_explain": ""
+		"tr_explain": "オロタ・ビケッタが持つ\n飴を模した巨大な杖。\nClient: <c a1ff6d>Xie<c> (Halloween 2015)"
 	},
 	{
 		"assign": "330708",
@@ -4526,14 +4526,14 @@
 		"jp_text": "極彩色のかけら",
 		"tr_text": "Rich-Colored Fragments",
 		"jp_explain": "不思議な色合いをした硬質のかけら。\n加工すれば装飾品に使えそう？\n依頼者：<c a1ff6d>シー<c>　クリスマス2015",
-		"tr_explain": ""
+		"tr_explain": "不思議な色合いをした硬質のかけら。\n加工すれば装飾品に使えそう？\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
 	},
 	{
 		"assign": "330712",
 		"jp_text": "ハッピーラッピーベル",
 		"tr_text": "Happy Rappy Bell",
 		"jp_explain": "セント・ラッピーが持つ小さなベル。\n澄んだ音色が夜の凍土に響きわたる。\n依頼者：<c a1ff6d>シー<c>　クリスマス2015",
-		"tr_explain": ""
+		"tr_explain": "セント・ラッピーが持つ小さなベル。\n澄んだ音色が夜の凍土に響きわたる。\nClient: <c a1ff6d>Xie<c> (Christmas 2015)"
 	},
 	{
 		"assign": "330713",
@@ -4561,28 +4561,28 @@
 		"jp_text": "太古の肉",
 		"tr_text": "Ancient Meat",
 		"jp_explain": "かつて地球にいた巨大生物の肉。\n骨に肉を巻きつけたような不思議な形。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "かつて地球にいた巨大生物の肉。\n骨に肉を巻きつけたような不思議な形。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330720",
 		"jp_text": "スネークヘリエンジン",
 		"tr_text": "Snake Heli-Engines",
 		"jp_explain": "スネークヘリのエンジン。\n取り込んだ空気で主軸を回転させる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "スネークヘリのエンジン。\n取り込んだ空気で主軸を回転させる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330721",
 		"jp_text": "１５式戦車の主砲",
 		"tr_text": "Type-15 Tank Cannon",
 		"jp_explain": "１５式戦車の主砲。\n様々な種類の砲弾を発射できる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "１５式戦車の主砲。\n様々な種類の砲弾を発射できる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330722",
 		"jp_text": "トレインモーター",
 		"tr_text": "Train Mortar",
 		"jp_explain": "トレイン・ギドランのモーター。\n小型で軽量かつ省電力な設計。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "トレイン・ギドランのモーター。\n小型で軽量かつ省電力な設計。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330723",
@@ -4596,14 +4596,14 @@
 		"jp_text": "ゾンビのネクタイ",
 		"tr_text": "Zombie Necktie",
 		"jp_explain": "ゾンビたちが身に着けているネクタイ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ゾンビたちが身に着けているネクタイ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330725",
 		"jp_text": "ロードローラーのローラー",
 		"tr_text": "Road Roller Roller",
 		"jp_explain": "ロードローラーの大きなローラー。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ロードローラーの大きなローラー。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330726",
@@ -4617,35 +4617,35 @@
 		"jp_text": "きれいな貝殻",
 		"tr_text": "Beautiful Shells",
 		"jp_explain": "きらきら光るきれいな貝殻。\nちょっとしたプレゼントに喜ばれそう。\n依頼者：<c a1ff6d>ジェネ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "きらきら光るきれいな貝殻。\nちょっとしたプレゼントに喜ばれそう。\nClient: <c a1ff6d>Gene<c> (repeatable)"
 	},
 	{
 		"assign": "330728",
 		"jp_text": "ピエロナイフ",
 		"tr_text": "Clown Knife",
 		"jp_explain": "ジャグラーピエロのナイフ。\nするどい刃がギラギラと光っている。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "ジャグラーピエロのナイフ。\nするどい刃がギラギラと光っている。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330729",
 		"jp_text": "ピエロチェーンソー",
 		"tr_text": "Clown Chainsaw",
 		"jp_explain": "チェーンソーピエロの武器だったもの。\n使用のさいには取り扱いに要注意。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "チェーンソーピエロの武器だったもの。\n使用のさいには取り扱いに要注意。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330730",
 		"jp_text": "牽引ビーム発生装置",
 		"tr_text": "Tractor Beam Generator",
 		"jp_explain": "U.F.Oに搭載されていた装置。\n謎の光線で物体を引き寄せられる。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "U.F.Oに搭載されていた装置。\n謎の光線で物体を引き寄せられる。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330731",
 		"jp_text": "トラックマフラー",
 		"tr_text": "Truck Muffler",
 		"jp_explain": "デビルズトレーラーの円筒型マフラー。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "デビルズトレーラーの円筒型マフラー。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330732",
@@ -4659,21 +4659,21 @@
 		"jp_text": "ネオン管",
 		"tr_text": "Neon Tube",
 		"jp_explain": "どことなくレトロさを感じるネオン管。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "どことなくレトロさを感じるネオン管。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330734",
 		"jp_text": "デュラハンライダーの側車",
 		"tr_text": "Dullahan Side Car",
 		"jp_explain": "デュラハンライダーのサイドカー。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "デュラハンライダーのサイドカー。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330735",
 		"jp_text": "グリュゾラス・ドラゴの鱗",
 		"tr_text": "Greuzoras Drago Scales",
 		"jp_explain": "グリュゾラス・ドラゴの硬質な鱗。\n光にあてると七色に輝く。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": ""
+		"tr_explain": "グリュゾラス・ドラゴの硬質な鱗。\n光にあてると七色に輝く。\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330736",
@@ -4687,7 +4687,7 @@
 		"jp_text": "目覚めの花",
 		"tr_text": "Awakening Flowers",
 		"jp_explain": "薬効があるとされる希少な花。\nその香りには気付け作用もあるらしい。\n依頼者：<c a1ff6d>アネット<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "薬効があるとされる希少な花。\nその香りには気付け作用もあるらしい。\nClient: <c a1ff6d>Annette<c> (one-time order)"
 	},
 	{
 		"assign": "330738",
@@ -4701,21 +4701,21 @@
 		"jp_text": "瑠璃色の小さな花",
 		"tr_text": "Small Azure Flowers",
 		"jp_explain": "瑠璃色の花弁を持つ小さな花。\n爽やかな香りがする。\n依頼者：<c a1ff6d>イツキ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "瑠璃色の花弁を持つ小さな花。\n爽やかな香りがする。\nClient: <c a1ff6d>Itsuki<c> (one-time order)"
 	},
 	{
 		"assign": "330740",
 		"jp_text": "漆黒のサンゴ",
 		"tr_text": "Jet Black Coral",
 		"jp_explain": "浮遊大陸で成長したサンゴ。\n艶めく黒色が目をひく。\n依頼者：<c a1ff6d>†コア†<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "浮遊大陸で成長したサンゴ。\n艶めく黒色が目をひく。\nClient: <c a1ff6d>†Coa†<c> (one-time order)"
 	},
 	{
 		"assign": "330741",
 		"jp_text": "浮遊大陸の白色粘土",
 		"tr_text": "Skyscape White Clay",
 		"jp_explain": "浮遊大陸でとれる粘土。焼成して磨くと\n銀細工のような光沢を帯びる。\n依頼者：<c a1ff6d>ムサシ<c>　再受注不可",
-		"tr_explain": ""
+		"tr_explain": "浮遊大陸でとれる粘土。焼成して磨くと\n銀細工のような光沢を帯びる。\nClient: <c a1ff6d>Musashi<c> (one-time order)"
 	},
 	{
 		"assign": "330742",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -380,7 +380,7 @@
 	{
 		"assign": "33054",
 		"jp_text": "丸い小石",
-		"tr_text": "Round Pebbles",
+		"tr_text": "Round Pebble",
 		"jp_explain": "丸くひらべったい石。\n冷たい輝きを宿している。\n依頼者：<c a1ff6d>クレシダ<c>　再受注可能",
 		"tr_explain": "A perfectly round stone. Has a faint,\ncold shine to it.\nClient: <c a1ff6d>Kressida<c> (repeatable)"
 	},
@@ -604,7 +604,7 @@
 	{
 		"assign": "33086",
 		"jp_text": "銀白色の小石",
-		"tr_text": "White Silver Pebbles",
+		"tr_text": "White Silver Pebble",
 		"jp_explain": "硬質な銀白色の鉱石の欠片。\n\n依頼者：<c a1ff6d>クレシダ<c>　再受注可能",
 		"tr_explain": "A piece of hard, silvery-white ore.\n\nClient: <c a1ff6d>Kressida<c> (repeatable)"
 	},
@@ -2235,7 +2235,7 @@
 	{
 		"assign": "330319",
 		"jp_text": "苔むした小石",
-		"tr_text": "Mossy Pebbles",
+		"tr_text": "Mossy Pebble",
 		"jp_explain": "苔のようなものに覆われている小石。\n\n依頼者：<c a1ff6d>クレシダ<c>　再受注不可",
 		"tr_explain": "A pebble covered with some kind of\nmoss.\nClient: <c a1ff6d>Kressida<c> (one-time order)"
 	},

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -641,7 +641,7 @@
 		"jp_text": "ファングバンサーの皮",
 		"tr_text": "Fang Banther Hide",
 		"jp_explain": "ファングバンサーから採れた皮。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "Leather harvested from a Fang\nBanther.\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Hide taken from a Fang Banther.\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33092",
@@ -669,14 +669,14 @@
 		"jp_text": "バリドランの肉",
 		"tr_text": "Baridran Meat",
 		"jp_explain": "バリドランから採れた肉。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "バリドランから採れた肉。\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Meat taken from a Baridran.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33096",
 		"jp_text": "ウィンディラの翼角",
 		"tr_text": "Windira Wing Horns",
 		"jp_explain": "ウィンディラの翼から採れた角。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ウィンディラの翼から採れた角。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Horns taken from a Windira's wings.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33097",
@@ -690,7 +690,7 @@
 		"jp_text": "クォーツ・ドラゴンの鱗",
 		"tr_text": "Quartz Dragon Scales",
 		"jp_explain": "クォーツ・ドラゴンから採れた鱗。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "クォーツ・ドラゴンから採れた鱗。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Scales taken from a Quartz Dragon.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "33099",
@@ -767,7 +767,7 @@
 		"jp_text": "アギニスのかぎ爪",
 		"tr_text": "Aginis Talon",
 		"jp_explain": "アギニスから採れたかぎ爪。\n\n依頼者：<c a1ff6d>シー<c>　ハロウィン",
-		"tr_explain": "アギニスから採れたかぎ爪。\n\nClient: <c a1ff6d>Xie<c> (Halloween)"
+		"tr_explain": "Talons taken from an Aginis.\n\nClient: <c a1ff6d>Xie<c> (Halloween)"
 	},
 	{
 		"assign": "330110",
@@ -795,140 +795,140 @@
 		"jp_text": "ナヴ・ラッピーの羽毛",
 		"tr_text": "Nab Rappy Feathers",
 		"jp_explain": "ナヴ・ラッピーから採れた羽毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ナヴ・ラッピーから採れた羽毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Feathers taken from a Nab Rappy.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330114",
 		"jp_text": "ウーダンの毛",
 		"tr_text": "Oodan Fur",
 		"jp_explain": "ウーダンから採れた毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ウーダンから採れた毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fur taken from an Oodan.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330115",
 		"jp_text": "ザウーダンの棘",
-		"tr_text": "Za Oodan Thorns",
+		"tr_text": "Za Oodan Spines",
 		"jp_explain": "ザウーダンから採れた上腕部の棘。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ザウーダンから採れた上腕部の棘。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Spines taken from the upper arm of a\nZa Oodan.\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330116",
 		"jp_text": "ガルフの牙",
 		"tr_text": "Gulf Fangs",
 		"jp_explain": "ガルフから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ガルフから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fangs taken from a Gulf.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330117",
 		"jp_text": "フォードランのたてがみ",
-		"tr_text": "Fordoran Manes",
+		"tr_text": "Fordoran Mane",
 		"jp_explain": "フォードランから採れたたてがみ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "フォードランから採れたたてがみ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Mane taken from a Fordoran.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330118",
 		"jp_text": "ノーディランの尻尾",
-		"tr_text": "Nordiran Tails",
+		"tr_text": "Nordiran Tail",
 		"jp_explain": "ノーディランから採れた尻尾。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ノーディランから採れた尻尾。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Tail taken from a Nordiran.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330119",
 		"jp_text": "シル・ディーニアンの鱗",
 		"tr_text": "Sil Dinian Scales",
 		"jp_explain": "シル・ディーニアンから採れた鱗。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "シル・ディーニアンから採れた鱗。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Scales taken from a Sil Dinian.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330120",
 		"jp_text": "ソル・ディーニアンの牙",
 		"tr_text": "Sol Dinian Fangs",
 		"jp_explain": "ソル・ディーニアンから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ソル・ディーニアンから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fangs taken from a Sol Dinian.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330121",
 		"jp_text": "ディーニアンの背びれ",
 		"tr_text": "Dinian Fins",
 		"jp_explain": "ディーニアンから採れた背びれの一部。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ディーニアンから採れた背びれの一部。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fins taken from a Dinian.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330122",
 		"jp_text": "フォンガルフの爪",
 		"tr_text": "Fangulf Claws",
 		"jp_explain": "フォンガルフから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "フォンガルフから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Claws taken from a Fangulf.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330123",
 		"jp_text": "ガロンゴの臼歯",
 		"tr_text": "Garongo Molars",
 		"jp_explain": "ガロンゴから採れた臼歯。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ガロンゴから採れた臼歯。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Molar teeth taken from a Garongo.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330124",
 		"jp_text": "ダガンの甲殻",
-		"tr_text": "Dagan Carapaces",
+		"tr_text": "Dagan Carapace",
 		"jp_explain": "ダガンから採れた甲殻。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ダガンから採れた甲殻。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Carapace taken from a Dagan.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330125",
 		"jp_text": "カルターゴの脚",
 		"tr_text": "Kartargot Legs",
 		"jp_explain": "カルターゴから採れた脚。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "カルターゴから採れた脚。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Legs taken from a Kartargot.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330126",
 		"jp_text": "ヴォル・ドラゴンの爪",
-		"tr_text": "Vol Dragon Claw",
+		"tr_text": "Vol Dragon Claws",
 		"jp_explain": "ヴォル・ドラゴンから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ヴォル・ドラゴンから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Claws taken from a Vol Dragon.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330127",
 		"jp_text": "クラーダの大あご",
 		"tr_text": "Krahda Mandibles",
 		"jp_explain": "クラーダから採れた大あご。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "クラーダから採れた大あご。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Mouth parts taken from a Krahda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330128",
 		"jp_text": "エル・アーダの羽",
 		"tr_text": "El Ahda Wings",
 		"jp_explain": "エル・アーダから採れた羽。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "エル・アーダから採れた羽。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Wings taken from an El Ahda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330129",
 		"jp_text": "シグノガンの砲身",
-		"tr_text": "Signo Gun Barrels",
+		"tr_text": "Signo Gun Barrel",
 		"jp_explain": "シグノガンを構成する部品の一つ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "シグノガンを構成する部品の一つ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "One of the parts that make up a\nSigno Gun.\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330130",
 		"jp_text": "グワナーダの甲殻",
 		"tr_text": "Gwanahda Carapaces",
 		"jp_explain": "グワナーダから採れた甲殻。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "グワナーダから採れた甲殻。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Carapace taken from a Gwanahda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330131",
 		"jp_text": "イエーデの毛",
 		"tr_text": "Yede Fur",
 		"jp_explain": "イエーデから採れた毛。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "イエーデから採れた毛。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fur taken from a Yede.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330132",
 		"jp_text": "マルモスのひづめ",
 		"tr_text": "Malmoth Hooves",
 		"jp_explain": "マルモスから採れたひづめ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "マルモスから採れたひづめ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Hooves taken from a Malmoth.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330133",
@@ -977,7 +977,7 @@
 		"jp_text": "キャタドランサの牙",
 		"tr_text": "Caterdransa Fangs",
 		"jp_explain": "キャタドランサから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "キャタドランサから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fangs taken from a Caterdransa.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330140",
@@ -2146,7 +2146,7 @@
 		"jp_text": "アギニスの尾羽根",
 		"tr_text": "Aginis Tail Feathers",
 		"jp_explain": "アギニスから採れた尾羽根。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "アギニスから採れた尾羽根。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Tail feathers taken from an Aginis.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330307",
@@ -2160,14 +2160,14 @@
 		"jp_text": "ブリアーダの羽",
 		"tr_text": "Breeahda Wings",
 		"jp_explain": "ブリアーダから採れた羽。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ブリアーダから採れた羽。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Wings taken from a Breeahda.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330309",
 		"jp_text": "ファンガルフルの爪",
 		"tr_text": "Fangulfur Claws",
 		"jp_explain": "ファンガルフルから採れた爪。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ファンガルフルから採れた爪。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Claws taken from a Fangulfur.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330310",
@@ -2181,7 +2181,7 @@
 		"jp_text": "クォーツ・ドラゴンの牙",
 		"tr_text": "Quartz Dragon Fangs",
 		"jp_explain": "クォーツ・ドラゴンから採れた牙。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "クォーツ・ドラゴンから採れた牙。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Fangs taken from a Quartz Dragon.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330312",
@@ -2214,9 +2214,9 @@
 	{
 		"assign": "330316",
 		"jp_text": "クラバーダの甲殻",
-		"tr_text": "Krabahda Shells",
+		"tr_text": "Krabahda Shell",
 		"jp_explain": "クラバーダから採れた甲殻。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "クラバーダから採れた甲殻。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Shell taken from a Krabahda.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330317",
@@ -2256,9 +2256,9 @@
 	{
 		"assign": "330322",
 		"jp_text": "ファンガルフルの牙",
-		"tr_text": "Fangulfur Fang",
+		"tr_text": "Fangulfur Fangs",
 		"jp_explain": "ファンガルフルより採れた牙。\n\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": "ファンガルフルより採れた牙。\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
+		"tr_explain": "Fangs taken from a Fangulfur.\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330323",
@@ -2277,9 +2277,9 @@
 	{
 		"assign": "330325",
 		"jp_text": "上質なロウ",
-		"tr_text": "High-Quality Raw",
+		"tr_text": "High-Quality Wax",
 		"jp_explain": "キャンドルを作るために必要なもの。\n\n依頼者：<c a1ff6d>シー<c>　クリスマス",
-		"tr_explain": "キャンドルを作るために必要なもの。\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
+		"tr_explain": "Just what you need to make a candle.\n\nClient: <c a1ff6d>Xie<c> (Christmas)"
 	},
 	{
 		"assign": "330326",
@@ -2601,7 +2601,7 @@
 		"jp_text": "ディガーラの爪",
 		"tr_text": "Deegalla Nails",
 		"jp_explain": "ディガーラから採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディガーラから採れた爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Nails taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330383",
@@ -2720,28 +2720,28 @@
 		"jp_text": "セグレズンのもも肉",
 		"tr_text": "Seglez'n Thigh Meat",
 		"jp_explain": "セグレズンから採れたもも肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "セグレズンから採れたもも肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Thigh meat taken from a Seglez'n.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330403",
 		"jp_text": "アクルプスの背びれ",
 		"tr_text": "Aqulupus Dorsal Fins",
 		"jp_explain": "アクルプスから採れた背びれ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "アクルプスから採れた背びれ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Dorsal fins taken from an Aqulupus.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330404",
 		"jp_text": "ブルメガーラのうろこ",
 		"tr_text": "Blumegalla Scales",
 		"jp_explain": "ブルメガーラから採れたうろこ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "ブルメガーラから採れたうろこ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Scales taken from a Blumegalla.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330405",
 		"jp_text": "オルグブランの胸肉",
-		"tr_text": "Org Blan Breasts",
+		"tr_text": "Org Blan Breast Meat",
 		"jp_explain": "オルグブランから採れた胸肉。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "オルグブランから採れた胸肉。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "Breast meat taken from a Org Blan.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330406",
@@ -2755,7 +2755,7 @@
 		"jp_text": "セグレズンの蓄電袋",
 		"tr_text": "Seglez'n Pouch",
 		"jp_explain": "セグレズンから採れた蓄電袋。\n\n依頼者：<c a1ff6d>シー<c>　サマー",
-		"tr_explain": "セグレズンから採れた蓄電袋。\n\nClient: <c a1ff6d>Xie<c> (Summer)"
+		"tr_explain": "Pouch taken from a Seglez'n.\n\nClient: <c a1ff6d>Xie<c> (Summer)"
 	},
 	{
 		"assign": "330408",
@@ -3210,7 +3210,7 @@
 		"jp_text": "ディガーラの皮",
 		"tr_text": "Deegalla Hide",
 		"jp_explain": "ディガーラから採れた皮。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディガーラから採れた皮。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Hide taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330473",
@@ -3292,16 +3292,16 @@
 	{
 		"assign": "330517",
 		"jp_text": "タロベッコのくちばし",
-		"tr_text": "Talobecko Beaks",
+		"tr_text": "Talobecko Beak",
 		"jp_explain": "タロベッコから採れたくちばし。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "タロベッコから採れたくちばし。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Beak taken from a Talobecko.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330518",
 		"jp_text": "ヴィド・ギロスの尾びれ",
-		"tr_text": "Vid Gilos Fins",
+		"tr_text": "Vid Gilos Tail Fin",
 		"jp_explain": "ヴィド・ギロスの尾にあるひれ。\n\n依頼者：<c a1ff6d>ファイナ<c>　再受注可能",
-		"tr_explain": "ヴィド・ギロスの尾にあるひれ。\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
+		"tr_explain": "Tail fin taken from a Vid Gilos.\n\nClient: <c a1ff6d>Faina<c> (repeatable)"
 	},
 	{
 		"assign": "330519",
@@ -3343,7 +3343,7 @@
 		"jp_text": "タグ・アクルプスの牙",
 		"tr_text": "Tag Aqulupus Fangs",
 		"jp_explain": "タグ・アクルプスから採れた牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "タグ・アクルプスから採れた牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fangs taken from a Tag Aqulupus.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330525",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -1509,21 +1509,21 @@
 		"jp_text": "スパルダンＡのパーツｆ",
 		"tr_text": "Spardan A Parts f",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330216",
 		"jp_text": "スパルダンＡのパーツｇ",
 		"tr_text": "Spardan A Parts g",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330217",
 		"jp_text": "スパルダンＡのパーツｉ",
 		"tr_text": "Spardan A Parts i",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330218",
@@ -1880,14 +1880,14 @@
 		"jp_text": "スパルダンＡのパーツｈ",
 		"tr_text": "Spardan A Parts h",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330269",
 		"jp_text": "スパルダンＡのパーツｊ",
 		"tr_text": "Spardan A Parts j",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330270",
@@ -2895,7 +2895,7 @@
 		"jp_text": "スパルダンＡの脚パーツ",
 		"tr_text": "Spardan A Leg Parts",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "スパルダンＡを構成する部品の一つ。\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
+		"tr_explain": "One of the parts that make up a\nSpardan A.\n\nClient: <c a1ff6d>Franka<c> (repeatable)"
 	},
 	{
 		"assign": "330428",

--- a/json/Item_Stack_Tool.txt
+++ b/json/Item_Stack_Tool.txt
@@ -429,9 +429,9 @@
 	{
 		"assign": "37073",
 		"jp_text": "王者の紋章",
-		"tr_text": "King's Crests",
+		"tr_text": "King's Crest",
 		"jp_explain": "様々な戦場で活躍したアークスの証。\n提示することで、ジグの持つ\n貴重なアイテムと交換ができる。",
-		"tr_explain": "Proof that one participated in\ngreat battles out of all ARKS. Can\ntrade this ifor items from Zieg."
+		"tr_explain": "Proof that one participated in\ngreat battles out of all ARKS. Can\ntrade this for items from Zieg."
 	},
 	{
 		"assign": "37074",


### PR DESCRIPTION
- Translates the clients on all CO items.
- Translates many CO item descriptions.
- Fixes a few CO item names, like Train **MOTORS** and a bunch of things that shouldn't really have been plural.

Submitting this now because I've corrected CO names to match the new CO item names in the same branch as I've edited the latest episode 5 scenes, and I want to be sure the items are going to match the COs. Will continue work on the order item descriptions.