### PR TITLE
Weapon names and Seraphy's notes

### DIFF
--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -702,7 +702,7 @@
 	{
 		"assign": "180172",
 		"jp_text": "古春菫",
-		"tr_text": "Koshunkin",
+		"tr_text": "Koharu Sumire",
 		"jp_explain": "絢爛な裝飾が施された古典的な形状の\n長銃。高い耐久性と圧倒的な命中精度で\n絶大な人気を誇る。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Compoundbow.txt
+++ b/json/Item_Weapon_Compoundbow.txt
@@ -618,7 +618,7 @@
 	{
 		"assign": "1150148",
 		"jp_text": "白雉春光",
-		"tr_text": "Shirokiji Shunkou",
+		"tr_text": "Wakuchi Shunkou",
 		"jp_explain": "新しい季節の始まりを祝し、制作された\n儀礼用の強弓。満開の桜に止まる鳥が\n見事に再現された逸品。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -681,7 +681,7 @@
 	{
 		"assign": "170169",
 		"jp_text": "紫黒桜",
-		"tr_text": "Shiguro Sakura",
+		"tr_text": "Shikoku Sakura",
 		"jp_explain": "春の宵を思わせる色合いが美しい銃剣。\nフレームに描かれた桜と波紋は見事で\n至極の逸品と言えるほどの出来映え。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_JetBoots.txt
+++ b/json/Item_Weapon_JetBoots.txt
@@ -296,7 +296,7 @@
 	{
 		"assign": "116057",
 		"jp_text": "流花風華",
-		"tr_text": "Ruka Kazehana",
+		"tr_text": "Ryuuka Fuuka",
 		"jp_explain": "春の夜と飛ぶ鳥をモチーフに制作された\n魔装脚。漆を思わせる黒に満開の桜と\n流水が描かれた雅やかな逸品。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Katana.txt
+++ b/json/Item_Weapon_Katana.txt
@@ -590,7 +590,7 @@
 	{
 		"assign": "1140141",
 		"jp_text": "玄朧夜",
-		"tr_text": "Gen Oboroyo",
+		"tr_text": "Gen Rouya",
 		"jp_explain": "飛ぶ鳥を思わせる独特の裝飾が芸術的な\n抜剣。先端へいくほど鮮やかな紫色に\n変わるのは、夜明けを表現したため。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -646,7 +646,7 @@
 	{
 		"assign": "160142",
 		"jp_text": "闘獅",
-		"tr_text": "Tousou Shishi",
+		"tr_text": "Toushi",
 		"jp_explain": "古来より強さの象徴とされた獅子を\n模して作られた鋼拳。威風堂々とした\n姿は勇猛な獅子そのものといえる。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -681,7 +681,7 @@
 	{
 		"assign": "130160",
 		"jp_text": "春閃",
-		"tr_text": "Haru Hirame",
+		"tr_text": "Shunsen",
 		"jp_explain": "厄や災いを祓う意味を持つ儀礼用の\n長槍。藍色と黒の飾緒と夜桜を思わせる\n見事な裝飾が入った刀身が美しい。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -828,7 +828,7 @@
 	{
 		"assign": "1110205",
 		"jp_text": "宵白鳳",
-		"tr_text": "Yoi Hakuhou",
+		"tr_text": "Shiyou Hakuhou",
 		"jp_explain": "吉兆の証とされる伝説の霊鳥を模して\n制作された美しい長杖。空を飛ぶ姿を\n想像し作られたと言われている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -772,7 +772,7 @@
 	{
 		"assign": "110204",
 		"jp_text": "朔桜",
-		"tr_text": "Saku Sakura",
+		"tr_text": "Sakuou",
 		"jp_explain": "舞い散る桜の花びらを見事に描いた鞘が\n美しい大剣。刃には細かな裝飾が丁寧に\n刻まれており、もはや芸術品と呼べる。",
 		"tr_explain": "A beautiful sword with depictions of\ncherry blossoms on its sheath. It\ncould be called a work of art."
 	},

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -793,7 +793,7 @@
 	{
 		"assign": "1100183",
 		"jp_text": "双淡月",
-		"tr_text": "Sou Awatsuki",
+		"tr_text": "Sou Tangetsu",
 		"jp_explain": "伝統的な手法を使い作成された双機銃。\n連射性能と命中精度に優れ、豪華絢爛な\n外装は高い耐久性を誇る。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -779,7 +779,7 @@
 	{
 		"assign": "1130193",
 		"jp_text": "小夜禊月",
-		"tr_text": "Sayo Kaigetsu",
+		"tr_text": "Sayo Keigetsu",
 		"jp_explain": "祭礼などで使用される紙垂を使い\n作られた由緒正しい短杖。場を清め\n災いを遠ざけると信じられている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -681,7 +681,7 @@
 	{
 		"assign": "120147",
 		"jp_text": "風霞",
-		"tr_text": "Kaze Kasumi",
+		"tr_text": "Fuuka",
 		"jp_explain": "鮮やかな紫紺色が目を引く自在槍。\n舞い散る花びらと共に、美しい\n桜色の刃が容赦なく標的を仕留める。",
 		"tr_explain": ""
 	},

--- a/json/Name_Chip_SPArksName.txt
+++ b/json/Name_Chip_SPArksName.txt
@@ -4347,12 +4347,12 @@
 	{
 		"assign": "7246",
 		"jp_text": "玄朧夜",
-		"tr_text": "Gen Oboroyo"
+		"tr_text": "Gen Rouya"
 	},
 	{
 		"assign": "7247",
 		"jp_text": "闇に咲く華 玄朧夜",
-		"tr_text": "Blooming Darkness Gen Oboroyo"
+		"tr_text": "Blooming Darkness Gen Rouya"
 	},
 	{
 		"assign": "7248",

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -13952,12 +13952,12 @@
 	{
 		"text_id": 1807000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1807000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1807200,
@@ -14007,12 +14007,12 @@
 	{
 		"text_id": 1823000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1823000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1823200,
@@ -14062,12 +14062,12 @@
 	{
 		"text_id": 1827000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1827000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1827200,
@@ -15142,12 +15142,12 @@
 	{
 		"text_id": 1805000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1805000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1805200,
@@ -15197,12 +15197,12 @@
 	{
 		"text_id": 1819000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1819000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1819200,
@@ -15252,12 +15252,12 @@
 	{
 		"text_id": 1825000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1825000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1825200,
@@ -16107,12 +16107,12 @@
 	{
 		"text_id": 1809000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1809000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1809200,
@@ -16212,12 +16212,12 @@
 	{
 		"text_id": 1845000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1845000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1845200,
@@ -16267,12 +16267,12 @@
 	{
 		"text_id": 1867000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1867000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1867200,
@@ -17312,12 +17312,12 @@
 	{
 		"text_id": 1811000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1811000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1811200,
@@ -17417,12 +17417,12 @@
 	{
 		"text_id": 1821000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1821000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1821200,
@@ -17472,12 +17472,12 @@
 	{
 		"text_id": 1813000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1813000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1813200,
@@ -17527,12 +17527,12 @@
 	{
 		"text_id": 1865000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1865000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1865200,
@@ -18502,12 +18502,12 @@
 	{
 		"text_id": 1801000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1801000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1801200,
@@ -18557,12 +18557,12 @@
 	{
 		"text_id": 1803000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1803000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1803200,
@@ -18612,12 +18612,12 @@
 	{
 		"text_id": 1815000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1815000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1815200,
@@ -18667,12 +18667,12 @@
 	{
 		"text_id": 1817000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1817000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1817200,
@@ -18822,12 +18822,12 @@
 	{
 		"text_id": 1847000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1847000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1847200,
@@ -19382,12 +19382,12 @@
 	{
 		"text_id": 1859000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1859000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1859200,
@@ -19437,12 +19437,12 @@
 	{
 		"text_id": 1863000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1863000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1863200,
@@ -22277,12 +22277,12 @@
 	{
 		"text_id": 1197028,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1197028,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1197029,
@@ -24452,12 +24452,12 @@
 	{
 		"text_id": 1197204,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1197204,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1197205,
@@ -26587,12 +26587,12 @@
 	{
 		"text_id": 1843000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1843000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1843200,
@@ -27902,12 +27902,12 @@
 	{
 		"text_id": 1853000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1853000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1853200,
@@ -27957,12 +27957,12 @@
 	{
 		"text_id": 1861000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1861000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1861200,
@@ -29777,12 +29777,12 @@
 	{
 		"text_id": 1849000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1849000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1849200,
@@ -29942,12 +29942,12 @@
 	{
 		"text_id": 1917000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1917000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1917200,
@@ -29997,12 +29997,12 @@
 	{
 		"text_id": 1931000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1931000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1931200,
@@ -30867,12 +30867,12 @@
 	{
 		"text_id": 1841000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1841000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1841200,
@@ -30922,12 +30922,12 @@
 	{
 		"text_id": 1855000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1855000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1855200,
@@ -31032,12 +31032,12 @@
 	{
 		"text_id": 1923000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1923000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1923200,
@@ -31087,12 +31087,12 @@
 	{
 		"text_id": 1925000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1925000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1925200,
@@ -31142,12 +31142,12 @@
 	{
 		"text_id": 1933000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1933000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1933200,
@@ -31197,12 +31197,12 @@
 	{
 		"text_id": 1937000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1937000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1937200,
@@ -31252,12 +31252,12 @@
 	{
 		"text_id": 1939000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1939000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1939200,
@@ -32027,12 +32027,12 @@
 	{
 		"text_id": 1941000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1941000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1941200,
@@ -32752,12 +32752,12 @@
 	{
 		"text_id": 1919000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1919000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1919200,
@@ -32807,12 +32807,12 @@
 	{
 		"text_id": 1935000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1935000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1935200,
@@ -32862,12 +32862,12 @@
 	{
 		"text_id": 1927000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1927000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1927200,
@@ -33792,12 +33792,12 @@
 	{
 		"text_id": 1965000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1965000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1965200,
@@ -34547,12 +34547,12 @@
 	{
 		"text_id": 1921000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1921000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1921200,
@@ -34602,12 +34602,12 @@
 	{
 		"text_id": 1945000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1945000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1945200,
@@ -34657,12 +34657,12 @@
 	{
 		"text_id": 1961000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1961000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1961200,
@@ -34712,12 +34712,12 @@
 	{
 		"text_id": 1973000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1973000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1973200,
@@ -34767,12 +34767,12 @@
 	{
 		"text_id": 1915000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1915000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1915200,
@@ -34822,12 +34822,12 @@
 	{
 		"text_id": 1963000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1963000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1963200,
@@ -34877,12 +34877,12 @@
 	{
 		"text_id": 1929000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1929000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1929200,
@@ -35522,12 +35522,12 @@
 	{
 		"text_id": 1953000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1953000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1953200,
@@ -35577,12 +35577,12 @@
 	{
 		"text_id": 1955000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1955000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1955200,
@@ -35632,12 +35632,12 @@
 	{
 		"text_id": 1993000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1993000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1993200,
@@ -35687,12 +35687,12 @@
 	{
 		"text_id": 1967000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1967000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1967200,
@@ -36437,12 +36437,12 @@
 	{
 		"text_id": 1959000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1959000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1959200,
@@ -36492,12 +36492,12 @@
 	{
 		"text_id": 1969000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1969000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1969200,
@@ -36547,12 +36547,12 @@
 	{
 		"text_id": 1989000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1989000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1989200,
@@ -38172,12 +38172,12 @@
 	{
 		"text_id": 1943000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1943000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1943200,
@@ -38227,12 +38227,12 @@
 	{
 		"text_id": 1947000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1947000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1947200,
@@ -38282,12 +38282,12 @@
 	{
 		"text_id": 1949000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1949000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1949200,
@@ -38337,12 +38337,12 @@
 	{
 		"text_id": 1957000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1957000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1957200,
@@ -38392,12 +38392,12 @@
 	{
 		"text_id": 1991000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1991000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1991200,
@@ -38447,12 +38447,12 @@
 	{
 		"text_id": 2001000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2001000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2001200,
@@ -39632,12 +39632,12 @@
 	{
 		"text_id": 1951000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1951000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1951200,
@@ -39687,12 +39687,12 @@
 	{
 		"text_id": 1983000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1983000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1983200,
@@ -39742,12 +39742,12 @@
 	{
 		"text_id": 1987000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1987000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1987200,
@@ -39797,12 +39797,12 @@
 	{
 		"text_id": 1971000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1971000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1971200,
@@ -39852,12 +39852,12 @@
 	{
 		"text_id": 1981000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1981000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1981200,
@@ -39907,12 +39907,12 @@
 	{
 		"text_id": 2017000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2017000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2017200,
@@ -39962,12 +39962,12 @@
 	{
 		"text_id": 1995000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1995000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1995200,
@@ -40887,12 +40887,12 @@
 	{
 		"text_id": 1977000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1977000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1977200,
@@ -40942,12 +40942,12 @@
 	{
 		"text_id": 2011000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2011000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2011200,
@@ -40997,12 +40997,12 @@
 	{
 		"text_id": 2009000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2009000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2009200,
@@ -41932,12 +41932,12 @@
 	{
 		"text_id": 1985000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1985000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1985200,
@@ -41987,12 +41987,12 @@
 	{
 		"text_id": 1997000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1997000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1997200,
@@ -42902,12 +42902,12 @@
 	{
 		"text_id": 2005000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2005000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2005200,
@@ -42957,12 +42957,12 @@
 	{
 		"text_id": 1979000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1979000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1979200,
@@ -43012,12 +43012,12 @@
 	{
 		"text_id": 2021000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2021000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2021200,
@@ -43067,12 +43067,12 @@
 	{
 		"text_id": 1975000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1975000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1975200,
@@ -44397,12 +44397,12 @@
 	{
 		"text_id": 2019000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2019000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2019200,
@@ -44452,12 +44452,12 @@
 	{
 		"text_id": 2025000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2025000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2025200,
@@ -44507,12 +44507,12 @@
 	{
 		"text_id": 2015000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2015000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2015200,
@@ -44922,12 +44922,12 @@
 	{
 		"text_id": 1999000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 1999000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 1999200,
@@ -44977,12 +44977,12 @@
 	{
 		"text_id": 2023000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2023000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2023200,
@@ -45412,12 +45412,12 @@
 	{
 		"text_id": 2003000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2003000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2003200,
@@ -45467,12 +45467,12 @@
 	{
 		"text_id": 2007000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2007000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2007200,
@@ -52607,12 +52607,12 @@
 	{
 		"text_id": 2013000,
 		"jp_text": "必殺技を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens Photon Arts."
 	},
 	{
 		"text_id": 2013000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
 	},
 	{
 		"text_id": 2013200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -52112,12 +52112,12 @@
 	{
 		"text_id": 7075000,
 		"jp_text": "エネミーの生体を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This chip seems to hold data\nfrom an enemy life form."
 	},
 	{
 		"text_id": 7075000,
 		"jp_text": "いつも戦っているエネミーの能力が\nチップになっています！\nどんな力を持っているのか\n楽しみですね！",
-		"tr_text": ""
+		"tr_text": "One of our enemies, fighting\nfor us in the form of a chip!\nI'm looking forward to seeing\nwhat kind of power it has!"
 	},
 	{
 		"text_id": 7075200,
@@ -54927,12 +54927,12 @@
 	{
 		"text_id": 7701000,
 		"jp_text": "エネミーの生体を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This chip seems to hold data\nfrom an enemy life form."
 	},
 	{
 		"text_id": 7701000,
 		"jp_text": "いつも戦っているエネミーの能力が\nチップになっています！\nどんな力を持っているのか\n楽しみですね！",
-		"tr_text": ""
+		"tr_text": "One of our enemies, fighting\nfor us in the form of a chip!\nI'm looking forward to seeing\nwhat kind of power it has!"
 	},
 	{
 		"text_id": 7701200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -4052,7 +4052,7 @@
 	{
 		"text_id": 2101200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2101200,
@@ -4097,7 +4097,7 @@
 	{
 		"text_id": 2103200,
 		"jp_text": "大剣用の必殺技\nツイスターフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Twister Fall,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2103200,
@@ -4142,7 +4142,7 @@
 	{
 		"text_id": 2121200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2121200,
@@ -4187,7 +4187,7 @@
 	{
 		"text_id": 2123200,
 		"jp_text": "大剣用の必殺技\nツイスターフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Twister Fall,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2123200,
@@ -4232,7 +4232,7 @@
 	{
 		"text_id": 2141200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2141200,
@@ -4277,7 +4277,7 @@
 	{
 		"text_id": 2143200,
 		"jp_text": "大剣用の必殺技\nツイスターフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Twister Fall,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2143200,
@@ -4322,7 +4322,7 @@
 	{
 		"text_id": 2201200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2201200,
@@ -4367,7 +4367,7 @@
 	{
 		"text_id": 2221200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2221200,
@@ -4412,7 +4412,7 @@
 	{
 		"text_id": 2241200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2241200,
@@ -4457,7 +4457,7 @@
 	{
 		"text_id": 2301200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2301200,
@@ -4502,7 +4502,7 @@
 	{
 		"text_id": 2321200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2321200,
@@ -4547,7 +4547,7 @@
 	{
 		"text_id": 2341200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2341200,
@@ -4592,7 +4592,7 @@
 	{
 		"text_id": 2401200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2401200,
@@ -4637,7 +4637,7 @@
 	{
 		"text_id": 2421200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2421200,
@@ -4682,7 +4682,7 @@
 	{
 		"text_id": 2441200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2441200,
@@ -4727,7 +4727,7 @@
 	{
 		"text_id": 2501200,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2501200,
@@ -4772,7 +4772,7 @@
 	{
 		"text_id": 2521200,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2521200,
@@ -4817,7 +4817,7 @@
 	{
 		"text_id": 2541200,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2541200,
@@ -4862,7 +4862,7 @@
 	{
 		"text_id": 2601200,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2601200,
@@ -4907,7 +4907,7 @@
 	{
 		"text_id": 2621200,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2621200,
@@ -4952,7 +4952,7 @@
 	{
 		"text_id": 2641200,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2641200,
@@ -4997,7 +4997,7 @@
 	{
 		"text_id": 2701200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2701200,
@@ -5047,7 +5047,7 @@
 	{
 		"text_id": 2721200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2721200,
@@ -5092,7 +5092,7 @@
 	{
 		"text_id": 2741200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2741200,
@@ -5137,7 +5137,7 @@
 	{
 		"text_id": 2801200,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2801200,
@@ -5182,7 +5182,7 @@
 	{
 		"text_id": 2803200,
 		"jp_text": "長銃用の必殺技\nワンポイントのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of One Point,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2803200,
@@ -5272,7 +5272,7 @@
 	{
 		"text_id": 2823200,
 		"jp_text": "長銃用の必殺技\nワンポイントのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of One Point,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2823200,
@@ -5317,7 +5317,7 @@
 	{
 		"text_id": 2841200,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2841200,
@@ -5362,7 +5362,7 @@
 	{
 		"text_id": 2843200,
 		"jp_text": "長銃用の必殺技\nワンポイントのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of One Point,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2843200,
@@ -5407,7 +5407,7 @@
 	{
 		"text_id": 2901200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2901200,
@@ -5452,7 +5452,7 @@
 	{
 		"text_id": 2921200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2921200,
@@ -5497,7 +5497,7 @@
 	{
 		"text_id": 2941200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2941200,
@@ -5542,7 +5542,7 @@
 	{
 		"text_id": 3001200,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3001200,
@@ -5587,7 +5587,7 @@
 	{
 		"text_id": 3021200,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3021200,
@@ -5632,7 +5632,7 @@
 	{
 		"text_id": 3041200,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3041200,
@@ -5677,7 +5677,7 @@
 	{
 		"text_id": 3101200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3101200,
@@ -5722,7 +5722,7 @@
 	{
 		"text_id": 3121200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3121200,
@@ -5767,7 +5767,7 @@
 	{
 		"text_id": 3141200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3141200,
@@ -5812,7 +5812,7 @@
 	{
 		"text_id": 3201200,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3201200,
@@ -5857,7 +5857,7 @@
 	{
 		"text_id": 3221200,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3221200,
@@ -5902,7 +5902,7 @@
 	{
 		"text_id": 3241200,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3241200,
@@ -5947,7 +5947,7 @@
 	{
 		"text_id": 3301200,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3301200,
@@ -5992,7 +5992,7 @@
 	{
 		"text_id": 3321200,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3321200,
@@ -6037,7 +6037,7 @@
 	{
 		"text_id": 3341200,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3341200,
@@ -6082,7 +6082,7 @@
 	{
 		"text_id": 3401200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3401200,
@@ -6127,7 +6127,7 @@
 	{
 		"text_id": 3421200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3421200,
@@ -6172,7 +6172,7 @@
 	{
 		"text_id": 3441200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3441200,
@@ -6237,7 +6237,7 @@
 	{
 		"text_id": 4903200,
 		"jp_text": "銃剣用の必殺技\nモードシフトのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Mode Shift,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 4903200,
@@ -16332,7 +16332,7 @@
 	{
 		"text_id": 2323200,
 		"jp_text": "長槍用の必殺技\nスピードレインのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Speed Rain,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2323200,
@@ -16377,7 +16377,7 @@
 	{
 		"text_id": 2343200,
 		"jp_text": "長槍用の必殺技\nスピードレインのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Speed Rain,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2343200,
@@ -16422,7 +16422,7 @@
 	{
 		"text_id": 2363200,
 		"jp_text": "長槍用の必殺技\nスピードレインのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Speed Rain,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2363200,
@@ -16472,7 +16472,7 @@
 	{
 		"text_id": 2923200,
 		"jp_text": "大砲用の必殺技\nスフィアイレイザーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sphere Eraser,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2923200,
@@ -16517,7 +16517,7 @@
 	{
 		"text_id": 2943200,
 		"jp_text": "大砲用の必殺技\nスフィアイレイザーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sphere Eraser,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2943200,
@@ -16562,7 +16562,7 @@
 	{
 		"text_id": 2963200,
 		"jp_text": "大砲用の必殺技\nスフィアイレイザーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sphere Eraser,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2963200,
@@ -17592,7 +17592,7 @@
 	{
 		"text_id": 2223200,
 		"jp_text": "自在槍用の必殺技\nワイルドラウンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Wild Round,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2223200,
@@ -17637,7 +17637,7 @@
 	{
 		"text_id": 2243200,
 		"jp_text": "自在槍用の必殺技\nワイルドラウンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Wild Round,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2243200,
@@ -17682,7 +17682,7 @@
 	{
 		"text_id": 2263200,
 		"jp_text": "自在槍用の必殺技\nワイルドラウンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Wild Round,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2263200,
@@ -17732,7 +17732,7 @@
 	{
 		"text_id": 2303200,
 		"jp_text": "長槍用の必殺技\nスピードレインのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Speed Rain,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2303200,
@@ -17777,7 +17777,7 @@
 	{
 		"text_id": 2903200,
 		"jp_text": "大砲用の必殺技\nスフィアイレイザーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sphere Eraser,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2903200,
@@ -17822,7 +17822,7 @@
 	{
 		"text_id": 3223200,
 		"jp_text": "強弓用の必殺技\nラストネメシスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Final Nemesis,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3223200,
@@ -17867,7 +17867,7 @@
 	{
 		"text_id": 3243200,
 		"jp_text": "強弓用の必殺技\nラストネメシスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Final Nemesis,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3243200,
@@ -17912,7 +17912,7 @@
 	{
 		"text_id": 3263200,
 		"jp_text": "強弓用の必殺技\nラストネメシスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Final Nemesis,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3263200,
@@ -18887,7 +18887,7 @@
 	{
 		"text_id": 2203200,
 		"jp_text": "自在槍用の必殺技\nワイルドラウンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Wild Round,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2203200,
@@ -18932,7 +18932,7 @@
 	{
 		"text_id": 2523200,
 		"jp_text": "両剣用の必殺技\nイリュージョンレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Illusion Rave,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2523200,
@@ -18977,7 +18977,7 @@
 	{
 		"text_id": 2543200,
 		"jp_text": "両剣用の必殺技\nイリュージョンレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Illusion Rave,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2543200,
@@ -19022,7 +19022,7 @@
 	{
 		"text_id": 2563200,
 		"jp_text": "両剣用の必殺技\nイリュージョンレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Illusion Rave,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2563200,
@@ -19072,7 +19072,7 @@
 	{
 		"text_id": 2723200,
 		"jp_text": "銃剣用の必殺技\nクライゼンシュラークのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kreisenschlag,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2723200,
@@ -19117,7 +19117,7 @@
 	{
 		"text_id": 2743200,
 		"jp_text": "銃剣用の必殺技\nクライゼンシュラークのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kreisenschlag,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2743200,
@@ -19162,7 +19162,7 @@
 	{
 		"text_id": 2763200,
 		"jp_text": "銃剣用の必殺技\nクライゼンシュラークのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kreisenschlag,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2763200,
@@ -19212,7 +19212,7 @@
 	{
 		"text_id": 3203200,
 		"jp_text": "強弓用の必殺技\nラストネメシスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Final Nemesis,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3203200,
@@ -19722,7 +19722,7 @@
 	{
 		"text_id": 2145200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2145200,
@@ -19767,7 +19767,7 @@
 	{
 		"text_id": 2245200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2245200,
@@ -19812,7 +19812,7 @@
 	{
 		"text_id": 2345200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2345200,
@@ -19857,7 +19857,7 @@
 	{
 		"text_id": 2445200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2445200,
@@ -19902,7 +19902,7 @@
 	{
 		"text_id": 2503200,
 		"jp_text": "両剣用の必殺技\nイリュージョンレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Illusion Rave,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2503200,
@@ -19947,7 +19947,7 @@
 	{
 		"text_id": 2645200,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2645200,
@@ -19992,7 +19992,7 @@
 	{
 		"text_id": 2703200,
 		"jp_text": "銃剣用の必殺技\nクライゼンシュラークのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kreisenschlag,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2703200,
@@ -20037,7 +20037,7 @@
 	{
 		"text_id": 2745200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2745200,
@@ -20082,7 +20082,7 @@
 	{
 		"text_id": 2845200,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2845200,
@@ -20127,7 +20127,7 @@
 	{
 		"text_id": 2945200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2945200,
@@ -20172,7 +20172,7 @@
 	{
 		"text_id": 3045200,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3045200,
@@ -20217,7 +20217,7 @@
 	{
 		"text_id": 3145200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3145200,
@@ -20262,7 +20262,7 @@
 	{
 		"text_id": 3245200,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3245200,
@@ -20307,7 +20307,7 @@
 	{
 		"text_id": 3445200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3445200,
@@ -20492,7 +20492,7 @@
 	{
 		"text_id": 2423200,
 		"jp_text": "双小剣用の必殺技\nオウルケストラーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Ooorchestraaa,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2423200,
@@ -20537,7 +20537,7 @@
 	{
 		"text_id": 2443200,
 		"jp_text": "双小剣用の必殺技\nオウルケストラーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Ooorchestraaa,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2443200,
@@ -20582,7 +20582,7 @@
 	{
 		"text_id": 2463200,
 		"jp_text": "双小剣用の必殺技\nオウルケストラーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Ooorchestraaa,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2463200,
@@ -20632,7 +20632,7 @@
 	{
 		"text_id": 3323200,
 		"jp_text": "魔装脚用の必殺技\nヴィントジーカーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Vinto Gigue,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3323200,
@@ -20677,7 +20677,7 @@
 	{
 		"text_id": 3343200,
 		"jp_text": "魔装脚用の必殺技\nヴィントジーカーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Vinto Gigue,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3343200,
@@ -20722,7 +20722,7 @@
 	{
 		"text_id": 3363200,
 		"jp_text": "魔装脚用の必殺技\nヴィントジーカーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Vinto Gigue,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3363200,
@@ -22537,7 +22537,7 @@
 	{
 		"text_id": 1197049,
 		"jp_text": "大剣用の必殺技\nオーバーエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Over End,\na Sword Photon Art."
 	},
 	{
 		"text_id": 1197049,
@@ -22582,7 +22582,7 @@
 	{
 		"text_id": 1197053,
 		"jp_text": "大剣用の必殺技\nオーバーエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Over End,\na Sword Photon Art."
 	},
 	{
 		"text_id": 1197053,
@@ -22627,7 +22627,7 @@
 	{
 		"text_id": 1197057,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 1197057,
@@ -22672,7 +22672,7 @@
 	{
 		"text_id": 1197061,
 		"jp_text": "大剣用の必殺技\nオーバーエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Over End,\na Sword Photon Art."
 	},
 	{
 		"text_id": 1197061,
@@ -22722,7 +22722,7 @@
 	{
 		"text_id": 1197065,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 1197065,
@@ -22767,7 +22767,7 @@
 	{
 		"text_id": 1197069,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 1197069,
@@ -22812,7 +22812,7 @@
 	{
 		"text_id": 1197073,
 		"jp_text": "双小剣用の必殺技\nオウルケストラーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Ooorchestraaa,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 1197073,
@@ -22857,7 +22857,7 @@
 	{
 		"text_id": 1197077,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 1197077,
@@ -22902,7 +22902,7 @@
 	{
 		"text_id": 1197081,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 1197081,
@@ -22947,7 +22947,7 @@
 	{
 		"text_id": 1197085,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 1197085,
@@ -22992,7 +22992,7 @@
 	{
 		"text_id": 1197089,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 1197089,
@@ -23037,7 +23037,7 @@
 	{
 		"text_id": 1197093,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 1197093,
@@ -23082,7 +23082,7 @@
 	{
 		"text_id": 1197097,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 1197097,
@@ -23127,7 +23127,7 @@
 	{
 		"text_id": 1197101,
 		"jp_text": "抜剣用の必殺技\nサクラエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sakura-endo,\na Katana Photon Art."
 	},
 	{
 		"text_id": 1197101,
@@ -23172,7 +23172,7 @@
 	{
 		"text_id": 1197105,
 		"jp_text": "抜剣用の必殺技\nサクラエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sakura-endo,\na Katana Photon Art."
 	},
 	{
 		"text_id": 1197105,
@@ -23217,7 +23217,7 @@
 	{
 		"text_id": 1197109,
 		"jp_text": "抜剣用の必殺技\nサクラエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sakura-endo,\na Katana Photon Art."
 	},
 	{
 		"text_id": 1197109,
@@ -23267,7 +23267,7 @@
 	{
 		"text_id": 1197113,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 1197113,
@@ -23312,7 +23312,7 @@
 	{
 		"text_id": 1197117,
 		"jp_text": "魔装脚用の必殺技\nヴィントジーカーのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Vinto Gigue,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 1197117,
@@ -23357,7 +23357,7 @@
 	{
 		"text_id": 1197121,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 1197121,
@@ -23402,7 +23402,7 @@
 	{
 		"text_id": 1197125,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 1197125,
@@ -23982,7 +23982,7 @@
 	{
 		"text_id": 1197165,
 		"jp_text": "大剣用の必殺技\nオーバーエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Over End,\na Sword Photon Art."
 	},
 	{
 		"text_id": 1197165,
@@ -24027,7 +24027,7 @@
 	{
 		"text_id": 1197169,
 		"jp_text": "鋼拳用の必殺技\nストレイトチャージのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Straight Charge,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 1197169,
@@ -24072,7 +24072,7 @@
 	{
 		"text_id": 1197173,
 		"jp_text": "鋼拳用の必殺技\nストレイトチャージのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Straight Charge,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 1197173,
@@ -24117,7 +24117,7 @@
 	{
 		"text_id": 1197177,
 		"jp_text": "鋼拳用の必殺技\nストレイトチャージのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Straight Charge,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 1197177,
@@ -24167,7 +24167,7 @@
 	{
 		"text_id": 1197181,
 		"jp_text": "抜剣用の必殺技\nサクラエンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Sakura-endo,\na Katana Photon Art."
 	},
 	{
 		"text_id": 1197181,
@@ -24622,7 +24622,7 @@
 	{
 		"text_id": 1197217,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 1197217,
@@ -24667,7 +24667,7 @@
 	{
 		"text_id": 1197221,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 1197221,
@@ -24712,7 +24712,7 @@
 	{
 		"text_id": 1197225,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 1197225,
@@ -24757,7 +24757,7 @@
 	{
 		"text_id": 1197229,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 1197229,
@@ -24802,7 +24802,7 @@
 	{
 		"text_id": 1197233,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 1197233,
@@ -24847,7 +24847,7 @@
 	{
 		"text_id": 1197236,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 1197236,
@@ -24892,7 +24892,7 @@
 	{
 		"text_id": 1197240,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 1197240,
@@ -24937,7 +24937,7 @@
 	{
 		"text_id": 1197244,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 1197244,
@@ -24982,7 +24982,7 @@
 	{
 		"text_id": 1197248,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 1197248,
@@ -25027,7 +25027,7 @@
 	{
 		"text_id": 1197252,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 1197252,
@@ -26257,7 +26257,7 @@
 	{
 		"text_id": 3023200,
 		"jp_text": "双機銃用の必殺技\nエルダーリべリオンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Elder Rebellion,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3023200,
@@ -26302,7 +26302,7 @@
 	{
 		"text_id": 3043200,
 		"jp_text": "双機銃用の必殺技\nエルダーリべリオンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Elder Rebellion,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3043200,
@@ -26347,7 +26347,7 @@
 	{
 		"text_id": 3063200,
 		"jp_text": "双機銃用の必殺技\nエルダーリべリオンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Elder Rebellion,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3063200,
@@ -26397,7 +26397,7 @@
 	{
 		"text_id": 2603200,
 		"jp_text": "鋼拳用の必殺技\nストレイトチャージのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Straight Charge,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2603200,
@@ -26652,7 +26652,7 @@
 	{
 		"text_id": 2151200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2151200,
@@ -26697,7 +26697,7 @@
 	{
 		"text_id": 2249200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2249200,
@@ -26742,7 +26742,7 @@
 	{
 		"text_id": 2351200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2351200,
@@ -26787,7 +26787,7 @@
 	{
 		"text_id": 2449200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2449200,
@@ -26832,7 +26832,7 @@
 	{
 		"text_id": 2549200,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2549200,
@@ -26877,7 +26877,7 @@
 	{
 		"text_id": 2651200,
 		"jp_text": "鋼拳用の必殺技\nペンデュラムロールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Pendulum Roll,\na Knuckles Photon Art."
 	},
 	{
 		"text_id": 2651200,
@@ -26922,7 +26922,7 @@
 	{
 		"text_id": 2751200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2751200,
@@ -26967,7 +26967,7 @@
 	{
 		"text_id": 2849200,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2849200,
@@ -27012,7 +27012,7 @@
 	{
 		"text_id": 2949200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2949200,
@@ -27057,7 +27057,7 @@
 	{
 		"text_id": 3149200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3149200,
@@ -27102,7 +27102,7 @@
 	{
 		"text_id": 3451200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3451200,
@@ -27147,7 +27147,7 @@
 	{
 		"text_id": 3349200,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3349200,
@@ -27582,7 +27582,7 @@
 	{
 		"text_id": 2833200,
 		"jp_text": "長銃用の必殺技\nディフューズシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Diffuse Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2833200,
@@ -27627,7 +27627,7 @@
 	{
 		"text_id": 2853200,
 		"jp_text": "長銃用の必殺技\nディフューズシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Diffuse Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2853200,
@@ -27672,7 +27672,7 @@
 	{
 		"text_id": 2873200,
 		"jp_text": "長銃用の必殺技\nディフューズシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Diffuse Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2873200,
@@ -27722,7 +27722,7 @@
 	{
 		"text_id": 3423200,
 		"jp_text": "飛翔剣用の必殺技\nイモータルダーヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Immortal Dove,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3423200,
@@ -27767,7 +27767,7 @@
 	{
 		"text_id": 3443200,
 		"jp_text": "飛翔剣用の必殺技\nイモータルダーヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Immortal Dove,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3443200,
@@ -27812,7 +27812,7 @@
 	{
 		"text_id": 3463200,
 		"jp_text": "飛翔剣用の必殺技\nイモータルダーヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Immortal Dove,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3463200,
@@ -28132,7 +28132,7 @@
 	{
 		"text_id": 2153200,
 		"jp_text": "大剣用の必殺技\nライジングエッジのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Rising Edge,\na Sword Photon Art."
 	},
 	{
 		"text_id": 2153200,
@@ -28177,7 +28177,7 @@
 	{
 		"text_id": 2251200,
 		"jp_text": "自在槍用の必殺技\nアザースピンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Other Spin,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2251200,
@@ -28222,7 +28222,7 @@
 	{
 		"text_id": 2353200,
 		"jp_text": "長槍用の必殺技\nトリックレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Trick Rave,\na Partizan Photon Art."
 	},
 	{
 		"text_id": 2353200,
@@ -28267,7 +28267,7 @@
 	{
 		"text_id": 2451200,
 		"jp_text": "双小剣用の必殺技\nレイジングワルツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Raging Waltz,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2451200,
@@ -28312,7 +28312,7 @@
 	{
 		"text_id": 2551200,
 		"jp_text": "両剣用の必殺技\nトルネードダンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tornado Dance,\na Double Saber Photon Art."
 	},
 	{
 		"text_id": 2551200,
@@ -28357,7 +28357,7 @@
 	{
 		"text_id": 2753200,
 		"jp_text": "銃剣用の必殺技\nスリラープロードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Thrillsplosion,\na Gunslash Photon Art."
 	},
 	{
 		"text_id": 2753200,
@@ -28402,7 +28402,7 @@
 	{
 		"text_id": 2951200,
 		"jp_text": "大砲用の必殺技\nゼロディスタンスのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Zero Distance,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2951200,
@@ -28447,7 +28447,7 @@
 	{
 		"text_id": 3003200,
 		"jp_text": "双機銃用の必殺技\nエルダーリベリオンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Elder Rebellion,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3003200,
@@ -28492,7 +28492,7 @@
 	{
 		"text_id": 3051200,
 		"jp_text": "双機銃用の必殺技\nサテライトエイムのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Satellite Aim,\na Twin Machineguns Photon Art."
 	},
 	{
 		"text_id": 3051200,
@@ -28537,7 +28537,7 @@
 	{
 		"text_id": 3151200,
 		"jp_text": "抜剣用の必殺技\nヒエンツバキのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Hien-tsubaki,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3151200,
@@ -28582,7 +28582,7 @@
 	{
 		"text_id": 3251200,
 		"jp_text": "強弓用の必殺技\nトレンシャルアロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Torrential Arrow,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3251200,
@@ -28627,7 +28627,7 @@
 	{
 		"text_id": 3351200,
 		"jp_text": "魔装脚用の必殺技\nグランウェイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Gran Wave,\na Jet Boots Photon Art."
 	},
 	{
 		"text_id": 3351200,
@@ -28672,7 +28672,7 @@
 	{
 		"text_id": 3453200,
 		"jp_text": "飛翔剣用の必殺技\nジャスティスクロウのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Justice Crow,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3453200,
@@ -28717,7 +28717,7 @@
 	{
 		"text_id": 2851200,
 		"jp_text": "長銃用の必殺技\nグレネードシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grenade Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2851200,
@@ -30062,7 +30062,7 @@
 	{
 		"text_id": 2813200,
 		"jp_text": "長銃用の必殺技\nディフューズシェルのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Diffuse Shell,\nan Assault Rifle Photon Art."
 	},
 	{
 		"text_id": 2813200,
@@ -30107,7 +30107,7 @@
 	{
 		"text_id": 3403200,
 		"jp_text": "飛翔剣用の必殺技\nイモータルダーヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Immortal Dove,\na Dual Blades Photon Art."
 	},
 	{
 		"text_id": 3403200,
@@ -31317,7 +31317,7 @@
 	{
 		"text_id": 2235200,
 		"jp_text": "自在槍用の必殺技\nカイザーライズのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kaiser Rise,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2235200,
@@ -31362,7 +31362,7 @@
 	{
 		"text_id": 2255200,
 		"jp_text": "自在槍用の必殺技\nカイザーライズのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kaiser Rise,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2255200,
@@ -31407,7 +31407,7 @@
 	{
 		"text_id": 2275200,
 		"jp_text": "自在槍用の必殺技\nカイザーライズのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Kaiser Rise,\na Wired Lance Photon Art."
 	},
 	{
 		"text_id": 2275200,
@@ -32182,7 +32182,7 @@
 	{
 		"text_id": 3233200,
 		"jp_text": "強弓用の必殺技\nミリオンストームのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Million Storm,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3233200,
@@ -32227,7 +32227,7 @@
 	{
 		"text_id": 3253200,
 		"jp_text": "強弓用の必殺技\nミリオンストームのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Million Storm,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3253200,
@@ -32272,7 +32272,7 @@
 	{
 		"text_id": 3273200,
 		"jp_text": "強弓用の必殺技\nミリオンストームのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Million Storm,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3273200,
@@ -32927,7 +32927,7 @@
 	{
 		"text_id": 3213200,
 		"jp_text": "強弓用の必殺技\nミリオンストームのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Million Storm,\na Bullet Bow Art."
 	},
 	{
 		"text_id": 3213200,
@@ -34942,7 +34942,7 @@
 	{
 		"text_id": 3133200,
 		"jp_text": "抜剣用の必殺技\nグレンテッセンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guren-tessen,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3133200,
@@ -34987,7 +34987,7 @@
 	{
 		"text_id": 3153200,
 		"jp_text": "抜剣用の必殺技\nグレンテッセンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guren-tessen,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3153200,
@@ -35032,7 +35032,7 @@
 	{
 		"text_id": 3173200,
 		"jp_text": "抜剣用の必殺技\nグレンテッセンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guren-tessen,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3173200,
@@ -35347,7 +35347,7 @@
 	{
 		"text_id": 2933200,
 		"jp_text": "大砲用の必殺技\nクラッカーバレットのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Cracker Bullet,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2933200,
@@ -35392,7 +35392,7 @@
 	{
 		"text_id": 2953200,
 		"jp_text": "大砲用の必殺技\nクラッカーバレットのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Cracker Bullet,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2953200,
@@ -35437,7 +35437,7 @@
 	{
 		"text_id": 2973200,
 		"jp_text": "大砲用の必殺技\nクラッカーバレットのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Cracker Bullet,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2973200,
@@ -35487,7 +35487,7 @@
 	{
 		"text_id": 3113200,
 		"jp_text": "抜剣用の必殺技\nグレンテッセンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guren-tessen,\na Katana Photon Art."
 	},
 	{
 		"text_id": 3113200,
@@ -36402,7 +36402,7 @@
 	{
 		"text_id": 2913200,
 		"jp_text": "大砲用の必殺技\nクラッカーバレットのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Cracker Bullet,\na Launcher Photon Art."
 	},
 	{
 		"text_id": 2913200,
@@ -38512,7 +38512,7 @@
 	{
 		"text_id": 2433200,
 		"jp_text": "<%wep>用の必殺技\nファセットフォリアのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Facet Folia,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2433200,
@@ -38557,7 +38557,7 @@
 	{
 		"text_id": 2453200,
 		"jp_text": "<%wep>用の必殺技\nファセットフォリアのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Facet Folia,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2453200,
@@ -38602,7 +38602,7 @@
 	{
 		"text_id": 2473200,
 		"jp_text": "<%wep>用の必殺技\nファセットフォリアのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Facet Folia,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2473200,
@@ -39552,7 +39552,7 @@
 	{
 		"text_id": 2413200,
 		"jp_text": "双小剣用の必殺技\nファセットフォリアのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Facet Folia,\na Twin Daggers Photon Art."
 	},
 	{
 		"text_id": 2413200,
@@ -41802,7 +41802,7 @@
 	{
 		"text_id": 3033200,
 		"jp_text": "<%wep>用の必殺技\nグリムバラージュのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grim Barrage,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3033200,
@@ -41847,7 +41847,7 @@
 	{
 		"text_id": 3053200,
 		"jp_text": "<%wep>用の必殺技\nグリムバラージュのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grim Barrage,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3053200,
@@ -41892,7 +41892,7 @@
 	{
 		"text_id": 3073200,
 		"jp_text": "<%wep>用の必殺技\nグリムバラージュのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grim Barrage,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3073200,
@@ -43132,7 +43132,7 @@
 	{
 		"text_id": 3013200,
 		"jp_text": "<%wep>用の必殺技\nグリムバラージュのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Grim Barrage,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3013200,
@@ -43177,7 +43177,7 @@
 	{
 		"text_id": 2135200,
 		"jp_text": "<%wep>用の必殺技\nギルティブレイクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guilty Break,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2135200,
@@ -43222,7 +43222,7 @@
 	{
 		"text_id": 2155200,
 		"jp_text": "<%wep>用の必殺技\nギルティブレイクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guilty Break,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2155200,
@@ -43267,7 +43267,7 @@
 	{
 		"text_id": 2175200,
 		"jp_text": "<%wep>用の必殺技\nギルティブレイクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guilty Break,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2175200,
@@ -43847,7 +43847,7 @@
 	{
 		"text_id": 2115200,
 		"jp_text": "<%wep>用の必殺技\nギルティブレイクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Guilty Break,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2115200,
@@ -44572,7 +44572,7 @@
 	{
 		"text_id": 3435200,
 		"jp_text": "<%wep>用の必殺技\nスターリングフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Starling Fall,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3435200,
@@ -44617,7 +44617,7 @@
 	{
 		"text_id": 3455200,
 		"jp_text": "<%wep>用の必殺技\nスターリングフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Starling Fall,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3455200,
@@ -44662,7 +44662,7 @@
 	{
 		"text_id": 3475200,
 		"jp_text": "<%wep>用の必殺技\nスターリングフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Starling Fall,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3475200,
@@ -45042,7 +45042,7 @@
 	{
 		"text_id": 3415200,
 		"jp_text": "<%wep>用の必殺技\nスターリングフォールのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Starling Fall,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3415200,
@@ -45532,7 +45532,7 @@
 	{
 		"text_id": 2633200,
 		"jp_text": "<%wep>用の必殺技\nメテオフィストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Meteor Fist,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2633200,
@@ -45577,7 +45577,7 @@
 	{
 		"text_id": 2653200,
 		"jp_text": "<%wep>用の必殺技\nメテオフィストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Meteor Fist,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2653200,
@@ -45622,7 +45622,7 @@
 	{
 		"text_id": 2673200,
 		"jp_text": "<%wep>用の必殺技\nメテオフィストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Meteor Fist,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2673200,
@@ -46307,7 +46307,7 @@
 	{
 		"text_id": 2613200,
 		"jp_text": "<%wep>用の必殺技\nメテオフィストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Meteor Fist,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2613200,
@@ -47017,7 +47017,7 @@
 	{
 		"text_id": 3333200,
 		"jp_text": "<%wep>用の必殺技\nストライクガストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Strike Gust,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3333200,
@@ -47062,7 +47062,7 @@
 	{
 		"text_id": 3353200,
 		"jp_text": "<%wep>用の必殺技\nストライクガストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Strike Gust,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3353200,
@@ -47107,7 +47107,7 @@
 	{
 		"text_id": 3373200,
 		"jp_text": "<%wep>用の必殺技\nストライクガストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Strike Gust,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3373200,
@@ -47647,7 +47647,7 @@
 	{
 		"text_id": 3313200,
 		"jp_text": "<%wep>用の必殺技\nストライクガストのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Strike Gust,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 3313200,
@@ -48017,7 +48017,7 @@
 	{
 		"text_id": 2335200,
 		"jp_text": "<%wep>用の必殺技\nティアーズグリッドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tear Grid,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2335200,
@@ -48062,7 +48062,7 @@
 	{
 		"text_id": 2355200,
 		"jp_text": "<%wep>用の必殺技\nティアーズグリッドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tear Grid,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2355200,
@@ -48107,7 +48107,7 @@
 	{
 		"text_id": 2375200,
 		"jp_text": "<%wep>用の必殺技\nティアーズグリッドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tear Grid,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2375200,
@@ -48887,7 +48887,7 @@
 	{
 		"text_id": 2315200,
 		"jp_text": "<%wep>用の必殺技\nティアーズグリッドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Tear Grid,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2315200,
@@ -51232,7 +51232,7 @@
 	{
 		"text_id": 2735200,
 		"jp_text": "<%wep>用の必殺技\nスラッシュレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Slash Rave,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2735200,
@@ -51277,7 +51277,7 @@
 	{
 		"text_id": 2755200,
 		"jp_text": "<%wep>用の必殺技\nスラッシュレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Slash Rave,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2755200,
@@ -51322,7 +51322,7 @@
 	{
 		"text_id": 2775200,
 		"jp_text": "<%wep>用の必殺技\nスラッシュレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Slash Rave,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2775200,
@@ -51967,7 +51967,7 @@
 	{
 		"text_id": 2715200,
 		"jp_text": "<%wep>用の必殺技\nスラッシュレイヴのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Slash Rave,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2715200,
@@ -54797,7 +54797,7 @@
 	{
 		"text_id": 2525200,
 		"jp_text": "<%wep>用の必殺技\nサプライズダンクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Surprise Dunk,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2525200,
@@ -54842,7 +54842,7 @@
 	{
 		"text_id": 2553200,
 		"jp_text": "<%wep>用の必殺技\nサプライズダンクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Surprise Dunk,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2553200,
@@ -54887,7 +54887,7 @@
 	{
 		"text_id": 2565200,
 		"jp_text": "<%wep>用の必殺技\nサプライズダンクのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Surprise Dunk,\na <%wep> Photon Art."
 	},
 	{
 		"text_id": 2565200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -4077,7 +4077,7 @@
 	{
 		"text_id": 2102200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2102200,
@@ -4122,7 +4122,7 @@
 	{
 		"text_id": 2104200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2104200,
@@ -4167,7 +4167,7 @@
 	{
 		"text_id": 2122200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2122200,
@@ -4212,7 +4212,7 @@
 	{
 		"text_id": 2124200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2124200,
@@ -4257,7 +4257,7 @@
 	{
 		"text_id": 2142200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2142200,
@@ -4302,7 +4302,7 @@
 	{
 		"text_id": 2144200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2144200,
@@ -4347,7 +4347,7 @@
 	{
 		"text_id": 2202200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2202200,
@@ -4392,7 +4392,7 @@
 	{
 		"text_id": 2222200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2222200,
@@ -4437,7 +4437,7 @@
 	{
 		"text_id": 2242200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2242200,
@@ -4482,7 +4482,7 @@
 	{
 		"text_id": 2302200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2302200,
@@ -4527,7 +4527,7 @@
 	{
 		"text_id": 2322200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2322200,
@@ -4572,7 +4572,7 @@
 	{
 		"text_id": 2342200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2342200,
@@ -4617,7 +4617,7 @@
 	{
 		"text_id": 2402200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2402200,
@@ -4662,7 +4662,7 @@
 	{
 		"text_id": 2422200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2422200,
@@ -4707,7 +4707,7 @@
 	{
 		"text_id": 2442200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2442200,
@@ -4752,7 +4752,7 @@
 	{
 		"text_id": 2502200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2502200,
@@ -4797,7 +4797,7 @@
 	{
 		"text_id": 2522200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2522200,
@@ -4842,7 +4842,7 @@
 	{
 		"text_id": 2542200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2542200,
@@ -4887,7 +4887,7 @@
 	{
 		"text_id": 2602200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2602200,
@@ -4932,7 +4932,7 @@
 	{
 		"text_id": 2622200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2622200,
@@ -4977,7 +4977,7 @@
 	{
 		"text_id": 2642200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2642200,
@@ -5027,7 +5027,7 @@
 	{
 		"text_id": 2702200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2702200,
@@ -5072,7 +5072,7 @@
 	{
 		"text_id": 2722200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2722200,
@@ -5117,7 +5117,7 @@
 	{
 		"text_id": 2742200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2742200,
@@ -5162,7 +5162,7 @@
 	{
 		"text_id": 2802200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2802200,
@@ -5207,7 +5207,7 @@
 	{
 		"text_id": 2804200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2804200,
@@ -5252,7 +5252,7 @@
 	{
 		"text_id": 2822200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2822200,
@@ -5297,7 +5297,7 @@
 	{
 		"text_id": 2824200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2824200,
@@ -5342,7 +5342,7 @@
 	{
 		"text_id": 2842200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2842200,
@@ -5387,7 +5387,7 @@
 	{
 		"text_id": 2844200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2844200,
@@ -5432,7 +5432,7 @@
 	{
 		"text_id": 2902200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2902200,
@@ -5477,7 +5477,7 @@
 	{
 		"text_id": 2922200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2922200,
@@ -5522,7 +5522,7 @@
 	{
 		"text_id": 2942200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2942200,
@@ -5567,7 +5567,7 @@
 	{
 		"text_id": 3002200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3002200,
@@ -5612,7 +5612,7 @@
 	{
 		"text_id": 3022200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3022200,
@@ -5657,7 +5657,7 @@
 	{
 		"text_id": 3042200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3042200,
@@ -5702,7 +5702,7 @@
 	{
 		"text_id": 3102200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3102200,
@@ -5747,7 +5747,7 @@
 	{
 		"text_id": 3122200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3122200,
@@ -5792,7 +5792,7 @@
 	{
 		"text_id": 3142200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3142200,
@@ -5837,7 +5837,7 @@
 	{
 		"text_id": 3202200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3202200,
@@ -5882,7 +5882,7 @@
 	{
 		"text_id": 3222200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3222200,
@@ -5927,7 +5927,7 @@
 	{
 		"text_id": 3242200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3242200,
@@ -5972,7 +5972,7 @@
 	{
 		"text_id": 3302200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3302200,
@@ -6017,7 +6017,7 @@
 	{
 		"text_id": 3322200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3322200,
@@ -6062,7 +6062,7 @@
 	{
 		"text_id": 3342200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3342200,
@@ -6107,7 +6107,7 @@
 	{
 		"text_id": 3402200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3402200,
@@ -6152,7 +6152,7 @@
 	{
 		"text_id": 3422200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3422200,
@@ -6197,7 +6197,7 @@
 	{
 		"text_id": 3442200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3442200,
@@ -6262,7 +6262,7 @@
 	{
 		"text_id": 4904200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 4904200,
@@ -6427,7 +6427,7 @@
 	{
 		"text_id": 5002200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5002200,
@@ -6472,7 +6472,7 @@
 	{
 		"text_id": 5004200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5004200,
@@ -6537,7 +6537,7 @@
 	{
 		"text_id": 5010200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5010200,
@@ -6582,7 +6582,7 @@
 	{
 		"text_id": 5032200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5032200,
@@ -6647,7 +6647,7 @@
 	{
 		"text_id": 5040200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5040200,
@@ -6692,7 +6692,7 @@
 	{
 		"text_id": 5062200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5062200,
@@ -6757,7 +6757,7 @@
 	{
 		"text_id": 5070200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5070200,
@@ -6802,7 +6802,7 @@
 	{
 		"text_id": 5102200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5102200,
@@ -6847,7 +6847,7 @@
 	{
 		"text_id": 5104200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5104200,
@@ -6912,7 +6912,7 @@
 	{
 		"text_id": 5110200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5110200,
@@ -6957,7 +6957,7 @@
 	{
 		"text_id": 5132200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5132200,
@@ -7022,7 +7022,7 @@
 	{
 		"text_id": 5140200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5140200,
@@ -7067,7 +7067,7 @@
 	{
 		"text_id": 5162200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5162200,
@@ -7132,7 +7132,7 @@
 	{
 		"text_id": 5170200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5170200,
@@ -7177,7 +7177,7 @@
 	{
 		"text_id": 5202200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5202200,
@@ -7222,7 +7222,7 @@
 	{
 		"text_id": 5204200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5204200,
@@ -7267,7 +7267,7 @@
 	{
 		"text_id": 5206200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5206200,
@@ -7332,7 +7332,7 @@
 	{
 		"text_id": 5232200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5232200,
@@ -7377,7 +7377,7 @@
 	{
 		"text_id": 5236200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5236200,
@@ -7422,7 +7422,7 @@
 	{
 		"text_id": 5262200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5262200,
@@ -7467,7 +7467,7 @@
 	{
 		"text_id": 5266200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5266200,
@@ -7512,7 +7512,7 @@
 	{
 		"text_id": 5302200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5302200,
@@ -7557,7 +7557,7 @@
 	{
 		"text_id": 5304200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5304200,
@@ -7642,7 +7642,7 @@
 	{
 		"text_id": 5332200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5332200,
@@ -7687,7 +7687,7 @@
 	{
 		"text_id": 5334200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5334200,
@@ -7752,7 +7752,7 @@
 	{
 		"text_id": 5362200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5362200,
@@ -7797,7 +7797,7 @@
 	{
 		"text_id": 5364200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5364200,
@@ -7862,7 +7862,7 @@
 	{
 		"text_id": 5402200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5402200,
@@ -7907,7 +7907,7 @@
 	{
 		"text_id": 5408200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5408200,
@@ -7952,7 +7952,7 @@
 	{
 		"text_id": 5410200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5410200,
@@ -7997,7 +7997,7 @@
 	{
 		"text_id": 5432200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5432200,
@@ -8042,7 +8042,7 @@
 	{
 		"text_id": 5434200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5434200,
@@ -8087,7 +8087,7 @@
 	{
 		"text_id": 5438200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5438200,
@@ -8132,7 +8132,7 @@
 	{
 		"text_id": 5462200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5462200,
@@ -8177,7 +8177,7 @@
 	{
 		"text_id": 5464200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5464200,
@@ -8222,7 +8222,7 @@
 	{
 		"text_id": 5468200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5468200,
@@ -8267,7 +8267,7 @@
 	{
 		"text_id": 5502200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5502200,
@@ -8352,7 +8352,7 @@
 	{
 		"text_id": 5532200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5532200,
@@ -8437,7 +8437,7 @@
 	{
 		"text_id": 5562200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5562200,
@@ -13992,7 +13992,7 @@
 	{
 		"text_id": 1808200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1808200,
@@ -14047,7 +14047,7 @@
 	{
 		"text_id": 1824200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1824200,
@@ -14102,7 +14102,7 @@
 	{
 		"text_id": 1828200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1828200,
@@ -14152,7 +14152,7 @@
 	{
 		"text_id": 1836200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1836200,
@@ -15182,7 +15182,7 @@
 	{
 		"text_id": 1806200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1806200,
@@ -15237,7 +15237,7 @@
 	{
 		"text_id": 1820200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1820200,
@@ -15292,7 +15292,7 @@
 	{
 		"text_id": 1826200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1826200,
@@ -15342,7 +15342,7 @@
 	{
 		"text_id": 1840200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1840200,
@@ -16147,7 +16147,7 @@
 	{
 		"text_id": 1810200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1810200,
@@ -16197,7 +16197,7 @@
 	{
 		"text_id": 1834200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1834200,
@@ -16252,7 +16252,7 @@
 	{
 		"text_id": 1846200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1846200,
@@ -16307,7 +16307,7 @@
 	{
 		"text_id": 1868200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1868200,
@@ -16357,7 +16357,7 @@
 	{
 		"text_id": 2324200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2324200,
@@ -16402,7 +16402,7 @@
 	{
 		"text_id": 2344200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2344200,
@@ -16452,7 +16452,7 @@
 	{
 		"text_id": 2364200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2364200,
@@ -16497,7 +16497,7 @@
 	{
 		"text_id": 2924200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2924200,
@@ -16542,7 +16542,7 @@
 	{
 		"text_id": 2944200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2944200,
@@ -16592,7 +16592,7 @@
 	{
 		"text_id": 2964200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2964200,
@@ -16642,7 +16642,7 @@
 	{
 		"text_id": 5394200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5394200,
@@ -17352,7 +17352,7 @@
 	{
 		"text_id": 1812200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1812200,
@@ -17402,7 +17402,7 @@
 	{
 		"text_id": 1838200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1838200,
@@ -17457,7 +17457,7 @@
 	{
 		"text_id": 1822200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1822200,
@@ -17512,7 +17512,7 @@
 	{
 		"text_id": 1814200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1814200,
@@ -17567,7 +17567,7 @@
 	{
 		"text_id": 1866200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1866200,
@@ -17617,7 +17617,7 @@
 	{
 		"text_id": 2224200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2224200,
@@ -17662,7 +17662,7 @@
 	{
 		"text_id": 2244200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2244200,
@@ -17712,7 +17712,7 @@
 	{
 		"text_id": 2264200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2264200,
@@ -17757,7 +17757,7 @@
 	{
 		"text_id": 2304200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2304200,
@@ -17802,7 +17802,7 @@
 	{
 		"text_id": 2904200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2904200,
@@ -17847,7 +17847,7 @@
 	{
 		"text_id": 3224200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3224200,
@@ -17892,7 +17892,7 @@
 	{
 		"text_id": 3244200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3244200,
@@ -17942,7 +17942,7 @@
 	{
 		"text_id": 3264200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3264200,
@@ -17987,7 +17987,7 @@
 	{
 		"text_id": 5234200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5234200,
@@ -18032,7 +18032,7 @@
 	{
 		"text_id": 5264200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5264200,
@@ -18082,7 +18082,7 @@
 	{
 		"text_id": 5294200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5294200,
@@ -18542,7 +18542,7 @@
 	{
 		"text_id": 1802200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1802200,
@@ -18597,7 +18597,7 @@
 	{
 		"text_id": 1804200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1804200,
@@ -18652,7 +18652,7 @@
 	{
 		"text_id": 1816200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1816200,
@@ -18707,7 +18707,7 @@
 	{
 		"text_id": 1818200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1818200,
@@ -18757,7 +18757,7 @@
 	{
 		"text_id": 1830200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1830200,
@@ -18807,7 +18807,7 @@
 	{
 		"text_id": 1832200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1832200,
@@ -18862,7 +18862,7 @@
 	{
 		"text_id": 1848200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1848200,
@@ -18912,7 +18912,7 @@
 	{
 		"text_id": 2204200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2204200,
@@ -18957,7 +18957,7 @@
 	{
 		"text_id": 2524200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2524200,
@@ -19002,7 +19002,7 @@
 	{
 		"text_id": 2544200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2544200,
@@ -19052,7 +19052,7 @@
 	{
 		"text_id": 2564200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2564200,
@@ -19097,7 +19097,7 @@
 	{
 		"text_id": 2724200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2724200,
@@ -19142,7 +19142,7 @@
 	{
 		"text_id": 2744200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2744200,
@@ -19192,7 +19192,7 @@
 	{
 		"text_id": 2764200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2764200,
@@ -19237,7 +19237,7 @@
 	{
 		"text_id": 3204000,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3204000,
@@ -19282,7 +19282,7 @@
 	{
 		"text_id": 5134200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5134200,
@@ -19327,7 +19327,7 @@
 	{
 		"text_id": 5164200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5164200,
@@ -19372,7 +19372,7 @@
 	{
 		"text_id": 5194200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5194200,
@@ -19422,7 +19422,7 @@
 	{
 		"text_id": 1860200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1860200,
@@ -19477,7 +19477,7 @@
 	{
 		"text_id": 1864200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1864200,
@@ -19532,7 +19532,7 @@
 	{
 		"text_id": 1884200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1884200,
@@ -19587,7 +19587,7 @@
 	{
 		"text_id": 1890200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1890200,
@@ -19642,7 +19642,7 @@
 	{
 		"text_id": 1908200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1908200,
@@ -19697,7 +19697,7 @@
 	{
 		"text_id": 1912200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1912200,
@@ -19747,7 +19747,7 @@
 	{
 		"text_id": 2146200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2146200,
@@ -19792,7 +19792,7 @@
 	{
 		"text_id": 2246200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2246200,
@@ -19837,7 +19837,7 @@
 	{
 		"text_id": 2346200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2346200,
@@ -19882,7 +19882,7 @@
 	{
 		"text_id": 2446200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2446200,
@@ -19927,7 +19927,7 @@
 	{
 		"text_id": 2504200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2504200,
@@ -19972,7 +19972,7 @@
 	{
 		"text_id": 2646200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2646200,
@@ -20017,7 +20017,7 @@
 	{
 		"text_id": 2704200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2704200,
@@ -20062,7 +20062,7 @@
 	{
 		"text_id": 2746200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2746200,
@@ -20107,7 +20107,7 @@
 	{
 		"text_id": 2846200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2846200,
@@ -20152,7 +20152,7 @@
 	{
 		"text_id": 2946200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2946200,
@@ -20197,7 +20197,7 @@
 	{
 		"text_id": 3046200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3046200,
@@ -20242,7 +20242,7 @@
 	{
 		"text_id": 3146200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3146200,
@@ -20287,7 +20287,7 @@
 	{
 		"text_id": 3246200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3246200,
@@ -20332,7 +20332,7 @@
 	{
 		"text_id": 3446200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3446200,
@@ -20377,7 +20377,7 @@
 	{
 		"text_id": 5034200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5034200,
@@ -20422,7 +20422,7 @@
 	{
 		"text_id": 5064200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5064200,
@@ -20472,7 +20472,7 @@
 	{
 		"text_id": 5094200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5094200,
@@ -20517,7 +20517,7 @@
 	{
 		"text_id": 2424200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2424200,
@@ -20562,7 +20562,7 @@
 	{
 		"text_id": 2444200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2444200,
@@ -20612,7 +20612,7 @@
 	{
 		"text_id": 2464200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2464200,
@@ -20657,7 +20657,7 @@
 	{
 		"text_id": 3324200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3324200,
@@ -20702,7 +20702,7 @@
 	{
 		"text_id": 3344200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3344200,
@@ -20752,7 +20752,7 @@
 	{
 		"text_id": 3364200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3364200,
@@ -22317,7 +22317,7 @@
 	{
 		"text_id": 1197031,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197031,
@@ -22367,7 +22367,7 @@
 	{
 		"text_id": 1197035,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197035,
@@ -22417,7 +22417,7 @@
 	{
 		"text_id": 1197039,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197039,
@@ -22467,7 +22467,7 @@
 	{
 		"text_id": 1197043,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197043,
@@ -22517,7 +22517,7 @@
 	{
 		"text_id": 1197047,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197047,
@@ -22562,7 +22562,7 @@
 	{
 		"text_id": 1197051,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197051,
@@ -22607,7 +22607,7 @@
 	{
 		"text_id": 1197055,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197055,
@@ -22652,7 +22652,7 @@
 	{
 		"text_id": 1197059,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197059,
@@ -22702,7 +22702,7 @@
 	{
 		"text_id": 1197063,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197063,
@@ -22747,7 +22747,7 @@
 	{
 		"text_id": 1197067,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197067,
@@ -22792,7 +22792,7 @@
 	{
 		"text_id": 1197071,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197071,
@@ -22837,7 +22837,7 @@
 	{
 		"text_id": 1197075,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197075,
@@ -22882,7 +22882,7 @@
 	{
 		"text_id": 1197079,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197079,
@@ -22927,7 +22927,7 @@
 	{
 		"text_id": 1197083,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197083,
@@ -22972,7 +22972,7 @@
 	{
 		"text_id": 1197087,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197087,
@@ -23017,7 +23017,7 @@
 	{
 		"text_id": 1197091,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197091,
@@ -23062,7 +23062,7 @@
 	{
 		"text_id": 1197095,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197095,
@@ -23107,7 +23107,7 @@
 	{
 		"text_id": 1197099,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197099,
@@ -23152,7 +23152,7 @@
 	{
 		"text_id": 1197103,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197103,
@@ -23197,7 +23197,7 @@
 	{
 		"text_id": 1197107,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197107,
@@ -23247,7 +23247,7 @@
 	{
 		"text_id": 1197111,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197111,
@@ -23292,7 +23292,7 @@
 	{
 		"text_id": 1197115,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197115,
@@ -23337,7 +23337,7 @@
 	{
 		"text_id": 1197119,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197119,
@@ -23382,7 +23382,7 @@
 	{
 		"text_id": 1197123,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197123,
@@ -23427,7 +23427,7 @@
 	{
 		"text_id": 1197127,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197127,
@@ -24007,7 +24007,7 @@
 	{
 		"text_id": 1197167,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197167,
@@ -24052,7 +24052,7 @@
 	{
 		"text_id": 1197171,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197171,
@@ -24097,7 +24097,7 @@
 	{
 		"text_id": 1197175,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197175,
@@ -24147,7 +24147,7 @@
 	{
 		"text_id": 1197179,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197179,
@@ -24192,7 +24192,7 @@
 	{
 		"text_id": 1197183,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197183,
@@ -24237,7 +24237,7 @@
 	{
 		"text_id": 1197187,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197187,
@@ -24282,7 +24282,7 @@
 	{
 		"text_id": 1197191,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197191,
@@ -24332,7 +24332,7 @@
 	{
 		"text_id": 1197195,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197195,
@@ -24382,7 +24382,7 @@
 	{
 		"text_id": 1197199,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197199,
@@ -24437,7 +24437,7 @@
 	{
 		"text_id": 1197203,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197203,
@@ -24492,7 +24492,7 @@
 	{
 		"text_id": 1197207,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197207,
@@ -24647,7 +24647,7 @@
 	{
 		"text_id": 1197219,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197219,
@@ -24692,7 +24692,7 @@
 	{
 		"text_id": 1197223,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197223,
@@ -24737,7 +24737,7 @@
 	{
 		"text_id": 1197227,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197227,
@@ -24782,7 +24782,7 @@
 	{
 		"text_id": 1197231,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197231,
@@ -24827,7 +24827,7 @@
 	{
 		"text_id": 1197235,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197235,
@@ -24872,7 +24872,7 @@
 	{
 		"text_id": 1197238,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197238,
@@ -24917,7 +24917,7 @@
 	{
 		"text_id": 1197242,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197242,
@@ -24962,7 +24962,7 @@
 	{
 		"text_id": 1197246,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197246,
@@ -25007,7 +25007,7 @@
 	{
 		"text_id": 1197250,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197250,
@@ -25052,7 +25052,7 @@
 	{
 		"text_id": 1197254,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1197254,
@@ -26282,7 +26282,7 @@
 	{
 		"text_id": 3024200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3024200,
@@ -26327,7 +26327,7 @@
 	{
 		"text_id": 3044200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3044200,
@@ -26377,7 +26377,7 @@
 	{
 		"text_id": 3064200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3064200,
@@ -26422,7 +26422,7 @@
 	{
 		"text_id": 2604200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2604200,
@@ -26467,7 +26467,7 @@
 	{
 		"text_id": 5504200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5504200,
@@ -26517,7 +26517,7 @@
 	{
 		"text_id": 1892200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1892200,
@@ -26572,7 +26572,7 @@
 	{
 		"text_id": 1900200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1900200,
@@ -26627,7 +26627,7 @@
 	{
 		"text_id": 1844200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1844200,
@@ -26677,7 +26677,7 @@
 	{
 		"text_id": 2152200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2152200,
@@ -26722,7 +26722,7 @@
 	{
 		"text_id": 2250200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2250200,
@@ -26767,7 +26767,7 @@
 	{
 		"text_id": 2352200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2352200,
@@ -26812,7 +26812,7 @@
 	{
 		"text_id": 2450200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2450200,
@@ -26857,7 +26857,7 @@
 	{
 		"text_id": 2550200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2550200,
@@ -26902,7 +26902,7 @@
 	{
 		"text_id": 2652200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2652200,
@@ -26947,7 +26947,7 @@
 	{
 		"text_id": 2752200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2752200,
@@ -26992,7 +26992,7 @@
 	{
 		"text_id": 2850200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2850200,
@@ -27037,7 +27037,7 @@
 	{
 		"text_id": 2950200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2950200,
@@ -27082,7 +27082,7 @@
 	{
 		"text_id": 3150200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3150200,
@@ -27127,7 +27127,7 @@
 	{
 		"text_id": 3452200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3452200,
@@ -27172,7 +27172,7 @@
 	{
 		"text_id": 3350200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3350200,
@@ -27607,7 +27607,7 @@
 	{
 		"text_id": 2834200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2834200,
@@ -27652,7 +27652,7 @@
 	{
 		"text_id": 2854200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2854200,
@@ -27702,7 +27702,7 @@
 	{
 		"text_id": 2874200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2874200,
@@ -27747,7 +27747,7 @@
 	{
 		"text_id": 3424200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3424200,
@@ -27792,7 +27792,7 @@
 	{
 		"text_id": 3444200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3444200,
@@ -27842,7 +27842,7 @@
 	{
 		"text_id": 3464200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3464200,
@@ -27892,7 +27892,7 @@
 	{
 		"text_id": 5494200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5494200,
@@ -27942,7 +27942,7 @@
 	{
 		"text_id": 1854200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1854200,
@@ -27997,7 +27997,7 @@
 	{
 		"text_id": 1862200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1862200,
@@ -28052,7 +28052,7 @@
 	{
 		"text_id": 1896200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1896200,
@@ -28107,7 +28107,7 @@
 	{
 		"text_id": 1910200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1910200,
@@ -28157,7 +28157,7 @@
 	{
 		"text_id": 2154200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2154200,
@@ -28202,7 +28202,7 @@
 	{
 		"text_id": 2252200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2252200,
@@ -28247,7 +28247,7 @@
 	{
 		"text_id": 2354200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2354200,
@@ -28292,7 +28292,7 @@
 	{
 		"text_id": 2452200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2452200,
@@ -28337,7 +28337,7 @@
 	{
 		"text_id": 2552200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2552200,
@@ -28382,7 +28382,7 @@
 	{
 		"text_id": 2754200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2754200,
@@ -28427,7 +28427,7 @@
 	{
 		"text_id": 2952200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2952200,
@@ -28472,7 +28472,7 @@
 	{
 		"text_id": 3004200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3004200,
@@ -28517,7 +28517,7 @@
 	{
 		"text_id": 3052200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3052200,
@@ -28562,7 +28562,7 @@
 	{
 		"text_id": 3152200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3152200,
@@ -28607,7 +28607,7 @@
 	{
 		"text_id": 3252200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3252200,
@@ -28652,7 +28652,7 @@
 	{
 		"text_id": 3352200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3352200,
@@ -28697,7 +28697,7 @@
 	{
 		"text_id": 3454200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3454200,
@@ -28742,7 +28742,7 @@
 	{
 		"text_id": 2852200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2852200,
@@ -29817,7 +29817,7 @@
 	{
 		"text_id": 1850200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1850200,
@@ -29872,7 +29872,7 @@
 	{
 		"text_id": 1888200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1888200,
@@ -29927,7 +29927,7 @@
 	{
 		"text_id": 1914200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1914200,
@@ -29982,7 +29982,7 @@
 	{
 		"text_id": 1918200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1918200,
@@ -30037,7 +30037,7 @@
 	{
 		"text_id": 1932200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1932200,
@@ -30087,7 +30087,7 @@
 	{
 		"text_id": 2814200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2814200,
@@ -30132,7 +30132,7 @@
 	{
 		"text_id": 3403200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3403200,
@@ -30177,7 +30177,7 @@
 	{
 		"text_id": 5404200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5404200,
@@ -30907,7 +30907,7 @@
 	{
 		"text_id": 1842200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1842200,
@@ -30962,7 +30962,7 @@
 	{
 		"text_id": 1856200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1856200,
@@ -31017,7 +31017,7 @@
 	{
 		"text_id": 1886200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1886200,
@@ -31072,7 +31072,7 @@
 	{
 		"text_id": 1924200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1924200,
@@ -31127,7 +31127,7 @@
 	{
 		"text_id": 1926200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1926200,
@@ -31182,7 +31182,7 @@
 	{
 		"text_id": 1934200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1934200,
@@ -31237,7 +31237,7 @@
 	{
 		"text_id": 1938200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1938200,
@@ -31292,7 +31292,7 @@
 	{
 		"text_id": 1940200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1940200,
@@ -31342,7 +31342,7 @@
 	{
 		"text_id": 2236200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2236200,
@@ -31387,7 +31387,7 @@
 	{
 		"text_id": 2256200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2256200,
@@ -31437,7 +31437,7 @@
 	{
 		"text_id": 2276200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2276200,
@@ -31482,7 +31482,7 @@
 	{
 		"text_id": 5036200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5036200,
@@ -31527,7 +31527,7 @@
 	{
 		"text_id": 5066200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5066200,
@@ -31577,7 +31577,7 @@
 	{
 		"text_id": 5096200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5096200,
@@ -32067,7 +32067,7 @@
 	{
 		"text_id": 1942200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1942200,
@@ -32117,7 +32117,7 @@
 	{
 		"text_id": 2216200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2216200,
@@ -32162,7 +32162,7 @@
 	{
 		"text_id": 5006200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5006200,
@@ -32207,7 +32207,7 @@
 	{
 		"text_id": 3234200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3234200,
@@ -32252,7 +32252,7 @@
 	{
 		"text_id": 3254200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3254200,
@@ -32302,7 +32302,7 @@
 	{
 		"text_id": 3274200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3274200,
@@ -32792,7 +32792,7 @@
 	{
 		"text_id": 1920200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1920200,
@@ -32847,7 +32847,7 @@
 	{
 		"text_id": 1936200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1936200,
@@ -32902,7 +32902,7 @@
 	{
 		"text_id": 1928200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1928200,
@@ -32952,7 +32952,7 @@
 	{
 		"text_id": 3214200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3214200,
@@ -32997,7 +32997,7 @@
 	{
 		"text_id": 5336200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5336200,
@@ -33042,7 +33042,7 @@
 	{
 		"text_id": 5366200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5366200,
@@ -33092,7 +33092,7 @@
 	{
 		"text_id": 5396200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5396200,
@@ -33832,7 +33832,7 @@
 	{
 		"text_id": 1966200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1966200,
@@ -33882,7 +33882,7 @@
 	{
 		"text_id": 5306200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5306200,
@@ -33927,7 +33927,7 @@
 	{
 		"text_id": 5238200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5238200,
@@ -33972,7 +33972,7 @@
 	{
 		"text_id": 5268200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5268200,
@@ -34022,7 +34022,7 @@
 	{
 		"text_id": 5298200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5298200,
@@ -34587,7 +34587,7 @@
 	{
 		"text_id": 1922200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1922200,
@@ -34642,7 +34642,7 @@
 	{
 		"text_id": 1946200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1946200,
@@ -34697,7 +34697,7 @@
 	{
 		"text_id": 1962200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1962200,
@@ -34752,7 +34752,7 @@
 	{
 		"text_id": 1974200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1974200,
@@ -34807,7 +34807,7 @@
 	{
 		"text_id": 1916200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1916200,
@@ -34862,7 +34862,7 @@
 	{
 		"text_id": 1964200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1964200,
@@ -34917,7 +34917,7 @@
 	{
 		"text_id": 1930200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1930200,
@@ -34967,7 +34967,7 @@
 	{
 		"text_id": 3134200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3134200,
@@ -35012,7 +35012,7 @@
 	{
 		"text_id": 3154200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3154200,
@@ -35062,7 +35062,7 @@
 	{
 		"text_id": 3174200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3174200,
@@ -35107,7 +35107,7 @@
 	{
 		"text_id": 5208200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5208200,
@@ -35372,7 +35372,7 @@
 	{
 		"text_id": 2934200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2934200,
@@ -35417,7 +35417,7 @@
 	{
 		"text_id": 2954200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2954200,
@@ -35467,7 +35467,7 @@
 	{
 		"text_id": 2974200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2974200,
@@ -35512,7 +35512,7 @@
 	{
 		"text_id": 3114200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3114200,
@@ -35562,7 +35562,7 @@
 	{
 		"text_id": 1954200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1954200,
@@ -35617,7 +35617,7 @@
 	{
 		"text_id": 1956200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1956200,
@@ -35672,7 +35672,7 @@
 	{
 		"text_id": 1994200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1994200,
@@ -35727,7 +35727,7 @@
 	{
 		"text_id": 1968200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1968200,
@@ -36287,7 +36287,7 @@
 	{
 		"text_id": 5136200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5136200,
@@ -36332,7 +36332,7 @@
 	{
 		"text_id": 5166200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5166200,
@@ -36382,7 +36382,7 @@
 	{
 		"text_id": 5196200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5196200,
@@ -36427,7 +36427,7 @@
 	{
 		"text_id": 2914200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2914200,
@@ -36477,7 +36477,7 @@
 	{
 		"text_id": 1960200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1960200,
@@ -36532,7 +36532,7 @@
 	{
 		"text_id": 1970200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1970200,
@@ -36587,7 +36587,7 @@
 	{
 		"text_id": 1990200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1990200,
@@ -38212,7 +38212,7 @@
 	{
 		"text_id": 1944200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1944200,
@@ -38267,7 +38267,7 @@
 	{
 		"text_id": 1948200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1948200,
@@ -38322,7 +38322,7 @@
 	{
 		"text_id": 1950200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1950200,
@@ -38377,7 +38377,7 @@
 	{
 		"text_id": 1958200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1958200,
@@ -38432,7 +38432,7 @@
 	{
 		"text_id": 1992200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1992200,
@@ -38487,7 +38487,7 @@
 	{
 		"text_id": 2002200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2002200,
@@ -38537,7 +38537,7 @@
 	{
 		"text_id": 2434200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2434200,
@@ -38582,7 +38582,7 @@
 	{
 		"text_id": 2454200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2454200,
@@ -38632,7 +38632,7 @@
 	{
 		"text_id": 2474200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2474200,
@@ -38677,7 +38677,7 @@
 	{
 		"text_id": 5106200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5106200,
@@ -38722,7 +38722,7 @@
 	{
 		"text_id": 5536200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5536200,
@@ -38767,7 +38767,7 @@
 	{
 		"text_id": 5566200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5566200,
@@ -38817,7 +38817,7 @@
 	{
 		"text_id": 5596200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5596200,
@@ -39577,7 +39577,7 @@
 	{
 		"text_id": 2414200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2414200,
@@ -39622,7 +39622,7 @@
 	{
 		"text_id": 5506200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5506200,
@@ -39672,7 +39672,7 @@
 	{
 		"text_id": 1952200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1952200,
@@ -39727,7 +39727,7 @@
 	{
 		"text_id": 1984200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1984200,
@@ -39782,7 +39782,7 @@
 	{
 		"text_id": 1988200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1988200,
@@ -39837,7 +39837,7 @@
 	{
 		"text_id": 1972200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1972200,
@@ -39892,7 +39892,7 @@
 	{
 		"text_id": 1982200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1982200,
@@ -39947,7 +39947,7 @@
 	{
 		"text_id": 2018200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2018200,
@@ -40002,7 +40002,7 @@
 	{
 		"text_id": 1996200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1996200,
@@ -40782,7 +40782,7 @@
 	{
 		"text_id": 5436200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5436200,
@@ -40827,7 +40827,7 @@
 	{
 		"text_id": 5466200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5466200,
@@ -40877,7 +40877,7 @@
 	{
 		"text_id": 5496200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5496200,
@@ -40927,7 +40927,7 @@
 	{
 		"text_id": 1978200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1978200,
@@ -40982,7 +40982,7 @@
 	{
 		"text_id": 2012200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2012200,
@@ -41037,7 +41037,7 @@
 	{
 		"text_id": 2010200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2010200,
@@ -41472,7 +41472,7 @@
 	{
 		"text_id": 5406200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5406200,
@@ -41827,7 +41827,7 @@
 	{
 		"text_id": 3034200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3034200,
@@ -41872,7 +41872,7 @@
 	{
 		"text_id": 3054200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3054200,
@@ -41922,7 +41922,7 @@
 	{
 		"text_id": 3074200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3074200,
@@ -41972,7 +41972,7 @@
 	{
 		"text_id": 1986200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1986200,
@@ -42027,7 +42027,7 @@
 	{
 		"text_id": 1998200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1998200,
@@ -42942,7 +42942,7 @@
 	{
 		"text_id": 2006200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2006200,
@@ -42997,7 +42997,7 @@
 	{
 		"text_id": 1980200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1980200,
@@ -43052,7 +43052,7 @@
 	{
 		"text_id": 2022200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2022200,
@@ -43107,7 +43107,7 @@
 	{
 		"text_id": 1976200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 1976200,
@@ -43157,7 +43157,7 @@
 	{
 		"text_id": 3014200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3014200,
@@ -43202,7 +43202,7 @@
 	{
 		"text_id": 2136200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2136200,
@@ -43247,7 +43247,7 @@
 	{
 		"text_id": 2156200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2156200,
@@ -43297,7 +43297,7 @@
 	{
 		"text_id": 2176200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2176200,
@@ -43872,7 +43872,7 @@
 	{
 		"text_id": 2116200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2116200,
@@ -44437,7 +44437,7 @@
 	{
 		"text_id": 2020200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2020200,
@@ -44492,7 +44492,7 @@
 	{
 		"text_id": 2026200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2026200,
@@ -44547,7 +44547,7 @@
 	{
 		"text_id": 2016200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2016200,
@@ -44597,7 +44597,7 @@
 	{
 		"text_id": 3436200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3436200,
@@ -44642,7 +44642,7 @@
 	{
 		"text_id": 3456200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3456200,
@@ -44692,7 +44692,7 @@
 	{
 		"text_id": 3476200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3476200,
@@ -44962,7 +44962,7 @@
 	{
 		"text_id": 2000200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2000200,
@@ -45017,7 +45017,7 @@
 	{
 		"text_id": 2024200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2024200,
@@ -45067,7 +45067,7 @@
 	{
 		"text_id": 3416200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3416200,
@@ -45452,7 +45452,7 @@
 	{
 		"text_id": 2004200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2004200,
@@ -45507,7 +45507,7 @@
 	{
 		"text_id": 2008200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2008200,
@@ -45557,7 +45557,7 @@
 	{
 		"text_id": 2634200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2634200,
@@ -45602,7 +45602,7 @@
 	{
 		"text_id": 2654200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2654200,
@@ -45652,7 +45652,7 @@
 	{
 		"text_id": 2674200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2674200,
@@ -46332,7 +46332,7 @@
 	{
 		"text_id": 2614200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2614200,
@@ -46497,7 +46497,7 @@
 	{
 		"text_id": 5866200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5866200,
@@ -47042,7 +47042,7 @@
 	{
 		"text_id": 3334200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3334200,
@@ -47087,7 +47087,7 @@
 	{
 		"text_id": 3354200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3354200,
@@ -47137,7 +47137,7 @@
 	{
 		"text_id": 3374200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3374200,
@@ -47187,7 +47187,7 @@
 	{
 		"text_id": 5766200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5766200,
@@ -47672,7 +47672,7 @@
 	{
 		"text_id": 3314200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 3314200,
@@ -48042,7 +48042,7 @@
 	{
 		"text_id": 2336200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2336200,
@@ -48087,7 +48087,7 @@
 	{
 		"text_id": 2356200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2356200,
@@ -48137,7 +48137,7 @@
 	{
 		"text_id": 2376200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2376200,
@@ -48187,7 +48187,7 @@
 	{
 		"text_id": 5824200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5824200,
@@ -48912,7 +48912,7 @@
 	{
 		"text_id": 2316200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2316200,
@@ -48962,7 +48962,7 @@
 	{
 		"text_id": 5774200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5774200,
@@ -49017,7 +49017,7 @@
 	{
 		"text_id": 5900200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5900200,
@@ -49577,7 +49577,7 @@
 	{
 		"text_id": 5856200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5856200,
@@ -49632,7 +49632,7 @@
 	{
 		"text_id": 5710200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5710200,
@@ -50537,7 +50537,7 @@
 	{
 		"text_id": 5724200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5724200,
@@ -50592,7 +50592,7 @@
 	{
 		"text_id": 5816200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5816200,
@@ -50647,7 +50647,7 @@
 	{
 		"text_id": 5870200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5870200,
@@ -51042,7 +51042,7 @@
 	{
 		"text_id": 5790200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5790200,
@@ -51097,7 +51097,7 @@
 	{
 		"text_id": 5884200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5884200,
@@ -51257,7 +51257,7 @@
 	{
 		"text_id": 2736200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2736200,
@@ -51302,7 +51302,7 @@
 	{
 		"text_id": 2756200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2756200,
@@ -51352,7 +51352,7 @@
 	{
 		"text_id": 2776200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2776200,
@@ -51402,7 +51402,7 @@
 	{
 		"text_id": 5748200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5748200,
@@ -51457,7 +51457,7 @@
 	{
 		"text_id": 5804200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5804200,
@@ -51992,7 +51992,7 @@
 	{
 		"text_id": 2716200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2716200,
@@ -52042,7 +52042,7 @@
 	{
 		"text_id": 5758200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5758200,
@@ -52097,7 +52097,7 @@
 	{
 		"text_id": 5834200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5834200,
@@ -52647,7 +52647,7 @@
 	{
 		"text_id": 2014200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2014200,
@@ -52702,7 +52702,7 @@
 	{
 		"text_id": 5704200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5704200,
@@ -52757,7 +52757,7 @@
 	{
 		"text_id": 5898200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5898200,
@@ -54432,7 +54432,7 @@
 	{
 		"text_id": 5786200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5786200,
@@ -54487,7 +54487,7 @@
 	{
 		"text_id": 5862200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5862200,
@@ -54822,7 +54822,7 @@
 	{
 		"text_id": 2526200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2526200,
@@ -54867,7 +54867,7 @@
 	{
 		"text_id": 2554200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2554200,
@@ -54917,7 +54917,7 @@
 	{
 		"text_id": 2566200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2566200,
@@ -55852,7 +55852,7 @@
 	{
 		"text_id": 5772200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5772200,
@@ -55907,7 +55907,7 @@
 	{
 		"text_id": 5836200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": "The chip has been released and\nits ability has been enhanced!"
+		"tr_text": "The chip has been released, and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5836200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -6402,7 +6402,7 @@
 	{
 		"text_id": 5001200,
 		"jp_text": "炎の法術\nフォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nFoie."
 	},
 	{
 		"text_id": 5001200,
@@ -6447,7 +6447,7 @@
 	{
 		"text_id": 5003200,
 		"jp_text": "炎の法術\nギ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nGifoie."
 	},
 	{
 		"text_id": 5003200,
@@ -6512,7 +6512,7 @@
 	{
 		"text_id": 5009200,
 		"jp_text": "炎の法術\nシフタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nShifta."
 	},
 	{
 		"text_id": 5009200,
@@ -6557,7 +6557,7 @@
 	{
 		"text_id": 5031200,
 		"jp_text": "炎の法術\nフォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nFoie."
 	},
 	{
 		"text_id": 5031200,
@@ -6622,7 +6622,7 @@
 	{
 		"text_id": 5039200,
 		"jp_text": "炎の法術\nシフタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nShifta."
 	},
 	{
 		"text_id": 5039200,
@@ -6667,7 +6667,7 @@
 	{
 		"text_id": 5061200,
 		"jp_text": "炎の法術\nフォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nFoie."
 	},
 	{
 		"text_id": 5061200,
@@ -6732,7 +6732,7 @@
 	{
 		"text_id": 5069200,
 		"jp_text": "炎の法術\nシフタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nShifta."
 	},
 	{
 		"text_id": 5069200,
@@ -6777,7 +6777,7 @@
 	{
 		"text_id": 5101200,
 		"jp_text": "氷の法術\nバータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nBarta."
 	},
 	{
 		"text_id": 5101200,
@@ -6822,7 +6822,7 @@
 	{
 		"text_id": 5103200,
 		"jp_text": "氷の法術\nギ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nGibarta."
 	},
 	{
 		"text_id": 5103200,
@@ -6887,7 +6887,7 @@
 	{
 		"text_id": 5109200,
 		"jp_text": "氷の法術\nデバンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nDeband."
 	},
 	{
 		"text_id": 5109200,
@@ -6932,7 +6932,7 @@
 	{
 		"text_id": 5131200,
 		"jp_text": "氷の法術\nバータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nBarta."
 	},
 	{
 		"text_id": 5131200,
@@ -6997,7 +6997,7 @@
 	{
 		"text_id": 5139200,
 		"jp_text": "氷の法術\nデバンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nDeband."
 	},
 	{
 		"text_id": 5139200,
@@ -7042,7 +7042,7 @@
 	{
 		"text_id": 5161200,
 		"jp_text": "氷の法術\nバータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nBarta."
 	},
 	{
 		"text_id": 5161200,
@@ -7107,7 +7107,7 @@
 	{
 		"text_id": 5169200,
 		"jp_text": "氷の法術\nデバンドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nDeband."
 	},
 	{
 		"text_id": 5169200,
@@ -7152,7 +7152,7 @@
 	{
 		"text_id": 5201200,
 		"jp_text": "雷の法術\nゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nZonde."
 	},
 	{
 		"text_id": 5201200,
@@ -7197,7 +7197,7 @@
 	{
 		"text_id": 5203200,
 		"jp_text": "雷の法術\nギ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nGizonde."
 	},
 	{
 		"text_id": 5203200,
@@ -7242,7 +7242,7 @@
 	{
 		"text_id": 5205200,
 		"jp_text": "雷の法術\nラ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nRazonde."
 	},
 	{
 		"text_id": 5205200,
@@ -7307,7 +7307,7 @@
 	{
 		"text_id": 5231200,
 		"jp_text": "雷の法術\nゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nZonde."
 	},
 	{
 		"text_id": 5231200,
@@ -7352,7 +7352,7 @@
 	{
 		"text_id": 5235200,
 		"jp_text": "雷の法術\nラ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nRazonde."
 	},
 	{
 		"text_id": 5235200,
@@ -7397,7 +7397,7 @@
 	{
 		"text_id": 5261200,
 		"jp_text": "雷の法術\nゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nZonde."
 	},
 	{
 		"text_id": 5261200,
@@ -7442,7 +7442,7 @@
 	{
 		"text_id": 5265200,
 		"jp_text": "雷の法術\nラ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nRazonde."
 	},
 	{
 		"text_id": 5265200,
@@ -7487,7 +7487,7 @@
 	{
 		"text_id": 5301200,
 		"jp_text": "風の法術\nザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nZan."
 	},
 	{
 		"text_id": 5301200,
@@ -7532,7 +7532,7 @@
 	{
 		"text_id": 5303200,
 		"jp_text": "風の法術\nギ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nGizan."
 	},
 	{
 		"text_id": 5303200,
@@ -7617,7 +7617,7 @@
 	{
 		"text_id": 5331200,
 		"jp_text": "風の法術\nザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nZan."
 	},
 	{
 		"text_id": 5331200,
@@ -7662,7 +7662,7 @@
 	{
 		"text_id": 5333200,
 		"jp_text": "風の法術\nギ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nGizan."
 	},
 	{
 		"text_id": 5333200,
@@ -7727,7 +7727,7 @@
 	{
 		"text_id": 5361200,
 		"jp_text": "風の法術\nザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nZan."
 	},
 	{
 		"text_id": 5361200,
@@ -7772,7 +7772,7 @@
 	{
 		"text_id": 5363200,
 		"jp_text": "風の法術\nギ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nGizan."
 	},
 	{
 		"text_id": 5363200,
@@ -7837,7 +7837,7 @@
 	{
 		"text_id": 5401200,
 		"jp_text": "光の法術\nグランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGrants."
 	},
 	{
 		"text_id": 5401200,
@@ -7882,7 +7882,7 @@
 	{
 		"text_id": 5407200,
 		"jp_text": "光の法術\nレスタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nResta."
 	},
 	{
 		"text_id": 5407200,
@@ -7927,7 +7927,7 @@
 	{
 		"text_id": 5409200,
 		"jp_text": "光の法術\nアンティのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nAnti."
 	},
 	{
 		"text_id": 5409200,
@@ -7972,7 +7972,7 @@
 	{
 		"text_id": 5431200,
 		"jp_text": "光の法術\nグランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGrants."
 	},
 	{
 		"text_id": 5431200,
@@ -8017,7 +8017,7 @@
 	{
 		"text_id": 5433200,
 		"jp_text": "光の法術\nギ・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGigrants."
 	},
 	{
 		"text_id": 5433200,
@@ -8062,7 +8062,7 @@
 	{
 		"text_id": 5437200,
 		"jp_text": "光の法術\nレスタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nResta."
 	},
 	{
 		"text_id": 5437200,
@@ -8107,7 +8107,7 @@
 	{
 		"text_id": 5461200,
 		"jp_text": "光の法術\nグランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGrants."
 	},
 	{
 		"text_id": 5461200,
@@ -8152,7 +8152,7 @@
 	{
 		"text_id": 5463200,
 		"jp_text": "光の法術\nギ・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGigrants."
 	},
 	{
 		"text_id": 5463200,
@@ -8197,7 +8197,7 @@
 	{
 		"text_id": 5467200,
 		"jp_text": "光の法術\nレスタのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nResta."
 	},
 	{
 		"text_id": 5467200,
@@ -8242,7 +8242,7 @@
 	{
 		"text_id": 5501200,
 		"jp_text": "闇の法術\nメギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nMegid."
 	},
 	{
 		"text_id": 5501200,
@@ -8327,7 +8327,7 @@
 	{
 		"text_id": 5531200,
 		"jp_text": "闇の法術\nメギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nMegid."
 	},
 	{
 		"text_id": 5531200,
@@ -8412,7 +8412,7 @@
 	{
 		"text_id": 5561200,
 		"jp_text": "闇の法術\nメギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nMegid."
 	},
 	{
 		"text_id": 5561200,
@@ -16612,7 +16612,7 @@
 	{
 		"text_id": 5393200,
 		"jp_text": "風の法術\nギ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nGizan."
 	},
 	{
 		"text_id": 5393200,
@@ -17962,7 +17962,7 @@
 	{
 		"text_id": 5233200,
 		"jp_text": "雷の法術\nギ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nGizonde."
 	},
 	{
 		"text_id": 5233200,
@@ -18007,7 +18007,7 @@
 	{
 		"text_id": 5263200,
 		"jp_text": "雷の法術\nギ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nGizonde."
 	},
 	{
 		"text_id": 5263200,
@@ -18052,7 +18052,7 @@
 	{
 		"text_id": 5293200,
 		"jp_text": "雷の法術\nギ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nGizonde."
 	},
 	{
 		"text_id": 5293200,
@@ -19257,7 +19257,7 @@
 	{
 		"text_id": 5133200,
 		"jp_text": "氷の法術\nギ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nGibarta."
 	},
 	{
 		"text_id": 5133200,
@@ -19302,7 +19302,7 @@
 	{
 		"text_id": 5163200,
 		"jp_text": "氷の法術\nギ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nGibarta."
 	},
 	{
 		"text_id": 5163200,
@@ -19347,7 +19347,7 @@
 	{
 		"text_id": 5193200,
 		"jp_text": "氷の法術\nギ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nGibarta."
 	},
 	{
 		"text_id": 5193200,
@@ -20352,7 +20352,7 @@
 	{
 		"text_id": 5033200,
 		"jp_text": "炎の法術\nギ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nGifoie."
 	},
 	{
 		"text_id": 5033200,
@@ -20397,7 +20397,7 @@
 	{
 		"text_id": 5063200,
 		"jp_text": "炎の法術\nギ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nGifoie."
 	},
 	{
 		"text_id": 5063200,
@@ -20442,7 +20442,7 @@
 	{
 		"text_id": 5093200,
 		"jp_text": "炎の法術\nギ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nGifoie."
 	},
 	{
 		"text_id": 5093200,
@@ -24212,7 +24212,7 @@
 	{
 		"text_id": 1197185,
 		"jp_text": "闇の法術\nギ・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nGimegid."
 	},
 	{
 		"text_id": 1197185,
@@ -24257,7 +24257,7 @@
 	{
 		"text_id": 1197189,
 		"jp_text": "闇の法術\nギ・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nGimegid."
 	},
 	{
 		"text_id": 1197189,
@@ -24302,7 +24302,7 @@
 	{
 		"text_id": 1197193,
 		"jp_text": "闇の法術\nギ・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nGimegid."
 	},
 	{
 		"text_id": 1197193,
@@ -26442,7 +26442,7 @@
 	{
 		"text_id": 5503200,
 		"jp_text": "闇の法術\nギ・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nGimegid."
 	},
 	{
 		"text_id": 5503200,
@@ -27862,7 +27862,7 @@
 	{
 		"text_id": 5493200,
 		"jp_text": "光属性の法術\nギ・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the 性 Technique,\nGigrants."
 	},
 	{
 		"text_id": 5493200,
@@ -30152,7 +30152,7 @@
 	{
 		"text_id": 5403200,
 		"jp_text": "光の法術\nギ・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Light Technique,\nGigrants."
 	},
 	{
 		"text_id": 5403200,
@@ -31457,7 +31457,7 @@
 	{
 		"text_id": 5035200,
 		"jp_text": "炎属性の法術\nナ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the 性 Technique,\nNafoie."
 	},
 	{
 		"text_id": 5035200,
@@ -31502,7 +31502,7 @@
 	{
 		"text_id": 5065200,
 		"jp_text": "炎属性の法術\nナ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the 性 Technique,\nNafoie."
 	},
 	{
 		"text_id": 5065200,
@@ -31547,7 +31547,7 @@
 	{
 		"text_id": 5095200,
 		"jp_text": "炎の法術\nナ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Fire Technique,\nNafoie."
 	},
 	{
 		"text_id": 5095200,
@@ -32137,7 +32137,7 @@
 	{
 		"text_id": 5005200,
 		"jp_text": "炎属性の法術\nナ・フォイエのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the 性 Technique,\nNafoie."
 	},
 	{
 		"text_id": 5005200,
@@ -32972,7 +32972,7 @@
 	{
 		"text_id": 5335200,
 		"jp_text": "風の法術\nサ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nSazan."
 	},
 	{
 		"text_id": 5335200,
@@ -33017,7 +33017,7 @@
 	{
 		"text_id": 5365200,
 		"jp_text": "風の法術\nサ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nSazan."
 	},
 	{
 		"text_id": 5365200,
@@ -33062,7 +33062,7 @@
 	{
 		"text_id": 5395200,
 		"jp_text": "風の法術\nサ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nSazan."
 	},
 	{
 		"text_id": 5395200,
@@ -33857,7 +33857,7 @@
 	{
 		"text_id": 5305200,
 		"jp_text": "風の法術\nサ・ザンのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Wind Technique,\nSazan."
 	},
 	{
 		"text_id": 5305200,
@@ -33902,7 +33902,7 @@
 	{
 		"text_id": 5237200,
 		"jp_text": "雷の法術\nナ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nNazonde."
 	},
 	{
 		"text_id": 5237200,
@@ -33947,7 +33947,7 @@
 	{
 		"text_id": 5267200,
 		"jp_text": "雷の法術\nナ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nNazonde."
 	},
 	{
 		"text_id": 5267200,
@@ -33992,7 +33992,7 @@
 	{
 		"text_id": 5297200,
 		"jp_text": "雷の法術\nナ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nNazonde."
 	},
 	{
 		"text_id": 5297200,
@@ -35082,7 +35082,7 @@
 	{
 		"text_id": 5207200,
 		"jp_text": "雷の法術\nナ・ゾンデのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Lightning Technique,\nNazonde."
 	},
 	{
 		"text_id": 5207200,
@@ -36262,7 +36262,7 @@
 	{
 		"text_id": 5135200,
 		"jp_text": "氷の法術\nナ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nNabarta."
 	},
 	{
 		"text_id": 5135200,
@@ -36307,7 +36307,7 @@
 	{
 		"text_id": 5165200,
 		"jp_text": "氷の法術\nナ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nNabarta."
 	},
 	{
 		"text_id": 5165200,
@@ -36352,7 +36352,7 @@
 	{
 		"text_id": 5195200,
 		"jp_text": "氷の法術\nナ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Ice Technique,\nNabarta."
 	},
 	{
 		"text_id": 5195200,
@@ -38652,7 +38652,7 @@
 	{
 		"text_id": 5105200,
 		"jp_text": "<%ele>の法術\nナ・バータのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nNabarta."
 	},
 	{
 		"text_id": 5105200,
@@ -38697,7 +38697,7 @@
 	{
 		"text_id": 5535200,
 		"jp_text": "<%ele>の法術\nイル・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlmegid."
 	},
 	{
 		"text_id": 5535200,
@@ -38742,7 +38742,7 @@
 	{
 		"text_id": 5565200,
 		"jp_text": "<%ele>の法術\nイル・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlmegid."
 	},
 	{
 		"text_id": 5565200,
@@ -38787,7 +38787,7 @@
 	{
 		"text_id": 5595200,
 		"jp_text": "<%ele>の法術\nイル・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlmegid."
 	},
 	{
 		"text_id": 5595200,
@@ -39597,7 +39597,7 @@
 	{
 		"text_id": 5505200,
 		"jp_text": "闇の法術\nイル・メギドのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the Dark Technique,\nIlmegid."
 	},
 	{
 		"text_id": 5505200,
@@ -40757,7 +40757,7 @@
 	{
 		"text_id": 5435200,
 		"jp_text": "<%ele>の法術\nイル・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlgrants."
 	},
 	{
 		"text_id": 5435200,
@@ -40802,7 +40802,7 @@
 	{
 		"text_id": 5465200,
 		"jp_text": "<%ele>の法術\nイル・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlgrants."
 	},
 	{
 		"text_id": 5465200,
@@ -40847,7 +40847,7 @@
 	{
 		"text_id": 5495200,
 		"jp_text": "<%ele>の法術\nイル・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlgrants."
 	},
 	{
 		"text_id": 5495200,
@@ -41447,7 +41447,7 @@
 	{
 		"text_id": 5405200,
 		"jp_text": "<%ele>の法術\nイル・グランツのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of the <%ele> Technique,\nIlgrants."
 	},
 	{
 		"text_id": 5405200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -51912,7 +51912,7 @@
 	{
 		"text_id": 8233200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8233200,
@@ -52172,7 +52172,7 @@
 	{
 		"text_id": 8235200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8235200,
@@ -52287,7 +52287,7 @@
 	{
 		"text_id": 8239200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8239200,
@@ -52347,7 +52347,7 @@
 	{
 		"text_id": 8241200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8241200,
@@ -52447,7 +52447,7 @@
 	{
 		"text_id": 8244200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8244200,
@@ -52507,7 +52507,7 @@
 	{
 		"text_id": 8246200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8246200,
@@ -52562,7 +52562,7 @@
 	{
 		"text_id": 8248200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8248200,
@@ -52782,7 +52782,7 @@
 	{
 		"text_id": 8250200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8250200,
@@ -52842,7 +52842,7 @@
 	{
 		"text_id": 8252200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8252200,
@@ -52902,7 +52902,7 @@
 	{
 		"text_id": 8254200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8254200,
@@ -52997,7 +52997,7 @@
 	{
 		"text_id": 8257200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8257200,
@@ -53057,7 +53057,7 @@
 	{
 		"text_id": 8259200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8259200,
@@ -53112,7 +53112,7 @@
 	{
 		"text_id": 8261200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8261200,
@@ -53457,17 +53457,17 @@
 	{
 		"text_id": 8273000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8273000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8273200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8273200,
@@ -53512,17 +53512,17 @@
 	{
 		"text_id": 8275000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8275000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8275200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8275200,
@@ -53572,17 +53572,17 @@
 	{
 		"text_id": 8277000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8277000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8277200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8277200,
@@ -53627,17 +53627,17 @@
 	{
 		"text_id": 8279000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8279000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8279200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8279200,
@@ -53682,17 +53682,17 @@
 	{
 		"text_id": 8283000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8283000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8283200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8283200,
@@ -53742,17 +53742,17 @@
 	{
 		"text_id": 8285000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8285000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8285200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8285200,
@@ -53837,17 +53837,17 @@
 	{
 		"text_id": 8288000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8288000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8288200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8288200,
@@ -54007,17 +54007,17 @@
 	{
 		"text_id": 8296000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8296000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8296200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8296200,
@@ -54127,17 +54127,17 @@
 	{
 		"text_id": 8300000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8300000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8300200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8300200,
@@ -54182,17 +54182,17 @@
 	{
 		"text_id": 8302000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8302000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8302200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8302200,
@@ -54237,17 +54237,17 @@
 	{
 		"text_id": 8304000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8304000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8304200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8304200,
@@ -54332,17 +54332,17 @@
 	{
 		"text_id": 8307000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8307000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8307200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8307200,
@@ -54502,17 +54502,17 @@
 	{
 		"text_id": 8309000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8309000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8309200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8309200,
@@ -54557,17 +54557,17 @@
 	{
 		"text_id": 8311000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8311000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8311200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8311200,
@@ -54617,17 +54617,17 @@
 	{
 		"text_id": 8313000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8313000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8313200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8313200,
@@ -54677,17 +54677,17 @@
 	{
 		"text_id": 8315000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8315000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8315200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8315200,
@@ -55027,17 +55027,17 @@
 	{
 		"text_id": 8317000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8317000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8317200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8317200,
@@ -55122,17 +55122,17 @@
 	{
 		"text_id": 8320000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8320000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8320200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8320200,
@@ -55182,17 +55182,17 @@
 	{
 		"text_id": 8322000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8322000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8322200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8322200,
@@ -55237,17 +55237,17 @@
 	{
 		"text_id": 8324000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8324000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8324200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8324200,
@@ -55292,17 +55292,17 @@
 	{
 		"text_id": 8326000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8326000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8326200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8326200,
@@ -55352,17 +55352,17 @@
 	{
 		"text_id": 8328000,
 		"jp_text": "チップの新技術により生まれた\n「ウェポノイドチップ」の\nひとつのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be one of the\nnext-generation \"Weaponoid\" chips."
 	},
 	{
 		"text_id": 8328000,
 		"jp_text": "通常のチップよりも\n強力な効果だと聞きますが\n一体どんなチップなんでしょう？",
-		"tr_text": ""
+		"tr_text": "I've heard that they have stronger\neffects than other chips.\nWhat kind of chip could it be?"
 	},
 	{
 		"text_id": 8328200,
 		"jp_text": "こちらは\nチップの新技術によって生まれた\n新世代のチップ「ウェポノイドチップ」\nのひとつです。",
-		"tr_text": ""
+		"tr_text": "This is one of the next-generation\n\"Weaponoid\" chips created from the\nlatest advances in chip technology."
 	},
 	{
 		"text_id": 8328200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -53197,12 +53197,12 @@
 	{
 		"text_id": 8270000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8270000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8270200,
@@ -53252,12 +53252,12 @@
 	{
 		"text_id": 8266000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8266000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8266200,
@@ -53312,12 +53312,12 @@
 	{
 		"text_id": 8264000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8264000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8264200,
@@ -53372,12 +53372,12 @@
 	{
 		"text_id": 8268000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8268000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8268200,
@@ -53432,12 +53432,12 @@
 	{
 		"text_id": 8272000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8272000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8272200,
@@ -53487,12 +53487,12 @@
 	{
 		"text_id": 8274000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8274000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8274200,
@@ -53547,12 +53547,12 @@
 	{
 		"text_id": 8276000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8276000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8276200,
@@ -53602,12 +53602,12 @@
 	{
 		"text_id": 8278000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8278000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8278200,
@@ -53657,12 +53657,12 @@
 	{
 		"text_id": 8280000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8280000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8280200,
@@ -53717,12 +53717,12 @@
 	{
 		"text_id": 8284000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8284000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8284200,
@@ -53782,12 +53782,12 @@
 	{
 		"text_id": 8286000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8286000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8286200,
@@ -53872,12 +53872,12 @@
 	{
 		"text_id": 8289000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8289000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8289200,
@@ -53927,12 +53927,12 @@
 	{
 		"text_id": 8291000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8291000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8291200,
@@ -53982,12 +53982,12 @@
 	{
 		"text_id": 8295000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8295000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8295200,
@@ -54042,12 +54042,12 @@
 	{
 		"text_id": 8297000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8297000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8297200,
@@ -54102,12 +54102,12 @@
 	{
 		"text_id": 8299000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8299000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8299200,
@@ -54157,12 +54157,12 @@
 	{
 		"text_id": 8301000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8301000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8301200,
@@ -54212,12 +54212,12 @@
 	{
 		"text_id": 8303000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8303000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8303200,
@@ -54277,12 +54277,12 @@
 	{
 		"text_id": 8305000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8305000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8305200,
@@ -54367,12 +54367,12 @@
 	{
 		"text_id": 8308000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8308000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8308200,
@@ -54422,12 +54422,12 @@
 	{
 		"text_id": 5786000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 5786000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 5786200,
@@ -54477,12 +54477,12 @@
 	{
 		"text_id": 5862000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 5862000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 5862200,
@@ -54532,12 +54532,12 @@
 	{
 		"text_id": 8310000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8310000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8310200,
@@ -54592,12 +54592,12 @@
 	{
 		"text_id": 8312000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8312000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8312200,
@@ -54652,12 +54652,12 @@
 	{
 		"text_id": 8314000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8314000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8314200,
@@ -54707,12 +54707,12 @@
 	{
 		"text_id": 8316000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8316000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8316200,
@@ -54762,12 +54762,12 @@
 	{
 		"text_id": 8343000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8343000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8343200,
@@ -54812,12 +54812,12 @@
 	{
 		"text_id": 2526000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 2526000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 2526200,
@@ -54857,12 +54857,12 @@
 	{
 		"text_id": 2554000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 2554000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 2554200,
@@ -54907,12 +54907,12 @@
 	{
 		"text_id": 2566000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 2566000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 2566200,
@@ -54952,12 +54952,12 @@
 	{
 		"text_id": 7702000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 7702000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 7702200,
@@ -55002,12 +55002,12 @@
 	{
 		"text_id": 8293000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8293000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8293200,
@@ -55067,12 +55067,12 @@
 	{
 		"text_id": 8318000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8318000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8318200,
@@ -55157,12 +55157,12 @@
 	{
 		"text_id": 8321000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8321000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8321200,
@@ -55212,12 +55212,12 @@
 	{
 		"text_id": 8323000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8323000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8323200,
@@ -55267,12 +55267,12 @@
 	{
 		"text_id": 8325000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8325000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8325200,
@@ -55327,12 +55327,12 @@
 	{
 		"text_id": 8327000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8327000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8327200,
@@ -55382,12 +55382,12 @@
 	{
 		"text_id": 8329000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8329000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8329200,
@@ -55442,12 +55442,12 @@
 	{
 		"text_id": 8331000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8331000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8331200,
@@ -55497,12 +55497,12 @@
 	{
 		"text_id": 8333000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8333000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8333200,
@@ -55557,12 +55557,12 @@
 	{
 		"text_id": 8335000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8335000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8335200,
@@ -55617,12 +55617,12 @@
 	{
 		"text_id": 8337000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8337000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8337200,
@@ -55677,12 +55677,12 @@
 	{
 		"text_id": 8339000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8339000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8339200,
@@ -55737,12 +55737,12 @@
 	{
 		"text_id": 8341000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 8341000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 8341200,
@@ -55842,12 +55842,12 @@
 	{
 		"text_id": 5772000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 5772000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 5772200,
@@ -55897,12 +55897,12 @@
 	{
 		"text_id": 5836000,
 		"jp_text": "解放には\nこのようなチップが必要です。",
-		"tr_text": ""
+		"tr_text": "To release this chip, you will\nneed these material chips."
 	},
 	{
 		"text_id": 5836000,
 		"jp_text": "素材チップは\n日替わりクエストなどで\n手に入りますよ！\nぜひ解放してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Material chips can be acquired from\nDaily Quests. Please gather materials\nand release this chip!"
 	},
 	{
 		"text_id": 5836200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -19492,7 +19492,7 @@
 	{
 		"text_id": 1883000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1883000,
@@ -19547,7 +19547,7 @@
 	{
 		"text_id": 1889000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1889000,
@@ -19602,7 +19602,7 @@
 	{
 		"text_id": 1907000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1907000,
@@ -19657,7 +19657,7 @@
 	{
 		"text_id": 1911000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1911000,
@@ -22327,7 +22327,7 @@
 	{
 		"text_id": 1197032,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197032,
@@ -22377,7 +22377,7 @@
 	{
 		"text_id": 1197036,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197036,
@@ -22427,7 +22427,7 @@
 	{
 		"text_id": 1197040,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197040,
@@ -22477,7 +22477,7 @@
 	{
 		"text_id": 1197044,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197044,
@@ -24342,7 +24342,7 @@
 	{
 		"text_id": 1197196,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197196,
@@ -24397,7 +24397,7 @@
 	{
 		"text_id": 1197200,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1197200,
@@ -26477,7 +26477,7 @@
 	{
 		"text_id": 1891000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1891000,
@@ -26532,7 +26532,7 @@
 	{
 		"text_id": 1899000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1899000,
@@ -28012,7 +28012,7 @@
 	{
 		"text_id": 1895000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1895000,
@@ -28067,7 +28067,7 @@
 	{
 		"text_id": 1909000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1909000,
@@ -29832,7 +29832,7 @@
 	{
 		"text_id": 1887000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1887000,
@@ -29887,7 +29887,7 @@
 	{
 		"text_id": 1913000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1913000,
@@ -30977,7 +30977,7 @@
 	{
 		"text_id": 1885000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 1885000,
@@ -46462,7 +46462,7 @@
 	{
 		"text_id": 5865000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5865200,
@@ -47152,7 +47152,7 @@
 	{
 		"text_id": 5765000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5765200,
@@ -48152,7 +48152,7 @@
 	{
 		"text_id": 5823000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5823200,
@@ -48927,7 +48927,7 @@
 	{
 		"text_id": 5773000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5773200,
@@ -48982,7 +48982,7 @@
 	{
 		"text_id": 5899000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5899200,
@@ -49542,7 +49542,7 @@
 	{
 		"text_id": 5855000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5855200,
@@ -49597,7 +49597,7 @@
 	{
 		"text_id": 5709000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5709200,
@@ -50502,7 +50502,7 @@
 	{
 		"text_id": 5723000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5723200,
@@ -50557,7 +50557,7 @@
 	{
 		"text_id": 5815000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5815200,
@@ -50612,7 +50612,7 @@
 	{
 		"text_id": 5869000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5869200,
@@ -51002,12 +51002,12 @@
 	{
 		"text_id": 5789000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5789000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5789200,
@@ -51057,12 +51057,12 @@
 	{
 		"text_id": 5883000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5883000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5883200,
@@ -51362,12 +51362,12 @@
 	{
 		"text_id": 5747000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5747000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5747200,
@@ -51417,12 +51417,12 @@
 	{
 		"text_id": 5803000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": "This seems to be a chip for\nstrengthening a certain kind\nof weapon."
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5803000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5803200,
@@ -52002,12 +52002,12 @@
 	{
 		"text_id": 5757000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5757000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5757200,
@@ -52057,12 +52057,12 @@
 	{
 		"text_id": 5833000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5833000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5833200,
@@ -52662,12 +52662,12 @@
 	{
 		"text_id": 5703000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5703000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5703200,
@@ -52717,12 +52717,12 @@
 	{
 		"text_id": 5897000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5897000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5897200,
@@ -54392,12 +54392,12 @@
 	{
 		"text_id": 5785000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5785000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5785200,
@@ -54447,12 +54447,12 @@
 	{
 		"text_id": 5861000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5861000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5861200,
@@ -55817,7 +55817,7 @@
 	{
 		"text_id": 5771000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5771200,
@@ -55867,12 +55867,12 @@
 	{
 		"text_id": 5835000,
 		"jp_text": "特定の武器を強化する効果を持つ\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a chip whose\nability strengthens certain weapons."
 	},
 	{
 		"text_id": 5835000,
 		"jp_text": "よく使う武器と\n組み合わせることができれば\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": ""
+		"tr_text": "It could be very effective if\nyou pair it with a weapon\ntype that you use often!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 5835200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -4042,7 +4042,7 @@
 	{
 		"text_id": 2101000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2101000,
@@ -4087,7 +4087,7 @@
 	{
 		"text_id": 2103000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2103000,
@@ -4132,7 +4132,7 @@
 	{
 		"text_id": 2121000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2121000,
@@ -4177,7 +4177,7 @@
 	{
 		"text_id": 2123000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2123000,
@@ -4222,7 +4222,7 @@
 	{
 		"text_id": 2141000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2141000,
@@ -4267,7 +4267,7 @@
 	{
 		"text_id": 2143000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2143000,
@@ -4312,7 +4312,7 @@
 	{
 		"text_id": 2201000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2201000,
@@ -4357,7 +4357,7 @@
 	{
 		"text_id": 2221000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2221000,
@@ -4402,7 +4402,7 @@
 	{
 		"text_id": 2241000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2241000,
@@ -4447,7 +4447,7 @@
 	{
 		"text_id": 2301000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2301000,
@@ -4492,7 +4492,7 @@
 	{
 		"text_id": 2321000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2321000,
@@ -4537,7 +4537,7 @@
 	{
 		"text_id": 2341000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2341000,
@@ -4582,7 +4582,7 @@
 	{
 		"text_id": 2401000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2401000,
@@ -4627,7 +4627,7 @@
 	{
 		"text_id": 2421000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2421000,
@@ -4672,7 +4672,7 @@
 	{
 		"text_id": 2441000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2441000,
@@ -4717,7 +4717,7 @@
 	{
 		"text_id": 2501000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2501000,
@@ -4762,7 +4762,7 @@
 	{
 		"text_id": 2521000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2521000,
@@ -4807,7 +4807,7 @@
 	{
 		"text_id": 2541000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2541000,
@@ -4852,7 +4852,7 @@
 	{
 		"text_id": 2601000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2601000,
@@ -4897,7 +4897,7 @@
 	{
 		"text_id": 2621000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2621000,
@@ -4942,7 +4942,7 @@
 	{
 		"text_id": 2641000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2641000,
@@ -4987,7 +4987,7 @@
 	{
 		"text_id": 2701000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2701000,
@@ -5037,7 +5037,7 @@
 	{
 		"text_id": 2721000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2721000,
@@ -5082,7 +5082,7 @@
 	{
 		"text_id": 2741000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2741000,
@@ -5127,7 +5127,7 @@
 	{
 		"text_id": 2801000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2801000,
@@ -5172,7 +5172,7 @@
 	{
 		"text_id": 2803000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2803000,
@@ -5217,7 +5217,7 @@
 	{
 		"text_id": 2821000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2821000,
@@ -5262,7 +5262,7 @@
 	{
 		"text_id": 2823000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2823000,
@@ -5307,7 +5307,7 @@
 	{
 		"text_id": 2841000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2841000,
@@ -5352,7 +5352,7 @@
 	{
 		"text_id": 2843000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2843000,
@@ -5397,7 +5397,7 @@
 	{
 		"text_id": 2901000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2901000,
@@ -5442,7 +5442,7 @@
 	{
 		"text_id": 2921000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2921000,
@@ -5487,7 +5487,7 @@
 	{
 		"text_id": 2941000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2941000,
@@ -5532,7 +5532,7 @@
 	{
 		"text_id": 3001000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3001000,
@@ -5577,7 +5577,7 @@
 	{
 		"text_id": 3021000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3021000,
@@ -5622,7 +5622,7 @@
 	{
 		"text_id": 3041000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3041000,
@@ -5667,7 +5667,7 @@
 	{
 		"text_id": 3101000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3101000,
@@ -5712,7 +5712,7 @@
 	{
 		"text_id": 3121000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3121000,
@@ -5757,7 +5757,7 @@
 	{
 		"text_id": 3141000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3141000,
@@ -5802,7 +5802,7 @@
 	{
 		"text_id": 3201000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3201000,
@@ -5847,7 +5847,7 @@
 	{
 		"text_id": 3221000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3221000,
@@ -5892,7 +5892,7 @@
 	{
 		"text_id": 3241000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3241000,
@@ -5937,7 +5937,7 @@
 	{
 		"text_id": 3301000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3301000,
@@ -5982,7 +5982,7 @@
 	{
 		"text_id": 3321000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3321000,
@@ -6027,7 +6027,7 @@
 	{
 		"text_id": 3341000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3341000,
@@ -6072,7 +6072,7 @@
 	{
 		"text_id": 3401000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3401000,
@@ -6117,7 +6117,7 @@
 	{
 		"text_id": 3421000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3421000,
@@ -6162,7 +6162,7 @@
 	{
 		"text_id": 3441000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3441000,
@@ -6227,7 +6227,7 @@
 	{
 		"text_id": 4903000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 4903000,
@@ -16322,7 +16322,7 @@
 	{
 		"text_id": 2323000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2323000,
@@ -16367,7 +16367,7 @@
 	{
 		"text_id": 2343000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2343000,
@@ -16412,7 +16412,7 @@
 	{
 		"text_id": 2363000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2363000,
@@ -16462,7 +16462,7 @@
 	{
 		"text_id": 2923000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2923000,
@@ -16507,7 +16507,7 @@
 	{
 		"text_id": 2943000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2943000,
@@ -16552,7 +16552,7 @@
 	{
 		"text_id": 2963000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2963000,
@@ -17582,7 +17582,7 @@
 	{
 		"text_id": 2223000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2223000,
@@ -17627,7 +17627,7 @@
 	{
 		"text_id": 2243000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2243000,
@@ -17672,7 +17672,7 @@
 	{
 		"text_id": 2263000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2263000,
@@ -17722,7 +17722,7 @@
 	{
 		"text_id": 2303000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2303000,
@@ -17767,7 +17767,7 @@
 	{
 		"text_id": 2903000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2903000,
@@ -17812,7 +17812,7 @@
 	{
 		"text_id": 3223000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3223000,
@@ -17857,7 +17857,7 @@
 	{
 		"text_id": 3243000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3243000,
@@ -17902,7 +17902,7 @@
 	{
 		"text_id": 3263000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3263000,
@@ -18877,7 +18877,7 @@
 	{
 		"text_id": 2203000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2203000,
@@ -18922,7 +18922,7 @@
 	{
 		"text_id": 2523000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2523000,
@@ -18967,7 +18967,7 @@
 	{
 		"text_id": 2543000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2543000,
@@ -19012,7 +19012,7 @@
 	{
 		"text_id": 2563000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2563000,
@@ -19062,7 +19062,7 @@
 	{
 		"text_id": 2723000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2723000,
@@ -19107,7 +19107,7 @@
 	{
 		"text_id": 2743000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2743000,
@@ -19152,7 +19152,7 @@
 	{
 		"text_id": 2763000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2763000,
@@ -19202,7 +19202,7 @@
 	{
 		"text_id": 3203000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3203000,
@@ -19712,7 +19712,7 @@
 	{
 		"text_id": 2145000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2145000,
@@ -19757,7 +19757,7 @@
 	{
 		"text_id": 2245000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2245000,
@@ -19802,7 +19802,7 @@
 	{
 		"text_id": 2345000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2345000,
@@ -19847,7 +19847,7 @@
 	{
 		"text_id": 2445000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2445000,
@@ -19892,7 +19892,7 @@
 	{
 		"text_id": 2503000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2503000,
@@ -19937,7 +19937,7 @@
 	{
 		"text_id": 2645000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2645000,
@@ -19982,7 +19982,7 @@
 	{
 		"text_id": 2703000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2703000,
@@ -20027,7 +20027,7 @@
 	{
 		"text_id": 2745000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2745000,
@@ -20072,7 +20072,7 @@
 	{
 		"text_id": 2845000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2845000,
@@ -20117,7 +20117,7 @@
 	{
 		"text_id": 2945000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2945000,
@@ -20162,7 +20162,7 @@
 	{
 		"text_id": 3045000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3045000,
@@ -20207,7 +20207,7 @@
 	{
 		"text_id": 3145000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3145000,
@@ -20252,7 +20252,7 @@
 	{
 		"text_id": 3245000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3245000,
@@ -20297,7 +20297,7 @@
 	{
 		"text_id": 3445000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3445000,
@@ -20482,7 +20482,7 @@
 	{
 		"text_id": 2423000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2423000,
@@ -20527,7 +20527,7 @@
 	{
 		"text_id": 2443000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2443000,
@@ -20572,7 +20572,7 @@
 	{
 		"text_id": 2463000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2463000,
@@ -20622,7 +20622,7 @@
 	{
 		"text_id": 3323000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3323000,
@@ -20667,7 +20667,7 @@
 	{
 		"text_id": 3343000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3343000,
@@ -20712,7 +20712,7 @@
 	{
 		"text_id": 3363000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3363000,
@@ -22527,7 +22527,7 @@
 	{
 		"text_id": 1197048,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197048,
@@ -22572,7 +22572,7 @@
 	{
 		"text_id": 1197052,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197052,
@@ -22617,7 +22617,7 @@
 	{
 		"text_id": 1197056,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197056,
@@ -22662,7 +22662,7 @@
 	{
 		"text_id": 1197060,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197060,
@@ -22712,7 +22712,7 @@
 	{
 		"text_id": 1197064,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197064,
@@ -22757,7 +22757,7 @@
 	{
 		"text_id": 1197068,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197068,
@@ -22802,7 +22802,7 @@
 	{
 		"text_id": 1197072,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197072,
@@ -22847,7 +22847,7 @@
 	{
 		"text_id": 1197076,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197076,
@@ -22892,7 +22892,7 @@
 	{
 		"text_id": 1197080,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197080,
@@ -22937,7 +22937,7 @@
 	{
 		"text_id": 1197084,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197084,
@@ -22982,7 +22982,7 @@
 	{
 		"text_id": 1197088,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197088,
@@ -23027,7 +23027,7 @@
 	{
 		"text_id": 1197092,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197092,
@@ -23072,7 +23072,7 @@
 	{
 		"text_id": 1197096,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197096,
@@ -23117,7 +23117,7 @@
 	{
 		"text_id": 1197100,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197100,
@@ -23162,7 +23162,7 @@
 	{
 		"text_id": 1197104,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197104,
@@ -23207,7 +23207,7 @@
 	{
 		"text_id": 1197108,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197108,
@@ -23257,7 +23257,7 @@
 	{
 		"text_id": 1197112,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197112,
@@ -23302,7 +23302,7 @@
 	{
 		"text_id": 1197116,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197116,
@@ -23347,7 +23347,7 @@
 	{
 		"text_id": 1197120,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197120,
@@ -23392,7 +23392,7 @@
 	{
 		"text_id": 1197124,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197124,
@@ -23972,7 +23972,7 @@
 	{
 		"text_id": 1197164,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197164,
@@ -24017,7 +24017,7 @@
 	{
 		"text_id": 1197168,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197168,
@@ -24062,7 +24062,7 @@
 	{
 		"text_id": 1197172,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197172,
@@ -24107,7 +24107,7 @@
 	{
 		"text_id": 1197176,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197176,
@@ -24157,7 +24157,7 @@
 	{
 		"text_id": 1197180,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197180,
@@ -24612,7 +24612,7 @@
 	{
 		"text_id": 1197216,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197216,
@@ -24657,7 +24657,7 @@
 	{
 		"text_id": 1197220,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197220,
@@ -24702,7 +24702,7 @@
 	{
 		"text_id": 1197224,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197224,
@@ -24747,7 +24747,7 @@
 	{
 		"text_id": 1197228,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197228,
@@ -24792,7 +24792,7 @@
 	{
 		"text_id": 1197232,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197232,
@@ -24837,7 +24837,7 @@
 	{
 		"text_id": 1197235,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197235,
@@ -24882,7 +24882,7 @@
 	{
 		"text_id": 1197239,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197239,
@@ -24927,7 +24927,7 @@
 	{
 		"text_id": 1197243,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197243,
@@ -24972,7 +24972,7 @@
 	{
 		"text_id": 1197247,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197247,
@@ -25017,7 +25017,7 @@
 	{
 		"text_id": 1197251,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 1197251,
@@ -26247,7 +26247,7 @@
 	{
 		"text_id": 3023000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3023000,
@@ -26292,7 +26292,7 @@
 	{
 		"text_id": 3043000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3043000,
@@ -26337,7 +26337,7 @@
 	{
 		"text_id": 3063000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3063000,
@@ -26387,7 +26387,7 @@
 	{
 		"text_id": 2603000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2603000,
@@ -26642,7 +26642,7 @@
 	{
 		"text_id": 2151000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2151000,
@@ -26687,7 +26687,7 @@
 	{
 		"text_id": 2249000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2249000,
@@ -26732,7 +26732,7 @@
 	{
 		"text_id": 2351000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2351000,
@@ -26777,7 +26777,7 @@
 	{
 		"text_id": 2449000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2449000,
@@ -26822,7 +26822,7 @@
 	{
 		"text_id": 2549000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2549000,
@@ -26867,7 +26867,7 @@
 	{
 		"text_id": 2651000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2651000,
@@ -26912,7 +26912,7 @@
 	{
 		"text_id": 2751000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2751000,
@@ -26957,7 +26957,7 @@
 	{
 		"text_id": 2849000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2849000,
@@ -27002,7 +27002,7 @@
 	{
 		"text_id": 2949000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2949000,
@@ -27047,7 +27047,7 @@
 	{
 		"text_id": 3149000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3149000,
@@ -27092,7 +27092,7 @@
 	{
 		"text_id": 3451000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3451000,
@@ -27137,7 +27137,7 @@
 	{
 		"text_id": 3349000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3349000,
@@ -27572,7 +27572,7 @@
 	{
 		"text_id": 2833000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2833000,
@@ -27617,7 +27617,7 @@
 	{
 		"text_id": 2853000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2853000,
@@ -27662,7 +27662,7 @@
 	{
 		"text_id": 2873000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2873000,
@@ -27712,7 +27712,7 @@
 	{
 		"text_id": 3423000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3423000,
@@ -27757,7 +27757,7 @@
 	{
 		"text_id": 3443000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3443000,
@@ -27802,7 +27802,7 @@
 	{
 		"text_id": 3463000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3463000,
@@ -28122,7 +28122,7 @@
 	{
 		"text_id": 2153000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2153000,
@@ -28167,7 +28167,7 @@
 	{
 		"text_id": 2251000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2251000,
@@ -28212,7 +28212,7 @@
 	{
 		"text_id": 2353000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2353000,
@@ -28257,7 +28257,7 @@
 	{
 		"text_id": 2451000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2451000,
@@ -28302,7 +28302,7 @@
 	{
 		"text_id": 2551000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2551000,
@@ -28347,7 +28347,7 @@
 	{
 		"text_id": 2753000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2753000,
@@ -28392,7 +28392,7 @@
 	{
 		"text_id": 2951000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2951000,
@@ -28437,7 +28437,7 @@
 	{
 		"text_id": 3003000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3003000,
@@ -28482,7 +28482,7 @@
 	{
 		"text_id": 3051000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3051000,
@@ -28527,7 +28527,7 @@
 	{
 		"text_id": 3151000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3151000,
@@ -28572,7 +28572,7 @@
 	{
 		"text_id": 3251000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3251000,
@@ -28617,7 +28617,7 @@
 	{
 		"text_id": 3351000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3351000,
@@ -28662,7 +28662,7 @@
 	{
 		"text_id": 3453000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3453000,
@@ -28707,7 +28707,7 @@
 	{
 		"text_id": 2851000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2851000,
@@ -30052,7 +30052,7 @@
 	{
 		"text_id": 2813000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2813000,
@@ -30097,7 +30097,7 @@
 	{
 		"text_id": 3403000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3403000,
@@ -31307,7 +31307,7 @@
 	{
 		"text_id": 2235000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2235000,
@@ -31352,7 +31352,7 @@
 	{
 		"text_id": 2255000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2255000,
@@ -31397,7 +31397,7 @@
 	{
 		"text_id": 2275000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2275000,
@@ -32082,7 +32082,7 @@
 	{
 		"text_id": 2215000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2215000,
@@ -32172,7 +32172,7 @@
 	{
 		"text_id": 3233000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3233000,
@@ -32217,7 +32217,7 @@
 	{
 		"text_id": 3253000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3253000,
@@ -32262,7 +32262,7 @@
 	{
 		"text_id": 3273000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3273000,
@@ -32917,7 +32917,7 @@
 	{
 		"text_id": 3213000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3213000,
@@ -34932,7 +34932,7 @@
 	{
 		"text_id": 3133000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3133000,
@@ -34977,7 +34977,7 @@
 	{
 		"text_id": 3153000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3153000,
@@ -35022,7 +35022,7 @@
 	{
 		"text_id": 3173000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3173000,
@@ -35337,7 +35337,7 @@
 	{
 		"text_id": 2933000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2933000,
@@ -35382,7 +35382,7 @@
 	{
 		"text_id": 2953000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2953000,
@@ -35427,7 +35427,7 @@
 	{
 		"text_id": 2973000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2973000,
@@ -35477,7 +35477,7 @@
 	{
 		"text_id": 3113000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3113000,
@@ -36392,7 +36392,7 @@
 	{
 		"text_id": 2913000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2913000,
@@ -38502,7 +38502,7 @@
 	{
 		"text_id": 2433000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2433000,
@@ -38547,7 +38547,7 @@
 	{
 		"text_id": 2453000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2453000,
@@ -38592,7 +38592,7 @@
 	{
 		"text_id": 2473000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2473000,
@@ -39542,7 +39542,7 @@
 	{
 		"text_id": 2413000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2413000,
@@ -41792,7 +41792,7 @@
 	{
 		"text_id": 3033000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3033000,
@@ -41837,7 +41837,7 @@
 	{
 		"text_id": 3053000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3053000,
@@ -41882,7 +41882,7 @@
 	{
 		"text_id": 3073000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3073000,
@@ -43122,7 +43122,7 @@
 	{
 		"text_id": 3013000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3013000,
@@ -43167,7 +43167,7 @@
 	{
 		"text_id": 2135000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2135000,
@@ -43212,7 +43212,7 @@
 	{
 		"text_id": 2155000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2155000,
@@ -43257,7 +43257,7 @@
 	{
 		"text_id": 2175000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2175000,
@@ -43837,7 +43837,7 @@
 	{
 		"text_id": 2115000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2115000,
@@ -44562,7 +44562,7 @@
 	{
 		"text_id": 3435000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3435000,
@@ -44607,7 +44607,7 @@
 	{
 		"text_id": 3455000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3455000,
@@ -44652,7 +44652,7 @@
 	{
 		"text_id": 3475000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3475000,
@@ -45032,7 +45032,7 @@
 	{
 		"text_id": 3415000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3415000,
@@ -45522,7 +45522,7 @@
 	{
 		"text_id": 2633000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2633000,
@@ -45567,7 +45567,7 @@
 	{
 		"text_id": 2653000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2653000,
@@ -45612,7 +45612,7 @@
 	{
 		"text_id": 2673000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2673000,
@@ -46297,7 +46297,7 @@
 	{
 		"text_id": 2613000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2613000,
@@ -47007,7 +47007,7 @@
 	{
 		"text_id": 3333000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3333000,
@@ -47052,7 +47052,7 @@
 	{
 		"text_id": 3353000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3353000,
@@ -47097,7 +47097,7 @@
 	{
 		"text_id": 3373000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3373000,
@@ -47637,7 +47637,7 @@
 	{
 		"text_id": 3313000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 3313000,
@@ -48007,7 +48007,7 @@
 	{
 		"text_id": 2335000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2335000,
@@ -48052,7 +48052,7 @@
 	{
 		"text_id": 2355000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2355000,
@@ -48097,7 +48097,7 @@
 	{
 		"text_id": 2375000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2375000,
@@ -48877,7 +48877,7 @@
 	{
 		"text_id": 2315000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2315000,
@@ -51222,7 +51222,7 @@
 	{
 		"text_id": 2735000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2735000,
@@ -51267,7 +51267,7 @@
 	{
 		"text_id": 2755000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2755000,
@@ -51312,7 +51312,7 @@
 	{
 		"text_id": 2775000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": "This seems to be\na Photon Art chip."
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2775000,
@@ -51957,12 +51957,12 @@
 	{
 		"text_id": 2715000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2715000,
 		"jp_text": "装備したらどのような\n必殺技を繰り出せるのでしょう……！？\nすごく楽しみですね！",
-		"tr_text": ""
+		"tr_text": "What kind of Photon Art can you\nperform by equipping this...?!\nI look forward to finding out!"
 	},
 	{
 		"text_id": 2715200,
@@ -54787,12 +54787,12 @@
 	{
 		"text_id": 2525000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2525000,
 		"jp_text": "装備したらどのような\n必殺技を繰り出せるのでしょう……！？\nすごく楽しみですね！",
-		"tr_text": ""
+		"tr_text": "What kind of Photon Art can you\nperform by equipping this...?!\nI look forward to finding out!"
 	},
 	{
 		"text_id": 2525200,
@@ -54832,12 +54832,12 @@
 	{
 		"text_id": 2553000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2553000,
 		"jp_text": "装備したらどのような\n必殺技を繰り出せるのでしょう……！？\nすごく楽しみですね！",
-		"tr_text": ""
+		"tr_text": "What kind of Photon Art can you\nperform by equipping this...?!\nI look forward to finding out!"
 	},
 	{
 		"text_id": 2553200,
@@ -54877,12 +54877,12 @@
 	{
 		"text_id": 2565000,
 		"jp_text": "必殺技を記録した\nチップのようです。",
-		"tr_text": ""
+		"tr_text": "This seems to be a Photon Art chip."
 	},
 	{
 		"text_id": 2565000,
 		"jp_text": "装備したらどのような\n必殺技を繰り出せるのでしょう……！？\nすごく楽しみですね！",
-		"tr_text": ""
+		"tr_text": "What kind of Photon Art can you\nperform by equipping this...?!\nI look forward to finding out!"
 	},
 	{
 		"text_id": 2565200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -47,7 +47,7 @@
 	{
 		"text_id": 1002200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released, and its\nability has become \"<%abi>\"!\nIts performance can also be enhanced\neven further than before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1002200,
@@ -117,7 +117,7 @@
 	{
 		"text_id": 1004200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released, and its\nability has become \"<%abi>\"!\nIts performance can also be enhanced\neven further than before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1004200,
@@ -182,7 +182,7 @@
 	{
 		"text_id": 1006200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": "This chip has been released, and its\nability has become \"<%abi>\"!\nIts performance can also be enhanced\neven further than before!"
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 1006200,
@@ -51257,12 +51257,12 @@
 	{
 		"text_id": 2736200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2736200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 2755000,
@@ -51302,12 +51302,12 @@
 	{
 		"text_id": 2756200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2756200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 2775000,
@@ -51352,12 +51352,12 @@
 	{
 		"text_id": 2776200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2776200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5747000,
@@ -51402,12 +51402,12 @@
 	{
 		"text_id": 5748200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5748200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5748200,
@@ -51457,12 +51457,12 @@
 	{
 		"text_id": 5804200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5804200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5804200,
@@ -51512,7 +51512,7 @@
 	{
 		"text_id": 8215200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8215200,
@@ -51567,7 +51567,7 @@
 	{
 		"text_id": 8217200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8217200,
@@ -51632,7 +51632,7 @@
 	{
 		"text_id": 8219200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8219200,
@@ -51722,7 +51722,7 @@
 	{
 		"text_id": 8222200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8222200,
@@ -51777,7 +51777,7 @@
 	{
 		"text_id": 8224200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8224200,
@@ -51832,7 +51832,7 @@
 	{
 		"text_id": 8226200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8226200,
@@ -51887,7 +51887,7 @@
 	{
 		"text_id": 8228200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8228200,
@@ -51942,7 +51942,7 @@
 	{
 		"text_id": 8234200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8234200,
@@ -51992,12 +51992,12 @@
 	{
 		"text_id": 2716200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2716200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5757000,
@@ -52042,12 +52042,12 @@
 	{
 		"text_id": 5758200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5758200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5758200,
@@ -52097,12 +52097,12 @@
 	{
 		"text_id": 5834200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5834200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5834200,
@@ -52152,12 +52152,12 @@
 	{
 		"text_id": 7076200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7076200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 8235000,
@@ -52207,7 +52207,7 @@
 	{
 		"text_id": 8236200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8236200,
@@ -52262,7 +52262,7 @@
 	{
 		"text_id": 8238200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8238200,
@@ -52322,7 +52322,7 @@
 	{
 		"text_id": 8240200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8240200,
@@ -52392,7 +52392,7 @@
 	{
 		"text_id": 8242200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8242200,
@@ -52482,7 +52482,7 @@
 	{
 		"text_id": 8245200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8245200,
@@ -52537,7 +52537,7 @@
 	{
 		"text_id": 8247200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8247200,
@@ -52592,7 +52592,7 @@
 	{
 		"text_id": 8249200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8249200,
@@ -52647,12 +52647,12 @@
 	{
 		"text_id": 2014200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2014200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 2014200,
@@ -52702,12 +52702,12 @@
 	{
 		"text_id": 5704200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5704200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5704200,
@@ -52757,12 +52757,12 @@
 	{
 		"text_id": 5898200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5898200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5898200,
@@ -52817,7 +52817,7 @@
 	{
 		"text_id": 8251200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8251200,
@@ -52877,7 +52877,7 @@
 	{
 		"text_id": 8253200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8253200,
@@ -52942,7 +52942,7 @@
 	{
 		"text_id": 8255200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8255200,
@@ -53032,7 +53032,7 @@
 	{
 		"text_id": 8258200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8258200,
@@ -53087,7 +53087,7 @@
 	{
 		"text_id": 8260200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8260200,
@@ -53152,7 +53152,7 @@
 	{
 		"text_id": 8262200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8262200,
@@ -53497,7 +53497,7 @@
 	{
 		"text_id": 8274200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8274200,
@@ -53557,7 +53557,7 @@
 	{
 		"text_id": 8276200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8276200,
@@ -53612,7 +53612,7 @@
 	{
 		"text_id": 8278200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8278200,
@@ -53667,7 +53667,7 @@
 	{
 		"text_id": 8280200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8280200,
@@ -53727,7 +53727,7 @@
 	{
 		"text_id": 8284200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8284200,
@@ -53792,7 +53792,7 @@
 	{
 		"text_id": 8286200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8286200,
@@ -53882,7 +53882,7 @@
 	{
 		"text_id": 8289200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8289200,
@@ -53937,7 +53937,7 @@
 	{
 		"text_id": 8291200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8291200,
@@ -53992,7 +53992,7 @@
 	{
 		"text_id": 8295200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8295200,
@@ -54052,7 +54052,7 @@
 	{
 		"text_id": 8297200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8297200,
@@ -54112,7 +54112,7 @@
 	{
 		"text_id": 8299200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8299200,
@@ -54167,7 +54167,7 @@
 	{
 		"text_id": 8301200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8301200,
@@ -54222,7 +54222,7 @@
 	{
 		"text_id": 8303200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8303200,
@@ -54287,7 +54287,7 @@
 	{
 		"text_id": 8305200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8305200,
@@ -54377,7 +54377,7 @@
 	{
 		"text_id": 8308200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8308200,
@@ -54432,12 +54432,12 @@
 	{
 		"text_id": 5786200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5786200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5786200,
@@ -54487,12 +54487,12 @@
 	{
 		"text_id": 5862200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5862200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5862200,
@@ -54542,7 +54542,7 @@
 	{
 		"text_id": 8310200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8310200,
@@ -54602,7 +54602,7 @@
 	{
 		"text_id": 8312200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8312200,
@@ -54662,7 +54662,7 @@
 	{
 		"text_id": 8314200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8314200,
@@ -54717,7 +54717,7 @@
 	{
 		"text_id": 8316200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8316200,
@@ -54772,7 +54772,7 @@
 	{
 		"text_id": 8343200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8343200,
@@ -54822,12 +54822,12 @@
 	{
 		"text_id": 2526200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2526200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 2553000,
@@ -54867,12 +54867,12 @@
 	{
 		"text_id": 2554200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2554200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 2565000,
@@ -54917,12 +54917,12 @@
 	{
 		"text_id": 2566200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 2566200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 7701000,
@@ -54962,12 +54962,12 @@
 	{
 		"text_id": 7702200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 7702200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 8292000,
@@ -55012,7 +55012,7 @@
 	{
 		"text_id": 8293200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8293200,
@@ -55077,7 +55077,7 @@
 	{
 		"text_id": 8318200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8318200,
@@ -55167,7 +55167,7 @@
 	{
 		"text_id": 8321200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8321200,
@@ -55222,7 +55222,7 @@
 	{
 		"text_id": 8323200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8323200,
@@ -55277,7 +55277,7 @@
 	{
 		"text_id": 8325200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8325200,
@@ -55337,7 +55337,7 @@
 	{
 		"text_id": 8327200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8327200,
@@ -55392,7 +55392,7 @@
 	{
 		"text_id": 8329200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8329200,
@@ -55452,7 +55452,7 @@
 	{
 		"text_id": 8331200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8331200,
@@ -55507,7 +55507,7 @@
 	{
 		"text_id": 8333200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8333200,
@@ -55567,7 +55567,7 @@
 	{
 		"text_id": 8335200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8335200,
@@ -55627,7 +55627,7 @@
 	{
 		"text_id": 8337200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8337200,
@@ -55687,7 +55687,7 @@
 	{
 		"text_id": 8339200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8339200,
@@ -55747,7 +55747,7 @@
 	{
 		"text_id": 8341200,
 		"jp_text": "チップが解放されアビリティが\n「<%abi>」に\nなりました！\n性能もより強化されていますよ！",
-		"tr_text": ""
+		"tr_text": "This chip has been released,\nand its ability has become\n\"<%abi>\"!\nIts performance can also be\nenhanced even further than before!"
 	},
 	{
 		"text_id": 8341200,
@@ -55852,12 +55852,12 @@
 	{
 		"text_id": 5772200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5772200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5772200,
@@ -55907,12 +55907,12 @@
 	{
 		"text_id": 5836200,
 		"jp_text": "チップが解放され\nアビリティ性能が高まりました！",
-		"tr_text": ""
+		"tr_text": "The chip has been released and\nits ability has been enhanced!"
 	},
 	{
 		"text_id": 5836200,
 		"jp_text": "ますます強力になった効果を\nぜひ試してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Please, try the ability again\nand see for yourself how\nmuch stronger it is!"
 	},
 	{
 		"text_id": 5836200,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -13957,7 +13957,7 @@
 	{
 		"text_id": 1807000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1807200,
@@ -14012,7 +14012,7 @@
 	{
 		"text_id": 1823000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1823200,
@@ -14067,7 +14067,7 @@
 	{
 		"text_id": 1827000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1827200,
@@ -15147,7 +15147,7 @@
 	{
 		"text_id": 1805000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1805200,
@@ -15202,7 +15202,7 @@
 	{
 		"text_id": 1819000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1819200,
@@ -15257,7 +15257,7 @@
 	{
 		"text_id": 1825000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1825200,
@@ -16112,7 +16112,7 @@
 	{
 		"text_id": 1809000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1809200,
@@ -16217,7 +16217,7 @@
 	{
 		"text_id": 1845000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1845200,
@@ -16272,7 +16272,7 @@
 	{
 		"text_id": 1867000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1867200,
@@ -17317,7 +17317,7 @@
 	{
 		"text_id": 1811000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1811200,
@@ -17422,7 +17422,7 @@
 	{
 		"text_id": 1821000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1821200,
@@ -17477,7 +17477,7 @@
 	{
 		"text_id": 1813000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1813200,
@@ -17532,7 +17532,7 @@
 	{
 		"text_id": 1865000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1865200,
@@ -18507,7 +18507,7 @@
 	{
 		"text_id": 1801000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1801200,
@@ -18562,7 +18562,7 @@
 	{
 		"text_id": 1803000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1803200,
@@ -18617,7 +18617,7 @@
 	{
 		"text_id": 1815000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1815200,
@@ -18672,7 +18672,7 @@
 	{
 		"text_id": 1817000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1817200,
@@ -18827,7 +18827,7 @@
 	{
 		"text_id": 1847000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1847200,
@@ -19387,7 +19387,7 @@
 	{
 		"text_id": 1859000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1859200,
@@ -19442,7 +19442,7 @@
 	{
 		"text_id": 1863000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1863200,
@@ -22282,7 +22282,7 @@
 	{
 		"text_id": 1197028,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1197029,
@@ -24457,7 +24457,7 @@
 	{
 		"text_id": 1197204,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1197205,
@@ -26592,7 +26592,7 @@
 	{
 		"text_id": 1843000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1843200,
@@ -27907,7 +27907,7 @@
 	{
 		"text_id": 1853000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1853200,
@@ -27962,7 +27962,7 @@
 	{
 		"text_id": 1861000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1861200,
@@ -29782,7 +29782,7 @@
 	{
 		"text_id": 1849000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1849200,
@@ -29947,7 +29947,7 @@
 	{
 		"text_id": 1917000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1917200,
@@ -30002,7 +30002,7 @@
 	{
 		"text_id": 1931000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1931200,
@@ -30872,7 +30872,7 @@
 	{
 		"text_id": 1841000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1841200,
@@ -30927,7 +30927,7 @@
 	{
 		"text_id": 1855000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1855200,
@@ -31037,7 +31037,7 @@
 	{
 		"text_id": 1923000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1923200,
@@ -31092,7 +31092,7 @@
 	{
 		"text_id": 1925000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1925200,
@@ -31147,7 +31147,7 @@
 	{
 		"text_id": 1933000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1933200,
@@ -31202,7 +31202,7 @@
 	{
 		"text_id": 1937000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1937200,
@@ -31257,7 +31257,7 @@
 	{
 		"text_id": 1939000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1939200,
@@ -32032,7 +32032,7 @@
 	{
 		"text_id": 1941000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1941200,
@@ -32757,7 +32757,7 @@
 	{
 		"text_id": 1919000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1919200,
@@ -32812,7 +32812,7 @@
 	{
 		"text_id": 1935000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1935200,
@@ -32867,7 +32867,7 @@
 	{
 		"text_id": 1927000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1927200,
@@ -33797,7 +33797,7 @@
 	{
 		"text_id": 1965000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1965200,
@@ -34552,7 +34552,7 @@
 	{
 		"text_id": 1921000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1921200,
@@ -34607,7 +34607,7 @@
 	{
 		"text_id": 1945000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1945200,
@@ -34662,7 +34662,7 @@
 	{
 		"text_id": 1961000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1961200,
@@ -34717,7 +34717,7 @@
 	{
 		"text_id": 1973000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1973200,
@@ -34772,7 +34772,7 @@
 	{
 		"text_id": 1915000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1915200,
@@ -34827,7 +34827,7 @@
 	{
 		"text_id": 1963000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1963200,
@@ -34882,7 +34882,7 @@
 	{
 		"text_id": 1929000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1929200,
@@ -35527,7 +35527,7 @@
 	{
 		"text_id": 1953000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1953200,
@@ -35582,7 +35582,7 @@
 	{
 		"text_id": 1955000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1955200,
@@ -35637,7 +35637,7 @@
 	{
 		"text_id": 1993000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1993200,
@@ -35692,7 +35692,7 @@
 	{
 		"text_id": 1967000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1967200,
@@ -36442,7 +36442,7 @@
 	{
 		"text_id": 1959000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1959200,
@@ -36497,7 +36497,7 @@
 	{
 		"text_id": 1969000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1969200,
@@ -36552,7 +36552,7 @@
 	{
 		"text_id": 1989000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1989200,
@@ -38177,7 +38177,7 @@
 	{
 		"text_id": 1943000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1943200,
@@ -38232,7 +38232,7 @@
 	{
 		"text_id": 1947000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1947200,
@@ -38287,7 +38287,7 @@
 	{
 		"text_id": 1949000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1949200,
@@ -38342,7 +38342,7 @@
 	{
 		"text_id": 1957000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1957200,
@@ -38397,7 +38397,7 @@
 	{
 		"text_id": 1991000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1991200,
@@ -38452,7 +38452,7 @@
 	{
 		"text_id": 2001000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2001200,
@@ -39637,7 +39637,7 @@
 	{
 		"text_id": 1951000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1951200,
@@ -39692,7 +39692,7 @@
 	{
 		"text_id": 1983000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1983200,
@@ -39747,7 +39747,7 @@
 	{
 		"text_id": 1987000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1987200,
@@ -39802,7 +39802,7 @@
 	{
 		"text_id": 1971000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1971200,
@@ -39857,7 +39857,7 @@
 	{
 		"text_id": 1981000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1981200,
@@ -39912,7 +39912,7 @@
 	{
 		"text_id": 2017000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2017200,
@@ -39967,7 +39967,7 @@
 	{
 		"text_id": 1995000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1995200,
@@ -40892,7 +40892,7 @@
 	{
 		"text_id": 1977000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1977200,
@@ -40947,7 +40947,7 @@
 	{
 		"text_id": 2011000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2011200,
@@ -41002,7 +41002,7 @@
 	{
 		"text_id": 2009000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2009200,
@@ -41937,7 +41937,7 @@
 	{
 		"text_id": 1985000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1985200,
@@ -41992,7 +41992,7 @@
 	{
 		"text_id": 1997000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1997200,
@@ -42907,7 +42907,7 @@
 	{
 		"text_id": 2005000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2005200,
@@ -42962,7 +42962,7 @@
 	{
 		"text_id": 1979000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1979200,
@@ -43017,7 +43017,7 @@
 	{
 		"text_id": 2021000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2021200,
@@ -43072,7 +43072,7 @@
 	{
 		"text_id": 1975000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1975200,
@@ -44402,7 +44402,7 @@
 	{
 		"text_id": 2019000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2019200,
@@ -44457,7 +44457,7 @@
 	{
 		"text_id": 2025000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2025200,
@@ -44512,7 +44512,7 @@
 	{
 		"text_id": 2015000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2015200,
@@ -44927,7 +44927,7 @@
 	{
 		"text_id": 1999000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 1999200,
@@ -44982,7 +44982,7 @@
 	{
 		"text_id": 2023000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2023200,
@@ -45417,7 +45417,7 @@
 	{
 		"text_id": 2003000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2003200,
@@ -45472,7 +45472,7 @@
 	{
 		"text_id": 2007000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2007200,
@@ -52612,7 +52612,7 @@
 	{
 		"text_id": 2013000,
 		"jp_text": "必殺技をバンバン使われる場合は\nとても有効ですよ！\nぜひ入手してくださいね！",
-		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!"
+		"tr_text": "It should be very effective if you use\nit when you're knocking seven bells\nout of an enemy with a Photon Art!\nPlease, you have to get one!"
 	},
 	{
 		"text_id": 2013200,

--- a/json/UI_Weaponoid_Name.txt
+++ b/json/UI_Weaponoid_Name.txt
@@ -1007,7 +1007,7 @@
 	{
 		"assign": "160",
 		"jp_text": "玄朧夜",
-		"tr_text": "Gen Oboroyo"
+		"tr_text": "Gen Rouya"
 	},
 	{
 		"assign": "164",


### PR DESCRIPTION
-Corrects weapon names for the purple cherry blossom weapons, based on the kanji readings from Sega found on swiki.
-Translates a hell of a lot of basic stock strings used on lots of different chips in Seraphy's chip notes.