### PR TITLE
Various

### DIFF
--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -522,14 +522,14 @@
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31010",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP recovery.\n[Effect Duration] Long"
+		"tr_explainLong": "① Increases maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31011",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -1957,14 +1957,14 @@
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly boosts additional damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31749",
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly boosts additional damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31750",

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -2076,14 +2076,14 @@
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "PA/T boost x lv. + barr. + counter-Freeze",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs based on this chip's\n    ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to 50% of your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to 50% of your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31789",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs based on this chip's\n    ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to 50% of your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    up to 50% of your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31790",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -7151,14 +7151,14 @@
 		"jp_explainShort": "氷属性時小増＋双機銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 双機銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40362",
 		"jp_explainShort": "氷属性時増＋双機銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 双機銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40363",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -1866,14 +1866,14 @@
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31274",
 		"jp_explainShort": "攻撃力超絶増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31275",
@@ -2846,14 +2846,14 @@
 		"jp_explainShort": "攻撃力劇的増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31456",
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31459",
@@ -3252,14 +3252,14 @@
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Boosts additional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases the enemy's weakness element.\n② Boosts additional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31537",
@@ -3791,14 +3791,14 @@
 		"jp_explainShort": "追加特大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31639",
 		"jp_explainShort": "追加絶大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts all additional damage.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31640",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -67,21 +67,21 @@
 		"jp_text": "クラーダの脚",
 		"tr_text": "Krahda Legs",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nクラーダの脚部。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A Krahda leg that remained intact\nafter the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A Krahda leg that remained intact\nafter the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33010",
 		"jp_text": "ブリアーダの尻尾",
 		"tr_text": "Breeahda Tail",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nブリアーダの尻尾。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A Breeahda tail that remained intact\nafter the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A Breeahda tail that remained intact\nafter the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33011",
 		"jp_text": "グワナーダのあご",
 		"tr_text": "Gwanahda Jaws",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nグワナーダのあごの部分。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A Gwanahda jaw that remained\nintact after the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A Gwanahda jaw that remained\nintact after the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33012",
@@ -95,14 +95,14 @@
 		"jp_text": "ガルフの爪",
 		"tr_text": "Gulf Claws",
 		"jp_explain": "ガルフから採れた爪。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Claws from a Gulf.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Claws from a Gulf.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33014",
 		"jp_text": "フォンガルフの牙",
 		"tr_text": "Fangulf Fangs",
 		"jp_explain": "フォンガルフから採れた牙。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Fangs from a Fangulf.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Fangs from a Fangulf.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33015",
@@ -116,14 +116,14 @@
 		"jp_text": "ロックベアの牙",
 		"tr_text": "Rockbear Fang",
 		"jp_explain": "ロックベアから採れた牙。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Fangs from a Rockbear.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Fangs from a Rockbear.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33017",
 		"jp_text": "スノウバンサーの牙",
 		"tr_text": "Snow Banther Fangs",
 		"jp_explain": "スノウバンサーから採れた牙。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Fangs from a Snow Banther.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Fangs from a Snow Banther.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33018",
@@ -137,28 +137,28 @@
 		"jp_text": "ディッグの角",
 		"tr_text": "Digg Piercing Horn",
 		"jp_explain": "ディッグの頭部から迫り出した角。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A horn from the head of a Digg.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A horn from the head of a Digg.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33020",
 		"jp_text": "フォードランの角",
 		"tr_text": "Fordoran Horns",
 		"jp_explain": "フォードランから採れた角。\n非常に硬く加工しづらい。\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "The horns of a Fordoran.\nSolid and difficult to process.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "The horns of a Fordoran.\nSolid and difficult to process.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33021",
 		"jp_text": "フォードランの上質角",
 		"tr_text": "High-Quality Fordoran Horns",
 		"jp_explain": "フォードランから採れた上質な角。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "High-quality horns from a Fordoran.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "High-quality horns from a Fordoran.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33022",
 		"jp_text": "ノーディランの角",
 		"tr_text": "Nordiran Horn",
 		"jp_explain": "ノーディランから採れた角。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A horn from a Nordiran.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A horn from a Nordiran.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33023",
@@ -172,56 +172,56 @@
 		"jp_text": "ヴォル・ドラゴンのかぎ爪",
 		"tr_text": "Vol Dragon Hooked Claw",
 		"jp_explain": "ヴォル・ドラゴンの前脚にあるかぎ爪。\n非常に硬く加工しづらい。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A claw from the leg of a Vol Dragon.\nVery tough, and difficult to process.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A claw from the leg of a Vol Dragon.\nVery tough, and difficult to process.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33025",
 		"jp_text": "ダガンの針",
 		"tr_text": "Dagan Stinger",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nダガンの頭部から生えている針。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A Dagan stinger that remained\nintact after the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A Dagan stinger that remained\nintact after the defeat of its owner.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33026",
 		"jp_text": "エル・アーダの刃",
 		"tr_text": "El Ahda Blades",
 		"jp_explain": "撃退後、拡散せずに形となって残った\nエル・アーダの腕部にある刃。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "El Ahda arm blades that remained\nintact after the defeat of their\nowner. Client: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "El Ahda arm blades that remained\nintact after the defeat of their\nowner. Client: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33027",
 		"jp_text": "ガロンゴの甲殻",
 		"tr_text": "Garongo Shell",
 		"jp_explain": "ガロンゴの背中を覆う殻。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "The shell of a Garongo.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "The shell of a Garongo.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33028",
 		"jp_text": "キャタドランの甲殻",
 		"tr_text": "Caterdran Shell",
 		"jp_explain": "キャタドランの背中を覆う殻。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "The shell of a Caterdra'n.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "The shell of a Caterdra'n.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33029",
 		"jp_text": "カルターゴの殻",
 		"tr_text": "Kartagot Shells",
 		"jp_explain": "カルターゴの背中を覆う殻。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "The shell of a Kartargot.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "The shell of a Kartargot.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33030",
 		"jp_text": "カルターゴの厚い殻",
 		"tr_text": "Kartagot Thick Shells",
 		"jp_explain": "カルターゴの背中を覆う分厚い殻。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A thick shell from a Kartagot.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A thick shell from a Kartagot.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33031",
 		"jp_text": "アギニスの羽根",
 		"tr_text": "Aginis Feathers",
 		"jp_explain": "アギニスから採れた美しい羽根。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Beautiful feathers from an Aginis.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Beautiful feathers from an Aginis.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33032",
@@ -235,14 +235,14 @@
 		"jp_text": "スパルダンＡのパーツａ",
 		"tr_text": "Spardan A Parts a",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33034",
 		"jp_text": "スパルダンＡのパーツｂ",
 		"tr_text": "Spardan A Parts b",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33035",
@@ -256,56 +256,56 @@
 		"jp_text": "スパルガンのパーツａ",
 		"tr_text": "Spargun Parts a",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpargun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpargun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33037",
 		"jp_text": "スパルガンのパーツｂ",
 		"tr_text": "Spargun Parts b",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpargun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpargun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33038",
 		"jp_text": "シグノガンのパーツａ",
 		"tr_text": "Signo Gun Parts a",
 		"jp_explain": "シグノガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSigno Gun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSigno Gun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33039",
 		"jp_text": "シグノガンのパーツｂ",
 		"tr_text": "Signo Gun Parts b",
 		"jp_explain": "シグノガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSigno Gun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSigno Gun. Its purpose is unknown.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33040",
 		"jp_text": "ディーニアンの剣の破片",
 		"tr_text": "Dinian Sword Fragment",
 		"jp_explain": "シル・ディーニアンの\n所持していた剣の破片。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A fragment of a sword belonging to\na Sil Dinian.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A fragment of a sword belonging to\na Sil Dinian.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33041",
 		"jp_text": "ディーニアンの盾の破片",
 		"tr_text": "Dinian Shield Fragment",
 		"jp_explain": "シル・ディーニアンの\n所持していた盾の破片。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A fragment of a shield belonging to\na Sil Dinian.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A fragment of a shield belonging to\na Sil Dinian.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33042",
 		"jp_text": "ディーニアンの杖の破片",
 		"tr_text": "Dinian Rod Fragment",
 		"jp_explain": "ソル・ディーニアンの\n所持していた杖の破片。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "A fragment of a rod belonging to\na Sol Dinian.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "A fragment of a rod belonging to\na Sol Dinian.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33043",
 		"jp_text": "謎の甲虫の殻",
 		"tr_text": "Mystery Carapace",
 		"jp_explain": "甲虫らしき生物の甲殻の一部。\n\n依頼者：<c a1ff6d>フランカ<c>　再受注可能",
-		"tr_explain": "Part of the shell of some beetle-like\norganism.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Part of the shell of some beetle-like\norganism.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33044",
@@ -340,21 +340,21 @@
 		"jp_text": "橙色の小さな花",
 		"tr_text": "Small Orange Flower",
 		"jp_explain": "ナベリウスで採取された花。\nマトイが気にしていたらしい……\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "A small flower from Naberius. Seems\nthat Matoi was interested in these...\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "A small flower from Naberius. Seems\nthat Matoi was interested in these...\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "33049",
 		"jp_text": "桃色の小さな花",
 		"tr_text": "Small Pink Flower",
 		"jp_explain": "ナベリウスで採取された花。\nマトイが興味深く見ていたらしい……\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "A small flower from Naberius. Seems\nthat Matoi was interested in these...\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "A small flower from Naberius. Seems\nthat Matoi was interested in these...\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "33050",
 		"jp_text": "黄色の小さな花",
 		"tr_text": "Small Yellow Flower",
 		"jp_explain": "ラッピーが愛すると言われる\n希少種な花。\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "A rare flower beloved by Rappies.\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "A rare flower beloved by Rappies.\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "33051",
@@ -417,28 +417,28 @@
 		"jp_text": "エコーのロッド",
 		"tr_text": "Echo's Rod",
 		"jp_explain": "もう使用していない旧型だが、大事に\n扱われ、新品のように輝いている。\n依頼者：<c a1ff6d>エコー<c>　再受注不可",
-		"tr_explain": "An outdated model, but treated\ncarefully and still looks brand new.\nClient: <c a1ff6d>Echo<c> (one-time order)"
+		"tr_explain": "An outdated model, but treated\ncarefully and still looks brand new.\nClient: <c a1ff6d>Echo<c> (non-repeatable)"
 	},
 	{
 		"assign": "33060",
 		"jp_text": "ヴォル・ドラゴンの翼膜",
 		"tr_text": "Vol Dragon Wings",
 		"jp_explain": "ヴォル・ドラゴンの翼膜。\n伸縮性が高いものは非常に稀少。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "The wings of a Vol Dragon. Those\nthat have a very high elasticity are\nrare. Client: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "The wings of a Vol Dragon. Those\nthat have a very high elasticity are\nrare. Client: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33061",
 		"jp_text": "ディーニアンの剣の刀身",
 		"tr_text": "Dinian Sword Blade",
 		"jp_explain": "シル・ディーニアンの剣の刀身。\n生体の一部のような刃が特徴。\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "Sil Dinian sword blade. The blade\nis organic, resembling a body part.\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "Sil Dinian sword blade. The blade\nis organic, resembling a body part.\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33062",
 		"jp_text": "キャタドランの水晶",
 		"tr_text": "Caterdran Crystal",
 		"jp_explain": "キャタドランの頭部にある水晶。\n貴重品として扱われる。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "A crystal from a Caterdra'n's head.\nConsidered a highly valuable item.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "A crystal from a Caterdra'n's head.\nConsidered a highly valuable item.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33063",
@@ -508,84 +508,84 @@
 		"jp_text": "砂ばらの結晶",
 		"tr_text": "Sand Rose Crystal",
 		"jp_explain": "重晶石で構成された\nばらのような形をした結晶。\n依頼者：<c a1ff6d>ハンス<c>　再受注不可",
-		"tr_explain": "An elegant, rose-like crystal\ncomposed of barite.\nClient: <c a1ff6d>Hans<c> (one-time order)"
+		"tr_explain": "An elegant, rose-like crystal\ncomposed of barite.\nClient: <c a1ff6d>Hans<c> (non-repeatable)"
 	},
 	{
 		"assign": "33073",
 		"jp_text": "ナベリウス観測素子ａ",
 		"tr_text": "Naberius Observation Device a",
 		"jp_explain": "アークスが、惑星ナベリウスの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33074",
 		"jp_text": "アムドゥスキア観測素子ａ",
 		"tr_text": "Amduscia Observation Device a",
 		"jp_explain": "アークスが、惑星アムドゥスキアの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33075",
 		"jp_text": "リリーパ観測素子ａ",
 		"tr_text": "Lillipa Observation Device a",
 		"jp_explain": "アークスが、惑星リリーパの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33076",
 		"jp_text": "ナベリウス観測素子ｂ",
 		"tr_text": "Naberius Observation Device b",
 		"jp_explain": "アークスが、惑星ナベリウスの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33077",
 		"jp_text": "アムドゥスキア観測素子ｂ",
 		"tr_text": "Amduscia Observation Device b",
 		"jp_explain": "アークスが、惑星アムドゥスキアの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33078",
 		"jp_text": "リリーパ観測素子ｂ",
 		"tr_text": "Lillipa Observation Device b",
 		"jp_explain": "アークスが、惑星リリーパの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33079",
 		"jp_text": "ナベリウス観測素子ｃ",
 		"tr_text": "Naberius Observation Device c",
 		"jp_explain": "アークスが、惑星ナベリウスの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33080",
 		"jp_text": "アムドゥスキア観測素子ｃ",
 		"tr_text": "Amduscia Observation Device c",
 		"jp_explain": "アークスが、惑星アムドゥスキアの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33081",
 		"jp_text": "リリーパ観測素子ｃ",
 		"tr_text": "Lillipa Observation Device c",
 		"jp_explain": "アークスが、惑星リリーパの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33082",
 		"jp_text": "フォンガルフの頭角",
 		"tr_text": "Fangulf Horn",
 		"jp_explain": "フォンガルフの頭部より採れた角。\n\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "Horn taken from a Fangulf's head.\n\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "Horn taken from a Fangulf's head.\n\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "33083",
 		"jp_text": "ガーディナンのパーツａ",
 		"tr_text": "Guardinane Parts a",
 		"jp_explain": "ガーディナンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>エコー<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nGuardinane. Its purpose is unknown.\nClient: <c a1ff6d>Echo<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nGuardinane. Its purpose is unknown.\nClient: <c a1ff6d>Echo<c> (non-repeatable)"
 	},
 	{
 		"assign": "33084",
@@ -634,7 +634,7 @@
 		"jp_text": "キングイエーデの髭",
 		"tr_text": "King Yede Beard",
 		"jp_explain": "キングイエーデから採れた髭。\n\n依頼者：<c a1ff6d>ローラ<c>　再受注不可",
-		"tr_explain": "The beard of a King Yede.\n\nClient: <c a1ff6d>Lola<c> (one-time order)"
+		"tr_explain": "The beard of a King Yede.\n\nClient: <c a1ff6d>Lola<c> (non-repeatable)"
 	},
 	{
 		"assign": "33091",
@@ -655,7 +655,7 @@
 		"jp_text": "ノーディランサの肉",
 		"tr_text": "Nordiransa Meat",
 		"jp_explain": "ノーディランサから採れた肉。\n\n依頼者：<c a1ff6d>アフィン<c>　再受注不可",
-		"tr_explain": "Meat taken from a Nordiransa.\n\nClient: <c a1ff6d>Afin<c> (one-time order)"
+		"tr_explain": "Meat taken from a Nordiransa.\n\nClient: <c a1ff6d>Afin<c> (non-repeatable)"
 	},
 	{
 		"assign": "33094",
@@ -704,63 +704,63 @@
 		"jp_text": "浮遊大陸の石片",
 		"tr_text": "Skyscape Rock Shards",
 		"jp_explain": "浮遊大陸で採れた石の欠片。\nほのかな光を放っている。\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "A piece of stone collected from the\nSkyscape. It glows with a faint light.\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "A piece of stone collected from the\nSkyscape. It glows with a faint light.\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "330101",
 		"jp_text": "クォーツ・ドラゴンの角片",
 		"tr_text": "Quartz Dragon Horn Shards",
 		"jp_explain": "クォーツ・ドラゴンの頭部にある\n角の欠片。\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "A fragment of the horn on the head\nof a Quartz Dragon.\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "A fragment of the horn on the head\nof a Quartz Dragon.\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "330102",
 		"jp_text": "肉厚の葉",
 		"tr_text": "Thick Leaves",
 		"jp_explain": "ナベリウスに自生している植物の葉。\n食用にもなり、噛み応えがある。\n依頼者：<c a1ff6d>ミケーラ<c>　再受注不可",
-		"tr_explain": "Leaves native to planet Naberius.\nCan be eaten, but are very chewy.\nClient: <c a1ff6d>Michaela<c> (one-time order)"
+		"tr_explain": "Leaves native to planet Naberius.\nCan be eaten, but are very chewy.\nClient: <c a1ff6d>Michaela<c> (non-repeatable)"
 	},
 	{
 		"assign": "330103",
 		"jp_text": "ナベリウス観測素子ｄ",
 		"tr_text": "Naberius Observation Device d",
 		"jp_explain": "アークスが、惑星ナベリウスの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330104",
 		"jp_text": "リリーパ観測素子ｄ",
 		"tr_text": "Lillipa Observation Device d",
 		"jp_explain": "アークスが、惑星リリーパの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330105",
 		"jp_text": "アムドゥスキア観測素子ｄ",
 		"tr_text": "Amduscia Observation Device d",
 		"jp_explain": "アークスが、惑星アムドゥスキアの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330106",
 		"jp_text": "破損したダーカーコアａ",
 		"tr_text": "Damaged Darker Core a",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や衝撃によって破損している。\n依頼者：<c a1ff6d>オーザ<c>　再受注不可",
-		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a slashing weapon.\nClient: <c a1ff6d>Ohza<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a slashing weapon.\nClient: <c a1ff6d>Ohza<c> (non-repeatable)"
 	},
 	{
 		"assign": "330107",
 		"jp_text": "破損したダーカーコアｂ",
 		"tr_text": "Damaged Darker Core b",
 		"jp_explain": "ダーカーから採取されたコア。\n銃撃や砲撃によって破損している。\n依頼者：<c a1ff6d>リサ<c>　再受注不可",
-		"tr_explain": "Core taken from a Darker. Has been\ndamaged by gunfire or shrapnel.\nClient: <c a1ff6d>Lisa<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by gunfire or shrapnel.\nClient: <c a1ff6d>Lisa<c> (non-repeatable)"
 	},
 	{
 		"assign": "330108",
 		"jp_text": "破損したダーカーコアｃ",
 		"tr_text": "Damaged Darker Core c",
 		"jp_explain": "ダーカーから採取されたコア。\n法撃や打撃によって破損している。\n依頼者：<c a1ff6d>マールー<c>　再受注不可",
-		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a Technique.\nClient: <c a1ff6d>Marlu<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a Technique.\nClient: <c a1ff6d>Marlu<c> (non-repeatable)"
 	},
 	{
 		"assign": "330109",
@@ -984,1162 +984,1162 @@
 		"jp_text": "アギニスの小爪",
 		"tr_text": "Aginis Wing Claw",
 		"jp_explain": "アギニスの翼から生える爪。\nあまり役に立っていない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "A claw that grows on the wing of an\nAginis. Not particularly useful.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A claw that grows on the wing of an\nAginis. Not particularly useful.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330141",
 		"jp_text": "アギニスの鋭いくちばし",
 		"tr_text": "Aginis Sharp Beak",
 		"jp_explain": "アギニスのくちばし。\n鋭く獲物を攻撃する。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "The beak of an Aginis. The sharp\npoint is used to attack prey.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "The beak of an Aginis. The sharp\npoint is used to attack prey.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330142",
 		"jp_text": "アギニスの朱い羽根",
 		"tr_text": "Aginis Scarlet Feathers",
 		"jp_explain": "アギニスの朱い羽根。\nきれいに生えそろっていて美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "アギニスの朱い羽根。\nきれいに生えそろっていて美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "アギニスの朱い羽根。\nきれいに生えそろっていて美しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330143",
 		"jp_text": "ウーダンの角",
 		"tr_text": "Oodan Horn",
 		"jp_explain": "ウーダンの頭に生える角。\n攻撃的な曲線を描く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "A horn from the head of an Oodan.\nIt has an aggressive-looking curve.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A horn from the head of an Oodan.\nIt has an aggressive-looking curve.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330144",
 		"jp_text": "ウーダンの爪",
 		"tr_text": "Oodan Claws",
 		"jp_explain": "ウーダンの爪。\nひっかいたり、地面を掴むのに使う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Claws from an Oodan. Used to scratch\nand to grip the ground.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from an Oodan. Used to scratch\nand to grip the ground.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330145",
 		"jp_text": "ウーダンの鋭い爪",
 		"tr_text": "Oodan Sharp Claws",
 		"jp_explain": "ウーダンの爪。\nひっかかれると痛そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Claws from an Oodan. A scratch from\none is painful.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from an Oodan. A scratch from\none is painful.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330146",
 		"jp_text": "ガルフの棘",
 		"tr_text": "Gulf Spines",
 		"jp_explain": "ガルフの背中の棘。\n気軽になでることを許さない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガルフの背中の棘。\n気軽になでることを許さない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガルフの背中の棘。\n気軽になでることを許さない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330147",
 		"jp_text": "ガルフの鋭い牙",
 		"tr_text": "Gulf Sharp Fangs",
 		"jp_explain": "ガルフの牙。\nかみつき攻撃に注意。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Fangs from a Gulf.\nBeware their biting attack.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fangs from a Gulf.\nBeware their biting attack.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330148",
 		"jp_text": "ガルフの鋭い爪",
 		"tr_text": "Gulf Sharp Claws",
 		"jp_explain": "ガルフの爪。\n飛びかかりながらのひっかきは脅威。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Claws from a Gulf. Their jumping\nscratch attack is dangerous.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from a Gulf. Their jumping\nscratch attack is dangerous.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330149",
 		"jp_text": "ガロンゴの足",
 		"tr_text": "Garongo Leg",
 		"jp_explain": "ガロンゴの足。\n意外と小回りが利く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガロンゴの足。\n意外と小回りが利く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガロンゴの足。\n意外と小回りが利く。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330150",
 		"jp_text": "ガロンゴの尾の殻",
 		"tr_text": "Garongo Tail Shell",
 		"jp_explain": "ガロンゴの尻尾の大きな殻。\n回転攻撃の勢いに貢献している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガロンゴの尻尾の大きな殻。\n回転攻撃の勢いに貢献している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガロンゴの尻尾の大きな殻。\n回転攻撃の勢いに貢献している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330151",
 		"jp_text": "ガロンゴの頭の殻",
 		"tr_text": "Garongo Head Shell",
 		"jp_explain": "ガロンゴの頭部の大きな殻。\n回転攻撃の時、実は隠れている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガロンゴの頭部の大きな殻。\n回転攻撃の時、実は隠れている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガロンゴの頭部の大きな殻。\n回転攻撃の時、実は隠れている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330152",
 		"jp_text": "ザウーダンの爪",
 		"tr_text": "Za Oodan Claws",
 		"jp_explain": "ザウーダンの爪。\n器用に岩を掘り起こす。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ザウーダンの爪。\n器用に岩を掘り起こす。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ザウーダンの爪。\n器用に岩を掘り起こす。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330153",
 		"jp_text": "ザウーダンの角",
 		"tr_text": "Za Oodan Horns",
 		"jp_explain": "ザウーダンの立派な角。\nでも攻撃には使わない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ザウーダンの立派な角。\nでも攻撃には使わない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ザウーダンの立派な角。\nでも攻撃には使わない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330154",
 		"jp_text": "ザウーダンの牙",
 		"tr_text": "Za Oodan Fangs",
 		"jp_explain": "ザウーダンの牙。\nなんでも噛みちぎる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ザウーダンの牙。\nなんでも噛みちぎる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ザウーダンの牙。\nなんでも噛みちぎる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330155",
 		"jp_text": "黒い小片",
 		"tr_text": "Black Pieces",
 		"jp_explain": "ダーカーの体の小片。\n小さくて部位はわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の小片。\n小さくて部位はわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の小片。\n小さくて部位はわからない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330156",
 		"jp_text": "赤い小片",
 		"tr_text": "Red Pieces",
 		"jp_explain": "ダーカーの体の小片。\n赤い部位と言うことしかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の小片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の小片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330157",
 		"jp_text": "赤い欠片",
 		"tr_text": "Red Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n赤い部位と言うことしかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の欠片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の欠片。\n赤い部位と言うことしかわからない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330158",
 		"jp_text": "ダガンの爪",
 		"tr_text": "Dagan Claws",
 		"jp_explain": "ダガンの脚先の爪。\n刺されると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの脚先の爪。\n刺されると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの脚先の爪。\n刺されると痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330159",
 		"jp_text": "ダガンの薄羽",
 		"tr_text": "Dagan Thin Wings",
 		"jp_explain": "ダガンの頭部に生える薄羽。\n何のためにあるか謎の器官。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの頭部に生える薄羽。\n何のためにあるか謎の器官。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの頭部に生える薄羽。\n何のためにあるか謎の器官。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330160",
 		"jp_text": "ダガンの鋭い針",
 		"tr_text": "Dagan Sharp Stinger",
 		"jp_explain": "ダガンの頭部に生える針。\n攻撃に使うと痛そうだが使用しない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの頭部に生える針。\n攻撃に使うと痛そうだが使用しない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの頭部に生える針。\n攻撃に使うと痛そうだが使用しない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330161",
 		"jp_text": "ナヴ・ラッピーの触角",
 		"tr_text": "Nab Rappy Antennas",
 		"jp_explain": "ナヴ・ラッピーに生える触角。\n周囲の状況把握に役立っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ナヴ・ラッピーに生える触角。\n周囲の状況把握に役立っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ナヴ・ラッピーに生える触角。\n周囲の状況把握に役立っている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330162",
 		"jp_text": "ナヴ・ラッピーのかぎ爪",
 		"tr_text": "Nab Rappy Claws",
 		"jp_explain": "ナヴ・ラッピーのかぎ爪。\nしっかりと地面を掴む。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ナヴ・ラッピーのかぎ爪。\nしっかりと地面を掴む。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ナヴ・ラッピーのかぎ爪。\nしっかりと地面を掴む。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330163",
 		"jp_text": "ナヴ・ラッピーの小爪",
 		"tr_text": "Nab Rappy Wing Claw",
 		"jp_explain": "ナヴ・ラッピーの翼に生える爪。\nかわいい外見に違わずあまり痛くない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ナヴ・ラッピーの翼に生える爪。\nかわいい外見に違わずあまり痛くない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ナヴ・ラッピーの翼に生える爪。\nかわいい外見に違わずあまり痛くない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330164",
 		"jp_text": "フォンガルフの鋭い牙",
 		"tr_text": "Sharp Fangulf Fangs",
 		"jp_explain": "フォンガルフの牙。\nかまれると非常に痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォンガルフの牙。\nかまれると非常に痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォンガルフの牙。\nかまれると非常に痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330165",
 		"jp_text": "フォンガルフの鋭い爪",
 		"tr_text": "Sharp Fangulf Claws",
 		"jp_explain": "フォンガルフの鋭利な爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Sharp claws taken from a Fangulf.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp claws taken from a Fangulf.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330166",
 		"jp_text": "フォンガルフの脚の角",
 		"tr_text": "Fangulf Leg Horns",
 		"jp_explain": "フォンガルフの脚に生える角。\n体を休める時に邪魔になりそう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォンガルフの脚に生える角。\n体を休める時に邪魔になりそう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォンガルフの脚に生える角。\n体を休める時に邪魔になりそう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330167",
 		"jp_text": "侵食核の欠片ａ",
 		"tr_text": "Tainted Core Fragments A",
 		"jp_explain": "原生種にとりついた侵食核。\n原生種の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "原生種にとりついた侵食核。\n原生種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "原生種にとりついた侵食核。\n原生種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330168",
 		"jp_text": "侵食核の欠片ｂ",
 		"tr_text": "Tainted Core Fragments B",
 		"jp_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330169",
 		"jp_text": "侵食核の欠片ｃ",
 		"tr_text": "Tainted Core Fragments C",
 		"jp_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330170",
 		"jp_text": "カルターゴの紫羽",
 		"tr_text": "Kartagot Purple Wings",
 		"jp_explain": "カルターゴの頭部から生える羽の\n紫色の部分。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの頭部から生える羽の\n紫色の部分。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの頭部から生える羽の\n紫色の部分。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330171",
 		"jp_text": "カルターゴの丈夫な殻",
 		"tr_text": "Kartagot Rear Shell",
 		"jp_explain": "カルターゴのお尻の殻。\n上に乗ってもびくともしない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴのお尻の殻。\n上に乗ってもびくともしない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴのお尻の殻。\n上に乗ってもびくともしない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330172",
 		"jp_text": "カルターゴの牙",
 		"tr_text": "Kartagot Fangs",
 		"jp_explain": "カルターゴの体型からどう使うのか\n謎の部位。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの体型からどう使うのか\n謎の部位。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの体型からどう使うのか\n謎の部位。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330173",
 		"jp_text": "シル・ディーニアンの肩甲",
 		"tr_text": "Sil Dinian Shoulder Blades",
 		"jp_explain": "シル・ディーニアンの肩当て。\n意外と自在に動く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シル・ディーニアンの肩当て。\n意外と自在に動く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シル・ディーニアンの肩当て。\n意外と自在に動く。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330174",
 		"jp_text": "シル・ディーニアンの盾角",
 		"tr_text": "Sil Dinian Shield Edges",
 		"jp_explain": "シル・ディーニアンの盾の角。\n殴られると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シル・ディーニアンの盾の角。\n殴られると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シル・ディーニアンの盾の角。\n殴られると痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330175",
 		"jp_text": "シル・ディーニアンの頭角",
 		"tr_text": "Sil Dinian Head Horns",
 		"jp_explain": "シル・ディーニアンの頭に生える角。\n頭突きには使いにくそう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シル・ディーニアンの頭に生える角。\n頭突きには使いにくそう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シル・ディーニアンの頭に生える角。\n頭突きには使いにくそう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330176",
 		"jp_text": "ソル・ディーニアンの肩甲",
 		"tr_text": "Sol Dinian Shoulder Blades",
 		"jp_explain": "ソル・ディーニアンの肩当て。\n腕を動かしても邪魔にならない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ソル・ディーニアンの肩当て。\n腕を動かしても邪魔にならない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ソル・ディーニアンの肩当て。\n腕を動かしても邪魔にならない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330177",
 		"jp_text": "ソル・ディーニアンの頭角",
 		"tr_text": "Sol Dinian Head Horns",
 		"jp_explain": "頭突きには使いにくそう。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Seem to be hardened for headbutts.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Seem to be hardened for headbutts.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330178",
 		"jp_text": "ソル・ディーニアンの銃晶",
 		"tr_text": "Sol Dinian Gun Crystals",
 		"jp_explain": "ソル・ディーニアンの銃のクリスタル。\n銃撃の威力をアップさせているらしい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ソル・ディーニアンの銃のクリスタル。\n銃撃の威力をアップさせているらしい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ソル・ディーニアンの銃のクリスタル。\n銃撃の威力をアップさせているらしい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330179",
 		"jp_text": "熱を持った黒い欠片",
 		"tr_text": "Heated Black Pieces",
 		"jp_explain": "ダーカーの体の一部。\n火山熱によって熱くなっている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の一部。\n火山熱によって熱くなっている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の一部。\n火山熱によって熱くなっている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330180",
 		"jp_text": "黒い欠片",
 		"tr_text": "Black Fragments",
 		"jp_explain": "ダーカーの体の一部。\nどこの部位かはよくわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の一部。\nどこの部位かはよくわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の一部。\nどこの部位かはよくわからない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330181",
 		"jp_text": "大きく赤い欠片",
 		"tr_text": "Large Red Fragments",
 		"jp_explain": "ダーカーの体の赤い部位の欠片。\n比較的大きいものがとれた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の赤い部位の欠片。\n比較的大きいものがとれた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の赤い部位の欠片。\n比較的大きいものがとれた。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330182",
 		"jp_text": "ダガンの角",
 		"tr_text": "Dagan Horns",
 		"jp_explain": "ダガンの頭の角。\n先に薄羽が生えている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの頭の角。\n先に薄羽が生えている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの頭の角。\n先に薄羽が生えている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330183",
 		"jp_text": "ダガンの脚関節",
 		"tr_text": "Dagan Leg Joints",
 		"jp_explain": "ダガンの脚の関節。\nなめらかに動く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの脚の関節。\nなめらかに動く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの脚の関節。\nなめらかに動く。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330184",
 		"jp_text": "ダガンの鋭い爪",
 		"tr_text": "Dagan Sharp Claws",
 		"jp_explain": "ダガンの爪。\n鋭く刺されるため非常に痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの爪。\n鋭く刺されるため非常に痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの爪。\n鋭く刺されるため非常に痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330185",
 		"jp_text": "ディーニアンの肩甲",
 		"tr_text": "Dinian Shoulder Blades",
 		"jp_explain": "ディーニアンの肩当て。\n肩周りをしっかりガード。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディーニアンの肩当て。\n肩周りをしっかりガード。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディーニアンの肩当て。\n肩周りをしっかりガード。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330186",
 		"jp_text": "ディーニアンの頭角",
 		"tr_text": "Dinian Head Horns",
 		"jp_explain": "ディーニアンの頭から首にかけての角。\n威圧感を増している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディーニアンの頭から首にかけての角。\n威圧感を増している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディーニアンの頭から首にかけての角。\n威圧感を増している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330187",
 		"jp_text": "ディーニアンの杖水晶",
 		"tr_text": "Dinian Wand Crystals",
 		"jp_explain": "ディーニアンの杖のクリスタル。\n法撃の威力をアップさせている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディーニアンの杖のクリスタル。\n法撃の威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディーニアンの杖のクリスタル。\n法撃の威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330188",
 		"jp_text": "ディッグの尻尾",
 		"tr_text": "Digg Tails",
 		"jp_explain": "ディッグの尻尾。\n小柄な体型の割に、太めの尻尾。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディッグの尻尾。\n小柄な体型の割に、太めの尻尾。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディッグの尻尾。\n小柄な体型の割に、太めの尻尾。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330189",
 		"jp_text": "ディッグの頭角",
 		"tr_text": "Digg Head Horns",
 		"jp_explain": "ディッグの頭頂部の角。\n頭をなでることをよしとしない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディッグの頭頂部の角。\n頭をなでることをよしとしない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディッグの頭頂部の角。\n頭をなでることをよしとしない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330190",
 		"jp_text": "ディッグの羽",
 		"tr_text": "Digg Wings",
 		"jp_explain": "ディッグの背にある小さな羽。\n小さすぎて飛ぶことはできない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディッグの背にある小さな羽。\n小さすぎて飛ぶことはできない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディッグの背にある小さな羽。\n小さすぎて飛ぶことはできない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330191",
 		"jp_text": "ノーディランの連角",
 		"tr_text": "Nordiran Horn Joints",
 		"jp_explain": "ノーディランの腰に連なる角。\n背後から襲われた時に役に立つ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ノーディランの腰に連なる角。\n背後から襲われた時に役に立つ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ノーディランの腰に連なる角。\n背後から襲われた時に役に立つ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330192",
 		"jp_text": "ノーディランの背水晶",
 		"tr_text": "Nordiran Back Crystals",
 		"jp_explain": "ノーディランの背に生えるクリスタル。\n大きくなるのに相応の年月が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ノーディランの背に生えるクリスタル。\n大きくなるのに相応の年月が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ノーディランの背に生えるクリスタル。\n大きくなるのに相応の年月が必要。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330193",
 		"jp_text": "ノーディランの腹水晶",
 		"tr_text": "Nordiran Belly Crystals",
 		"jp_explain": "ノーディランの腹に生えるクリスタル。\n小ぶりだが量があるため迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ノーディランの腹に生えるクリスタル。\n小ぶりだが量があるため迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ノーディランの腹に生えるクリスタル。\n小ぶりだが量があるため迫力がある。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330194",
 		"jp_text": "フォードランの連角",
 		"tr_text": "Fordoran Horn Joints",
 		"jp_explain": "フォードランの腰に連なる角。\n後ろから見ても迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォードランの腰に連なる角。\n後ろから見ても迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォードランの腰に連なる角。\n後ろから見ても迫力がある。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330195",
 		"jp_text": "フォードランの背水晶",
 		"tr_text": "Fordoran Back Crystals",
 		"jp_explain": "フォードランの背に生えるクリスタル。\nこれのおかげで乗ることは難しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォードランの背に生えるクリスタル。\nこれのおかげで乗ることは難しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォードランの背に生えるクリスタル。\nこれのおかげで乗ることは難しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330196",
 		"jp_text": "フォードランの腹水晶",
 		"tr_text": "Fordoran Belly Crystals",
 		"jp_explain": "フォードランの腹に生えるクリスタル。\n乗られるとミンチになってしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォードランの腹に生えるクリスタル。\n乗られるとミンチになってしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォードランの腹に生えるクリスタル。\n乗られるとミンチになってしまう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330197",
 		"jp_text": "熱を持った侵食核の欠片ａ",
 		"tr_text": "Heated Tainted Core Fragments A",
 		"jp_explain": "龍族にとりついた侵食核。\n龍族の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "龍族にとりついた侵食核。\n龍族の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "龍族にとりついた侵食核。\n龍族の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330198",
 		"jp_text": "熱を持った侵食核の欠片ｂ",
 		"tr_text": "Heated Tainted Core Fragments B",
 		"jp_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330199",
 		"jp_text": "熱を持った侵食核の欠片ｃ",
 		"tr_text": "Heated Tainted Core Fragments C",
 		"jp_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330200",
 		"jp_text": "エル・アーダのあご",
 		"tr_text": "El Ahda Jaws",
 		"jp_explain": "エル・アーダのあご。\nかみつかれると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダのあご。\nかみつかれると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダのあご。\nかみつかれると痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330201",
 		"jp_text": "エル・アーダの触角",
 		"tr_text": "El Ahda Antennae",
 		"jp_explain": "エル・アーダの触角。\n節くれ立って大きい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダの触角。\n節くれ立って大きい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダの触角。\n節くれ立って大きい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330202",
 		"jp_text": "エル・アーダの尻尾",
 		"tr_text": "El Ahda Tail",
 		"jp_explain": "エル・アーダの尻尾。\n鋭い針が内蔵されている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダの尻尾。\n鋭い針が内蔵されている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダの尻尾。\n鋭い針が内蔵されている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330203",
 		"jp_text": "カルターゴの角",
 		"tr_text": "Kartagot Horns",
 		"jp_explain": "カルターゴの角。\n冠のようにも見える。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの角。\n冠のようにも見える。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの角。\n冠のようにも見える。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330204",
 		"jp_text": "カルターゴの黒羽",
 		"tr_text": "Kartagot Black Wings",
 		"jp_explain": "カルターゴの黒羽。\n胴体をカバーするのに使う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの黒羽。\n胴体をカバーするのに使う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの黒羽。\n胴体をカバーするのに使う。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330205",
 		"jp_text": "カルターゴの腰殻",
 		"tr_text": "Kartagot Waist Carapace",
 		"jp_explain": "カルターゴの腰を覆う殻。\nこれにより前面はしっかり守られている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの腰を覆う殻。\nこれにより前面はしっかり守られている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの腰を覆う殻。\nこれにより前面はしっかり守られている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330206",
 		"jp_text": "クラーダの尾羽",
 		"tr_text": "Krahda Tail",
 		"jp_explain": "クラーダの尾羽。\n体格の割に立派なものを持っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの尾羽。\n体格の割に立派なものを持っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの尾羽。\n体格の割に立派なものを持っている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330207",
 		"jp_text": "クラーダの鎌",
 		"tr_text": "Krahda Sickle",
 		"jp_explain": "クラーダの鎌。\n左右の鎌による同時攻撃は注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの鎌。\n左右の鎌による同時攻撃は注意が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの鎌。\n左右の鎌による同時攻撃は注意が必要。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330208",
 		"jp_text": "クラーダの頭殻",
 		"tr_text": "Krahda Head Carapace",
 		"jp_explain": "クラーダの頭を守る殻。\n弱い攻撃ははじかれてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの頭を守る殻。\n弱い攻撃ははじかれてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの頭を守る殻。\n弱い攻撃ははじかれてしまう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330209",
 		"jp_text": "シグノガンの肩部装甲",
 		"tr_text": "Signo Gun Shoulder Armor",
 		"jp_explain": "シグノガンの肩口を直接守る装甲。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Armor that protects a Signo Gun's\ncollar.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Armor that protects a Signo Gun's\ncollar.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330210",
 		"jp_text": "シグノガンの脚部装甲",
 		"tr_text": "Signo Gun Leg Armor",
 		"jp_explain": "シグノガンの左脚を守る装甲。\n左脚だけなのはスムーズに構えるため。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノガンの左脚を守る装甲。\n左脚だけなのはスムーズに構えるため。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シグノガンの左脚を守る装甲。\n左脚だけなのはスムーズに構えるため。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330211",
 		"jp_text": "シグノガンの砲弾",
 		"tr_text": "Signogun Cannon Shells",
 		"jp_explain": "シグノガンの砲弾。\n火力が高いので、要注意。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノガンの砲弾。\n火力が高いので、要注意。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シグノガンの砲弾。\n火力が高いので、要注意。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330212",
 		"jp_text": "スパルガンのパーツｆ",
 		"tr_text": "Spargun Parts f",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330213",
 		"jp_text": "スパルガンのパーツｇ",
 		"tr_text": "Spargun Parts g",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330214",
 		"jp_text": "スパルガンのパーツｉ",
 		"tr_text": "Spargun Parts i",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330215",
 		"jp_text": "スパルダンＡのパーツｆ",
 		"tr_text": "Spardan A Parts f",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330216",
 		"jp_text": "スパルダンＡのパーツｇ",
 		"tr_text": "Spardan A Parts g",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330217",
 		"jp_text": "スパルダンＡのパーツｉ",
 		"tr_text": "Spardan A Parts i",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330218",
 		"jp_text": "乾いた黒い欠片",
 		"tr_text": "Dried Black Pieces",
 		"jp_explain": "ダーカーの体の黒い欠片。\n砂漠の影響で乾燥している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の黒い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の黒い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330219",
 		"jp_text": "乾いた赤い欠片",
 		"tr_text": "Dried Red Fragments",
 		"jp_explain": "ダーカーの体の赤い欠片。\n砂漠の影響で乾燥している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の赤い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の赤い欠片。\n砂漠の影響で乾燥している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330220",
 		"jp_text": "黒い塊",
 		"tr_text": "Black Lump",
 		"jp_explain": "ダーカーの体の黒い部分の塊。\n禍々しい雰囲気を醸し出している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の黒い部分の塊。\n禍々しい雰囲気を醸し出している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の黒い部分の塊。\n禍々しい雰囲気を醸し出している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330221",
 		"jp_text": "ダガンの脚甲",
 		"tr_text": "Dagan Leg Carapaces",
 		"jp_explain": "ダガンの脚を守る甲殻。\nそこそこの防御力を持つ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの脚を守る甲殻。\nそこそこの防御力を持つ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの脚を守る甲殻。\nそこそこの防御力を持つ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330222",
 		"jp_text": "ダガンの堅い甲殻",
 		"tr_text": "Dagan Hard Shell",
 		"jp_explain": "ダガンの甲殻のうち特に堅い部位。\nここ以外を狙えると戦いやすい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの甲殻のうち特に堅い部位。\nここ以外を狙えると戦いやすい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの甲殻のうち特に堅い部位。\nここ以外を狙えると戦いやすい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330223",
 		"jp_text": "ダガンのきれいな薄羽",
 		"tr_text": "Odd Dagan Wing",
 		"jp_explain": "ダガンの頭部から生える薄羽。\n激しい戦闘の中破損状況が軽微なもの。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの頭部から生える薄羽。\n激しい戦闘の中破損状況が軽微なもの。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの頭部から生える薄羽。\n激しい戦闘の中破損状況が軽微なもの。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330224",
 		"jp_text": "ブリアーダの前脚",
 		"tr_text": "Breeahda Forelegs",
 		"jp_explain": "ブリアーダの前脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Breeahda parts that seem to be\nfront legs.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Breeahda parts that seem to be\nfront legs.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330225",
 		"jp_text": "ブリアーダの後脚",
 		"tr_text": "Breeahda Hindlegs",
 		"jp_explain": "ブリアーダの後脚と思われる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Breeahda parts that seem to be\nback legs.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Breeahda parts that seem to be\nback legs.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330226",
 		"jp_text": "ブリアーダの肩角",
 		"tr_text": "Breeahda Shoulder Blades",
 		"jp_explain": "ブリアーダの前脚をつなぐ肩の角。\n威嚇用の飾りと思われる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの前脚をつなぐ肩の角。\n威嚇用の飾りと思われる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブリアーダの前脚をつなぐ肩の角。\n威嚇用の飾りと思われる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330227",
 		"jp_text": "乾いた侵食核の欠片ａ",
 		"tr_text": "Dried Tainted Core Fragment A",
 		"jp_explain": "機甲種にとりついた侵食核。\n機甲種の凶暴化を助長していた。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "機甲種にとりついた侵食核。\n機甲種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "機甲種にとりついた侵食核。\n機甲種の凶暴化を助長していた。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330228",
 		"jp_text": "乾いた侵食核の欠片ｂ",
 		"tr_text": "Dried Tainted Core Fragment B",
 		"jp_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330229",
 		"jp_text": "乾いた侵食核の欠片ｃ",
 		"tr_text": "Dried Tainted Core Fragment C",
 		"jp_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330230",
 		"jp_text": "イエーデの足爪",
 		"tr_text": "Yede Foot Nails",
 		"jp_explain": "イエーデの足に生えるごつい爪。\n雪の中でも地面を踏みしめられる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "イエーデの足に生えるごつい爪。\n雪の中でも地面を踏みしめられる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "イエーデの足に生えるごつい爪。\n雪の中でも地面を踏みしめられる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330231",
 		"jp_text": "イエーデの尾骨",
 		"tr_text": "Yede Tailbone",
 		"jp_explain": "イエーデの岩のような尾骨。\n毛皮にも覆われず、堂々としたもの。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "イエーデの岩のような尾骨。\n毛皮にも覆われず、堂々としたもの。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "イエーデの岩のような尾骨。\n毛皮にも覆われず、堂々としたもの。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330232",
 		"jp_text": "ガルフルの鋭い爪",
 		"tr_text": "Gulfur Sharp Claws",
 		"jp_explain": "ガルフルの爪。\nその鋭さは傷を重傷化させてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガルフルの爪。\nその鋭さは傷を重傷化させてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガルフルの爪。\nその鋭さは傷を重傷化させてしまう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330233",
 		"jp_text": "ガルフルの鋭い牙",
 		"tr_text": "Gulfur Sharp Fangs",
 		"jp_explain": "ガルフルの牙。\nその鋭さはなんでもかみ砕いてしまう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガルフルの牙。\nその鋭さはなんでもかみ砕いてしまう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガルフルの牙。\nその鋭さはなんでもかみ砕いてしまう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330234",
 		"jp_text": "キングイエーデの尾骨",
 		"tr_text": "King Yede Coccyx",
 		"jp_explain": "キングイエーデの尾骨。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "The tailbone of a King Yede.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "The tailbone of a King Yede.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330235",
 		"jp_text": "キングイエーデの頭骨",
 		"tr_text": "King Yede Skull",
 		"jp_explain": "キングイエーデの岩のような頭骨。\n非常に堅い、まさに石頭。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "キングイエーデの岩のような頭骨。\n非常に堅い、まさに石頭。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "キングイエーデの岩のような頭骨。\n非常に堅い、まさに石頭。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330236",
 		"jp_text": "凍った赤い欠片",
 		"tr_text": "Frozen Red Fragments",
 		"jp_explain": "ダーカーの赤い体の欠片。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの赤い体の欠片。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの赤い体の欠片。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330237",
 		"jp_text": "大きく黒い塊",
 		"tr_text": "Large Black Lump",
 		"jp_explain": "ダーカーの黒い体の塊。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの黒い体の塊。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの黒い体の塊。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330238",
 		"jp_text": "ナヴ・ラッピーの凍った爪",
 		"tr_text": "Frozen Nab Rappy Claw",
 		"jp_explain": "ナヴ・ラッピーの爪。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ナヴ・ラッピーの爪。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ナヴ・ラッピーの爪。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330239",
 		"jp_text": "ナヴ・ラッピーの氷結片",
 		"tr_text": "Frozen Nab Rappy Beak",
 		"jp_explain": "ナヴ・ラッピーのくちばし。\n凍土の影響で凍り付いている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ナヴ・ラッピーのくちばし。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ナヴ・ラッピーのくちばし。\n凍土の影響で凍り付いている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330240",
 		"jp_text": "ファンガルフルの鋭い爪",
 		"tr_text": "Fangulfur Sharp Claws",
 		"jp_explain": "ファンガルフルの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Sharp claws taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp claws taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330241",
 		"jp_text": "ファンガルフルの鋭い牙",
 		"tr_text": "Fangulfur Sharp Fangs",
 		"jp_explain": "ファンガルフルの牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Sharp fangs taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Sharp fangs taken from a Fangulfur.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330242",
 		"jp_text": "マルモスの鼻",
 		"tr_text": "Malmoth Trunk",
 		"jp_explain": "マルモスの長い鼻。\n非常に器用に動かすことができる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "マルモスの長い鼻。\n非常に器用に動かすことができる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "マルモスの長い鼻。\n非常に器用に動かすことができる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330243",
 		"jp_text": "マルモスの剛毛",
 		"tr_text": "Malmoth Bristles",
 		"jp_explain": "マルモスの剛毛。\nタフな体力と相まって倒しにくい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "マルモスの剛毛。\nタフな体力と相まって倒しにくい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "マルモスの剛毛。\nタフな体力と相まって倒しにくい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330244",
 		"jp_text": "ミクダの堅い甲羅",
 		"tr_text": "Micda Hard Shell",
 		"jp_explain": "ミクダの堅い甲羅。\n正面から戦うのは愚策。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ミクダの堅い甲羅。\n正面から戦うのは愚策。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ミクダの堅い甲羅。\n正面から戦うのは愚策。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330245",
 		"jp_text": "ミクダのあご",
 		"tr_text": "Micda Jaws",
 		"jp_explain": "ミクダのあご。\n普段隠れていてほとんど目立たない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ミクダのあご。\n普段隠れていてほとんど目立たない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ミクダのあご。\n普段隠れていてほとんど目立たない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330246",
 		"jp_text": "凍った侵食核の欠片ａ",
 		"tr_text": "Frozen Tainted Core Fragment A",
 		"jp_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "原生種にとりついた侵食核。\nとりつかれた原生種はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330247",
 		"jp_text": "凍った侵食核の欠片ｂ",
 		"tr_text": "Frozen Tainted Core Fragment B",
 		"jp_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "原生種にとりついた侵食核。\nどんな原生種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330248",
 		"jp_text": "エル・アーダの爪",
 		"tr_text": "El Ahda Nails",
 		"jp_explain": "エル・アーダの腕の爪。\n豪快なひっかきは脅威。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダの腕の爪。\n豪快なひっかきは脅威。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダの腕の爪。\n豪快なひっかきは脅威。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330249",
 		"jp_text": "エル・アーダの角",
 		"tr_text": "El Ahda Horns",
 		"jp_explain": "エル・アーダの額の角。\n周囲の情報を敏感に察知する。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダの額の角。\n周囲の情報を敏感に察知する。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダの額の角。\n周囲の情報を敏感に察知する。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330250",
 		"jp_text": "ガーディナンの弾倉",
 		"tr_text": "Guardinane Magazine",
 		"jp_explain": "ガーディナンの弾倉。\n見た目より多くの弾を秘めている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガーディナンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガーディナンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330251",
 		"jp_text": "ガーディナンの脚部",
 		"tr_text": "Guardinane Leg",
 		"jp_explain": "ガーディナンの脚部パーツ。\nこれでの自立は無理そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガーディナンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガーディナンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330252",
 		"jp_text": "ガーディンの弾倉",
 		"tr_text": "Guardine Magazine",
 		"jp_explain": "ガーディンの弾倉。\n見た目より多くの弾を秘めている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガーディンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガーディンの弾倉。\n見た目より多くの弾を秘めている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330253",
 		"jp_text": "ガーディンの脚部",
 		"tr_text": "Guardine Leg",
 		"jp_explain": "ガーディンの脚部パーツ。\nこれでの自立は無理そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガーディンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガーディンの脚部パーツ。\nこれでの自立は無理そう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330254",
 		"jp_text": "カルターゴの脚節",
 		"tr_text": "Kartagot Leg Section",
 		"jp_explain": "カルターゴの脚節。\n短いががっしりしている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの脚節。\n短いががっしりしている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの脚節。\n短いががっしりしている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330255",
 		"jp_text": "カルターゴの脚角",
 		"tr_text": "Kartagot Leg Horns",
 		"jp_explain": "カルターゴの膝の角。\n連なって生える様は美しくもある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの膝の角。\n連なって生える様は美しくもある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの膝の角。\n連なって生える様は美しくもある。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330256",
 		"jp_text": "ギルナスの肩ボルト",
 		"tr_text": "Gilnas Shoulder Bolt",
 		"jp_explain": "ギルナスの肩にあるボルト。\n肩パーツをしっかりと固定している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ギルナスの肩にあるボルト。\n肩パーツをしっかりと固定している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ギルナスの肩にあるボルト。\n肩パーツをしっかりと固定している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330257",
 		"jp_text": "ギルナスのコアレンズ",
 		"tr_text": "Gilnas Core Lens",
 		"jp_explain": "ギルナス・コアのレンズ。\n攻撃を撃ち出す要のパーツ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ギルナス・コアのレンズ。\n攻撃を撃ち出す要のパーツ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ギルナス・コアのレンズ。\n攻撃を撃ち出す要のパーツ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330258",
 		"jp_text": "ギルナッチの肩部ランプ",
 		"tr_text": "Gilnach Shoulder Armor",
 		"jp_explain": "ギルナッチの肩に光るランプ。\nギルナッチの肩幅も一目瞭然。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ギルナッチの肩に光るランプ。\nギルナッチの肩幅も一目瞭然。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ギルナッチの肩に光るランプ。\nギルナッチの肩幅も一目瞭然。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330259",
 		"jp_text": "ギルナッチの頭部ランプ",
 		"tr_text": "Gilnach Head Lamp",
 		"jp_explain": "ギルナッチの頭部で回転するランプ。\nどんな事態で点灯するかは不明である。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ギルナッチの頭部で回転するランプ。\nどんな事態で点灯するかは不明である。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ギルナッチの頭部で回転するランプ。\nどんな事態で点灯するかは不明である。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330260",
 		"jp_text": "クラーダの後脚",
 		"tr_text": "Krahda Hind Legs",
 		"jp_explain": "クラーダの後脚。\n体長の倍の高さを飛ぶ驚異の跳躍力。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの後脚。\n体長の倍の高さを飛ぶ驚異の跳躍力。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの後脚。\n体長の倍の高さを飛ぶ驚異の跳躍力。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330261",
 		"jp_text": "クラーダの鋭い鎌",
 		"tr_text": "Krahda Sharp Sickle",
 		"jp_explain": "クラーダの備える鎌。\n形は小さいが鋭く、斬られると痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの備える鎌。\n形は小さいが鋭く、斬られると痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの備える鎌。\n形は小さいが鋭く、斬られると痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330262",
 		"jp_text": "シグノビートの腕部装甲",
 		"tr_text": "Signo Beat Arm Armor",
 		"jp_explain": "シグノビートの腕を守る装甲。\n分厚い金属で覆われている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノビートの腕を守る装甲。\n分厚い金属で覆われている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シグノビートの腕を守る装甲。\n分厚い金属で覆われている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330263",
 		"jp_text": "シグノビートの不発機雷",
 		"tr_text": "Signo Beat Unexploded Mine",
 		"jp_explain": "シグノビートの投げる機雷の不発弾。\nどんなきっかけで爆発するかわからない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノビートの投げる機雷の不発弾。\nどんなきっかけで爆発するかわからない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シグノビートの投げる機雷の不発弾。\nどんなきっかけで爆発するかわからない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330264",
 		"jp_text": "スパルガンのパーツｈ",
 		"tr_text": "Spargun Parts h",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330265",
 		"jp_text": "スパルガンのパーツｊ",
 		"tr_text": "Spargun Parts j",
 		"jp_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルガンを構成する部品の一つ。\n用途は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330266",
 		"jp_text": "スパルザイルのレンズ",
 		"tr_text": "Sparzyle Lens",
 		"jp_explain": "スパルザイルの頭部レンズ。\nあらゆる角度で獲物を狙う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルザイルの頭部レンズ。\nあらゆる角度で獲物を狙う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルザイルの頭部レンズ。\nあらゆる角度で獲物を狙う。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330267",
 		"jp_text": "スパルザイルの起爆剤",
 		"tr_text": "Sparzyle Explosives",
 		"jp_explain": "スパルザイルが自爆する際の起爆剤。\n取り扱いは丁重に。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "スパルザイルが自爆する際の起爆剤。\n取り扱いは丁重に。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "スパルザイルが自爆する際の起爆剤。\n取り扱いは丁重に。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330268",
 		"jp_text": "スパルダンＡのパーツｈ",
 		"tr_text": "Spardan A Parts h",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330269",
 		"jp_text": "スパルダンＡのパーツｊ",
 		"tr_text": "Spardan A Parts j",
 		"jp_explain": "スパルダンＡを構成する部品の一つ。\n用途は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpardan A. Its purpose is unknown.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330270",
 		"jp_text": "大きく黒い欠片",
 		"tr_text": "Large Black Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n比較的大きい欠片だが、部位は不明。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の欠片。\n比較的大きい欠片だが、部位は不明。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の欠片。\n比較的大きい欠片だが、部位は不明。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330271",
 		"jp_text": "赤い塊",
 		"tr_text": "Red Lump",
 		"jp_explain": "ダーカーの体の赤い部位の塊。\n若干グロテスク。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の赤い部位の塊。\n若干グロテスク。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の赤い部位の塊。\n若干グロテスク。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330272",
 		"jp_text": "ブリアーダの針",
 		"tr_text": "Breeahda Stinger",
 		"jp_explain": "ブリアーダのあごの針。\n鋭いので注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダのあごの針。\n鋭いので注意が必要。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブリアーダのあごの針。\n鋭いので注意が必要。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330273",
 		"jp_text": "ブリアーダのかぎ爪",
 		"tr_text": "Breeahda Claws",
 		"jp_explain": "ブリアーダの前脚のかぎ爪。\nこれでひっかかれたら痛そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの前脚のかぎ爪。\nこれでひっかかれたら痛そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブリアーダの前脚のかぎ爪。\nこれでひっかかれたら痛そう。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330274",
 		"jp_text": "油まみれの侵食核の欠片ａ",
 		"tr_text": "Oil Covered Tainted Core A",
 		"jp_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "機甲種にとりついた侵食核。\nとりつかれた機甲種はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330275",
 		"jp_text": "油まみれの侵食核の欠片ｂ",
 		"tr_text": "Oil Covered Tainted Core B",
 		"jp_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "機甲種にとりついた侵食核。\nどんな機甲種も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330276",
 		"jp_text": "ウィンディラの棘",
 		"tr_text": "Windira Spine",
 		"jp_explain": "ウィンディラの尾に連なる棘。\n掴むと刺さって痛い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウィンディラの尾に連なる棘。\n掴むと刺さって痛い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ウィンディラの尾に連なる棘。\n掴むと刺さって痛い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330277",
 		"jp_text": "ウィンディラの胸角",
 		"tr_text": "Windira Breast Horns",
 		"jp_explain": "ウィンディラの胸の角。\n突進をよけたつもりで引っかかる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウィンディラの胸の角。\n突進をよけたつもりで引っかかる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ウィンディラの胸の角。\n突進をよけたつもりで引っかかる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330278",
 		"jp_text": "オル・ミクダの甲羅",
 		"tr_text": "Ol Micda Carapaces",
 		"jp_explain": "オル・ミクダの甲羅。\n堅いため甲羅をよけて攻撃するべし。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "オル・ミクダの甲羅。\n堅いため甲羅をよけて攻撃するべし。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "オル・ミクダの甲羅。\n堅いため甲羅をよけて攻撃するべし。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330279",
 		"jp_text": "オル・ミクダの二本角",
 		"tr_text": "Ol Micda Twin Horns",
 		"jp_explain": "オル・ミクダの二本の角。\n周囲の情報をチェックしている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "オル・ミクダの二本の角。\n周囲の情報をチェックしている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "オル・ミクダの二本の角。\n周囲の情報をチェックしている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330280",
 		"jp_text": "ガウォンダの肩甲",
 		"tr_text": "Ga Wonda Shoulder Blades",
 		"jp_explain": "ガウォンダの肩を守る甲殻。\n守備範囲はあまり広くない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガウォンダの肩を守る甲殻。\n守備範囲はあまり広くない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガウォンダの肩を守る甲殻。\n守備範囲はあまり広くない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330281",
 		"jp_text": "ガウォンダの脚甲",
 		"tr_text": "Ga Wonda Leg Armor",
 		"jp_explain": "ガウォンダの脚を覆う甲殻。\n脚のガードは堅い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガウォンダの脚を覆う甲殻。\n脚のガードは堅い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガウォンダの脚を覆う甲殻。\n脚のガードは堅い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330282",
 		"jp_text": "サディニアンの頭角",
 		"tr_text": "Sadinian Head Horns",
 		"jp_explain": "サディニアンの頭の角。\n正面より横からのが迫力がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "サディニアンの頭の角。\n正面より横からのが迫力がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "サディニアンの頭の角。\n正面より横からのが迫力がある。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330283",
 		"jp_text": "サディニアンの杖水晶",
 		"tr_text": "Sadinian Wand Crystals",
 		"jp_explain": "サディニアンの杖のクリスタル。\n法撃の威力上昇に貢献している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "サディニアンの杖のクリスタル。\n法撃の威力上昇に貢献している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "サディニアンの杖のクリスタル。\n法撃の威力上昇に貢献している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330284",
 		"jp_text": "シル・サディニアンの盾角",
 		"tr_text": "Sadinian Shield Edges",
 		"jp_explain": "シル・サディニアンの盾の角。\n防具だが打撃力が高い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シル・サディニアンの盾の角。\n防具だが打撃力が高い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シル・サディニアンの盾の角。\n防具だが打撃力が高い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330285",
 		"jp_text": "シル・サディニアンの頭角",
 		"tr_text": "Sil Sadinian Head Horns",
 		"jp_explain": "シル・サディニアンの頭の角。\n後頭部まで連なる様は、モヒカンの様。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シル・サディニアンの頭の角。\n後頭部まで連なる様は、モヒカンの様。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シル・サディニアンの頭の角。\n後頭部まで連なる様は、モヒカンの様。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330286",
 		"jp_text": "セト・サディニアンの頭角",
 		"tr_text": "Set Sadinian Head Horns",
 		"jp_explain": "セト・サディニアンの頭の角。\n小柄な体格に似合わず立派な角。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "セト・サディニアンの頭の角。\n小柄な体格に似合わず立派な角。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "セト・サディニアンの頭の角。\n小柄な体格に似合わず立派な角。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330287",
 		"jp_text": "セト・サディニアンのひれ",
 		"tr_text": "Set Sadinian Fin",
 		"jp_explain": "セト・サディニアンの頭から\n足下まで伸びる長いひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "セト・サディニアンの頭から\n足下まで伸びる長いひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "セト・サディニアンの頭から\n足下まで伸びる長いひれ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330288",
 		"jp_text": "ソル・サディニアンの頭角",
 		"tr_text": "Sol Sadinian Head Horns",
 		"jp_explain": "ソル・サディニアンの頭の角。\n威圧感を醸し出している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ソル・サディニアンの頭の角。\n威圧感を醸し出している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ソル・サディニアンの頭の角。\n威圧感を醸し出している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330289",
 		"jp_text": "ソル・サディニアンの銃晶",
 		"tr_text": "Sol Sadinian Gun Crystals",
 		"jp_explain": "ソル・サディニアンの銃のクリスタル。\n射撃威力をアップさせている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ソル・サディニアンの銃のクリスタル。\n射撃威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ソル・サディニアンの銃のクリスタル。\n射撃威力をアップさせている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330290",
 		"jp_text": "固く黒い欠片",
 		"tr_text": "Hardened Black Fragments",
 		"jp_explain": "ダーカーの体の欠片。\n固くて黒い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の欠片。\n固くて黒い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の欠片。\n固くて黒い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330291",
 		"jp_text": "赤い半球体",
 		"tr_text": "Red Hemisphere",
 		"jp_explain": "ダーカーの体の欠片。\n赤い半球体が丸ごと残った。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーカーの体の欠片。\n赤い半球体が丸ごと残った。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーカーの体の欠片。\n赤い半球体が丸ごと残った。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330292",
 		"jp_text": "ダーガッシュの牙",
 		"tr_text": "Dahgash Fangs",
 		"jp_explain": "ダーガッシュの牙。\n巨大な口に鋭い牙で、重傷必至。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーガッシュの牙。\n巨大な口に鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーガッシュの牙。\n巨大な口に鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330293",
 		"jp_text": "ダーガッシュの背びれ",
 		"tr_text": "Dahgash Rear Fin",
 		"jp_explain": "ダーガッシュの背びれ。\n空中を進む推力を出力している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーガッシュの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーガッシュの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330294",
 		"jp_text": "ダガッチャの牙",
 		"tr_text": "Dagacha Fangs",
 		"jp_explain": "ダガッチャの牙。\n小柄ながら鋭い牙で、重傷必至。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガッチャの牙。\n小柄ながら鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガッチャの牙。\n小柄ながら鋭い牙で、重傷必至。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330295",
 		"jp_text": "ダガッチャの背びれ",
 		"tr_text": "Dagacha Rear Fin",
 		"jp_explain": "ダガッチャの背びれ。\n空中を進む推力を出力している。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガッチャの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガッチャの背びれ。\n空中を進む推力を出力している。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330296",
 		"jp_text": "ノーディランサの背水晶",
 		"tr_text": "Nordiransa Back Crystals",
 		"jp_explain": "ノーディランサの背のクリスタル。\n青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ノーディランサの背のクリスタル。\n青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ノーディランサの背のクリスタル。\n青白く美しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330297",
 		"jp_text": "ノーディランサの腹水晶",
 		"tr_text": "Nodiransa Belly Crystal",
 		"jp_explain": "ノーディランサの腹のクリスタル。\n不揃いだが、青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ノーディランサの腹のクリスタル。\n不揃いだが、青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ノーディランサの腹のクリスタル。\n不揃いだが、青白く美しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330298",
 		"jp_text": "バリドランの腕角",
 		"tr_text": "Baridran Arm Horns",
 		"jp_explain": "バリドランの腕の角。\n普段の攻撃では使わない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "バリドランの腕の角。\n普段の攻撃では使わない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "バリドランの腕の角。\n普段の攻撃では使わない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330299",
 		"jp_text": "バリドランの背びれ",
 		"tr_text": "Baridran Rear Fin",
 		"jp_explain": "バリドランの背中のひれ。\n脆いため、状態が良いものは貴重。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "バリドランの背中のひれ。\n脆いため、状態が良いものは貴重。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "バリドランの背中のひれ。\n脆いため、状態が良いものは貴重。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330300",
 		"jp_text": "フォードランサの背水晶",
 		"tr_text": "Fordoransa Back Crystals",
 		"jp_explain": "フォードランサの背のクリスタル。\n大きく青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォードランサの背のクリスタル。\n大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォードランサの背のクリスタル。\n大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330301",
 		"jp_text": "フォードランサの腹水晶",
 		"tr_text": "Fordoransa Belly Crystal",
 		"jp_explain": "フォードランサの腹のクリスタル。\n不揃いだが、大きく青白く美しい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "フォードランサの腹のクリスタル。\n不揃いだが、大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "フォードランサの腹のクリスタル。\n不揃いだが、大きく青白く美しい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330302",
 		"jp_text": "ミクダの滑りやすい脚",
 		"tr_text": "Micda Slippery Legs",
 		"jp_explain": "ミクダの脚。\n滑らかな回転攻撃はこの脚有ればこそ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ミクダの脚。\n滑らかな回転攻撃はこの脚有ればこそ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ミクダの脚。\n滑らかな回転攻撃はこの脚有ればこそ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330303",
 		"jp_text": "ミクダの蛇腹の首",
 		"tr_text": "Micda Serpentine Neck",
 		"jp_explain": "ミクダの蛇腹の首。\n回転攻撃時は内側に入り込んでいる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ミクダの蛇腹の首。\n回転攻撃時は内側に入り込んでいる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ミクダの蛇腹の首。\n回転攻撃時は内側に入り込んでいる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330304",
 		"jp_text": "軽い侵食核の欠片ａ",
 		"tr_text": "Light Tainted Core Fragments A",
 		"jp_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "龍族にとりついた侵食核。\nとりつかれた龍族はより強くなる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330305",
 		"jp_text": "軽い侵食核の欠片ｂ",
 		"tr_text": "Light Tainted Core Fragments B",
 		"jp_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "龍族にとりついた侵食核。\nどんな龍族も凶暴になっていく。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330306",
@@ -2188,28 +2188,28 @@
 		"jp_text": "ナベリウス観測素子ｅ",
 		"tr_text": "Naberius Observation Device e",
 		"jp_explain": "アークスが、惑星ナベリウスの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Naberius to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330313",
 		"jp_text": "アムドゥスキア観測素子ｅ",
 		"tr_text": "Amduscia Observation Device e",
 		"jp_explain": "アークスが、惑星アムドゥスキアの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Amduscia to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330314",
 		"jp_text": "リリーパ観測素子ｅ",
 		"tr_text": "Lillipa Observation Device e",
 		"jp_explain": "アークスが、惑星リリーパの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Lillipa to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330315",
 		"jp_text": "遺跡機構の破片",
 		"tr_text": "Ruins Machine Fragments",
 		"jp_explain": "ナベリウスの奥地にある\n遺跡機構の破片。\n依頼者：<c a1ff6d>フィリア<c>　再受注不可",
-		"tr_explain": "Fragments of a machine located\nin the Ruins area of Naberius.\nClient: <c a1ff6d>Philia<c> (one-time order)"
+		"tr_explain": "Fragments of a machine located\nin the Ruins area of Naberius.\nClient: <c a1ff6d>Philia<c> (non-repeatable)"
 	},
 	{
 		"assign": "330316",
@@ -2237,7 +2237,7 @@
 		"jp_text": "苔むした小石",
 		"tr_text": "Mossy Pebble",
 		"jp_explain": "苔のようなものに覆われている小石。\n\n依頼者：<c a1ff6d>クレシダ<c>　再受注不可",
-		"tr_explain": "A pebble covered with some kind of\nmoss.\nClient: <c a1ff6d>Kressida<c> (one-time order)"
+		"tr_explain": "A pebble covered with some kind of\nmoss.\nClient: <c a1ff6d>Kressida<c> (non-repeatable)"
 	},
 	{
 		"assign": "330320",
@@ -2300,119 +2300,119 @@
 		"jp_text": "ディーニアンの杖",
 		"tr_text": "Dinian Cane Piece",
 		"jp_explain": "ディーニアンの所持していた\n杖の柄部分。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": "ディーニアンの所持していた\n杖の柄部分。\nClient: <c a1ff6d>Toro<c> (one-time order)"
+		"tr_explain": "ディーニアンの所持していた\n杖の柄部分。\nClient: <c a1ff6d>Toro<c> (non-repeatable)"
 	},
 	{
 		"assign": "330329",
 		"jp_text": "ディッグの水晶石",
 		"tr_text": "Crystal Stone",
 		"jp_explain": "ディッグの頭部より迫り出した\n鉱石のようなものの破片。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": "ディッグの頭部より迫り出した\n鉱石のようなものの破片。\nClient: <c a1ff6d>Toro<c> (one-time order)"
+		"tr_explain": "ディッグの頭部より迫り出した\n鉱石のようなものの破片。\nClient: <c a1ff6d>Toro<c> (non-repeatable)"
 	},
 	{
 		"assign": "330340",
 		"jp_text": "異質な侵食核",
 		"tr_text": "Foreign Tainted Core",
 		"jp_explain": "侵食核の残滓。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "侵食核の残滓。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "侵食核の残滓。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330341",
 		"jp_text": "クラーダの牙",
 		"tr_text": "Krahda Fangs",
 		"jp_explain": "クラーダの二本の牙。\n攻撃にはあまり向かない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラーダの二本の牙。\n攻撃にはあまり向かない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラーダの二本の牙。\n攻撃にはあまり向かない。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330342",
 		"jp_text": "ダガンの腹部",
 		"tr_text": "Dagan Abdomen",
 		"jp_explain": "ダガンの四肢や頭部をつなげる腹部。\nコンパクトにまとまっている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガンの四肢や頭部をつなげる腹部。\nコンパクトにまとまっている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガンの四肢や頭部をつなげる腹部。\nコンパクトにまとまっている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330343",
 		"jp_text": "エル・アーダの後脚",
 		"tr_text": "El Ahda Hind-leg",
 		"jp_explain": "エル・アーダの後脚。\n空中での姿勢制御に使われる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "エル・アーダの後脚。\n空中での姿勢制御に使われる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "エル・アーダの後脚。\n空中での姿勢制御に使われる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330344",
 		"jp_text": "カルターゴの蛇腹殻",
 		"tr_text": "Kartagot Belly Carapace",
 		"jp_explain": "カルターゴの蛇腹状の殻。\n柔軟に曲げることができる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カルターゴの蛇腹状の殻。\n柔軟に曲げることができる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カルターゴの蛇腹状の殻。\n柔軟に曲げることができる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330345",
 		"jp_text": "ブリアーダの背殻の欠片",
 		"tr_text": "Breeahda Rear Fin Fragment",
 		"jp_explain": "ブリアーダの巨大な背中の殻の欠片。\n中身を守るため、見た目以上に強固。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの巨大な背中の殻の欠片。\n中身を守るため、見た目以上に強固。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブリアーダの巨大な背中の殻の欠片。\n中身を守るため、見た目以上に強固。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330346",
 		"jp_text": "ミクダの紋様殻",
 		"tr_text": "Micda Shell Patterns",
 		"jp_explain": "ミクダの甲羅の欠片。\n紋様に傷もなくきれいな状態。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ミクダの甲羅の欠片。\n紋様に傷もなくきれいな状態。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ミクダの甲羅の欠片。\n紋様に傷もなくきれいな状態。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330347",
 		"jp_text": "オル・ミクダの紋様殻",
 		"tr_text": "Ol Micda Shell Patterns",
 		"jp_explain": "オル・ミクダの甲羅の欠片。\n紋様部分がきれいに残っている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "オル・ミクダの甲羅の欠片。\n紋様部分がきれいに残っている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "オル・ミクダの甲羅の欠片。\n紋様部分がきれいに残っている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330348",
 		"jp_text": "ダーガッシュの頭びれ",
 		"tr_text": "Dahgash Head Fin",
 		"jp_explain": "ダーガッシュの頭部にあるひれ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダーガッシュの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダーガッシュの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330349",
 		"jp_text": "ダガッチャの頭びれ",
 		"tr_text": "Dagacha Head Fin",
 		"jp_explain": "ダガッチャの頭部にあるひれ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ダガッチャの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ダガッチャの頭部にあるひれ。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330350",
 		"jp_text": "ガウォンダの腰甲",
 		"tr_text": "Ga Wonda Waist Armor",
 		"jp_explain": "ガウォンダの腰を守る甲殻。\n可動範囲が大きい。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガウォンダの腰を守る甲殻。\n可動範囲が大きい。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガウォンダの腰を守る甲殻。\n可動範囲が大きい。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330351",
 		"jp_text": "グウォンダのひれ刀",
 		"tr_text": "Gu Wonda Sword Fin",
 		"jp_explain": "グウォンダの右腕のひれ刀。\n伸縮幅が大きく、間合いが広い。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "グウォンダの右腕のひれ刀。\n伸縮幅が大きく、間合いが広い。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "グウォンダの右腕のひれ刀。\n伸縮幅が大きく、間合いが広い。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330352",
 		"jp_text": "クラバーダの牙",
 		"tr_text": "Krabahda Fangs",
 		"jp_explain": "クラバーダの大口に生える牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "クラバーダの大口に生える牙。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "クラバーダの大口に生える牙。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330353",
 		"jp_text": "キュクロナーダの尻尾片",
 		"tr_text": "Kuklonahda Tail Piece",
 		"jp_explain": "キュクロナーダの尻尾の欠片。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "キュクロナーダの尻尾の欠片。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "キュクロナーダの尻尾の欠片。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330354",
 		"jp_text": "サイクロネーダの星球片",
 		"tr_text": "Cyclonehda Spherical Piece",
 		"jp_explain": "サイクロネーダの右腕にある\n星球状部位の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "サイクロネーダの右腕にある\n星球状部位の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "サイクロネーダの右腕にある\n星球状部位の欠片。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330355",
@@ -2601,21 +2601,21 @@
 		"jp_text": "ディガーラの爪",
 		"tr_text": "Deegalla Claws",
 		"jp_explain": "ディガーラから採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Claws taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330383",
 		"jp_text": "ソル・ディガーラの爪",
 		"tr_text": "Sol Deegalla Claws",
 		"jp_explain": "ソル・ディガーラより採れた爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Claws taken from a Sol Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws taken from a Sol Deegalla.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330384",
 		"jp_text": "ペンドランの尻尾片",
 		"tr_text": "Pendran Tail Piece",
 		"jp_explain": "ペンドランから採れた\n尻尾の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ペンドランから採れた\n尻尾の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ペンドランから採れた\n尻尾の欠片。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330385",
@@ -2706,7 +2706,7 @@
 		"jp_text": "ウォパル観測素子ａ",
 		"tr_text": "Wopal Observation Device a",
 		"jp_explain": "アークスが、惑星ウォパルの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330399",
@@ -2769,21 +2769,21 @@
 		"jp_text": "トルボンの殻",
 		"tr_text": "Torbon Shell",
 		"jp_explain": "トルボンの殻の破片。\n条件下で発光する珍しい素材。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "トルボンの殻の破片。\n条件下で発光する珍しい素材。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "トルボンの殻の破片。\n条件下で発光する珍しい素材。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330410",
 		"jp_text": "セグレズンの帯電皮",
 		"tr_text": "Seglez'n Electric Hide",
 		"jp_explain": "セグレズンの皮膚。\n帯電性と伸縮性が高い素材。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "セグレズンの皮膚。\n帯電性と伸縮性が高い素材。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "セグレズンの皮膚。\n帯電性と伸縮性が高い素材。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330411",
 		"jp_text": "ブルメッタの尻尾",
 		"tr_text": "Blumetta Tail",
 		"jp_explain": "ブルメッタの尻尾。\n毒をもった小さい種が含まれている。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブルメッタの尻尾。\n毒をもった小さい種が含まれている。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブルメッタの尻尾。\n毒をもった小さい種が含まれている。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330412",
@@ -2811,21 +2811,21 @@
 		"jp_text": "バトラガンの脚部装甲",
 		"tr_text": "Batra Gun Leg Armor",
 		"jp_explain": "脚部を覆う分厚い装甲。\n背後からの攻撃を防ぐ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "脚部を覆う分厚い装甲。\n背後からの攻撃を防ぐ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "脚部を覆う分厚い装甲。\n背後からの攻撃を防ぐ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330416",
 		"jp_text": "カストガーディナンの電銃",
 		"tr_text": "Cust. Guardinane Spark Gun",
 		"jp_explain": "カストガーディナンに搭載された\n強力なスタン銃。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "カストガーディナンに搭載された\n強力なスタン銃。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "カストガーディナンに搭載された\n強力なスタン銃。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330417",
 		"jp_text": "ガノンバルガーの大砲",
 		"tr_text": "Ganon Vargr Cannons",
 		"jp_explain": "ガノンバルガーに搭載された\nツインの大砲。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガノンバルガーに搭載された\nツインの大砲。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガノンバルガーに搭載された\nツインの大砲。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330418",
@@ -3063,210 +3063,210 @@
 		"jp_text": "ウーダンの牙",
 		"tr_text": "Oodan Fang",
 		"jp_explain": "鋭く尖ったウーダンの牙。\n取り扱いには注意が必要。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "The sharp, pointed fang of an Oodan.\nHandle with care.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "The sharp, pointed fang of an Oodan.\nHandle with care.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330452",
 		"jp_text": "フォンガルフの毛皮",
 		"tr_text": "Fangulf Pelt",
 		"jp_explain": "ごわごわしたフォンガルフの毛皮。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ごわごわしたフォンガルフの毛皮。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ごわごわしたフォンガルフの毛皮。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330453",
 		"jp_text": "ガロンゴの歯",
 		"tr_text": "Garongo Tooth",
 		"jp_explain": "すりつぶすのに適したガロンゴの歯。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "すりつぶすのに適したガロンゴの歯。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "すりつぶすのに適したガロンゴの歯。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330454",
 		"jp_text": "ディッグの灼熱角",
 		"tr_text": "Scorching Hot Digg Horn",
 		"jp_explain": "高熱を帯びたディッグの角。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "高熱を帯びたディッグの角。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "高熱を帯びたディッグの角。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330455",
 		"jp_text": "シル・ディーニアンのひれ",
 		"tr_text": "Sil Dinian Flipper",
 		"jp_explain": "頭頂から背まで続いている\nシル・ディーニアンのひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "頭頂から背まで続いている\nシル・ディーニアンのひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "頭頂から背まで続いている\nシル・ディーニアンのひれ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330456",
 		"jp_text": "フォードランの硬いたてがみ",
 		"tr_text": "Fordoran Tough Mane",
 		"jp_explain": "鋼のように硬い\n フォードランのたてがみ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "鋼のように硬い\n フォードランのたてがみ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "鋼のように硬い\n フォードランのたてがみ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330457",
 		"jp_text": "スパルガンのパーツｋ",
 		"tr_text": "Spargun Parts k",
 		"jp_explain": "スパルガンを構成するパーツ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "One of the parts that make up a\nSpargun.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "One of the parts that make up a\nSpargun.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330458",
 		"jp_text": "シグノガンの脚部",
 		"tr_text": "Signo Gun Leg",
 		"jp_explain": "どんな地形でも大砲が撃てる\nバランスの良い二足脚部。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "どんな地形でも大砲が撃てる\nバランスの良い二足脚部。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "どんな地形でも大砲が撃てる\nバランスの良い二足脚部。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330459",
 		"jp_text": "ブリアーダの強靭なかぎ爪",
 		"tr_text": "Breeahda Hard Claws",
 		"jp_explain": "ブリアーダの中でも強力な個体から\n採取した強靭なかぎ爪。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブリアーダの中でも強力な個体から\n採取した強靭なかぎ爪。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブリアーダの中でも強力な個体から\n採取した強靭なかぎ爪。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330460",
 		"jp_text": "ガルフルの強靭な爪",
 		"tr_text": "Gulfur Hard Claw",
 		"jp_explain": "硬い氷もなんなく穿ってみせる\n分厚く強靭な爪。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "硬い氷もなんなく穿ってみせる\n分厚く強靭な爪。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "硬い氷もなんなく穿ってみせる\n分厚く強靭な爪。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330461",
 		"jp_text": "マルモスの肩こぶ",
 		"tr_text": "Malmoth Shoulder Lump",
 		"jp_explain": "硬く分厚い氷壁をも破壊する\nマルモスの肩にある、こぶ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "硬く分厚い氷壁をも破壊する\nマルモスの肩にある、こぶ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "硬く分厚い氷壁をも破壊する\nマルモスの肩にある、こぶ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330462",
 		"jp_text": "キングイエーデの拳骨",
 		"tr_text": "King Yede Fist",
 		"jp_explain": "砕けないものはないと言われる\nキングイエーデの巨大な拳骨。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "砕けないものはないと言われる\nキングイエーデの巨大な拳骨。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "砕けないものはないと言われる\nキングイエーデの巨大な拳骨。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330463",
 		"jp_text": "ガーディンのレンズ",
 		"tr_text": "Guardine Lens",
 		"jp_explain": "ガーディンの内蔵カメラのレンズ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガーディンの内蔵カメラのレンズ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガーディンの内蔵カメラのレンズ。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330464",
 		"jp_text": "シグノビートの左腕",
 		"tr_text": "Signo Beat Left Arm",
 		"jp_explain": "シグノビートの左腕。\n万力のような力をもつ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "シグノビートの左腕。\n万力のような力をもつ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "シグノビートの左腕。\n万力のような力をもつ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330465",
 		"jp_text": "ギルナッチの脚部",
 		"tr_text": "Gilnach Leg",
 		"jp_explain": "ギルナッチを構成する脚部のパーツ。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ギルナッチを構成する脚部のパーツ。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ギルナッチを構成する脚部のパーツ。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330466",
 		"jp_text": "シル・サディニアンのひれ",
 		"tr_text": "Sil Sadinian Flipper",
 		"jp_explain": "頭頂から背まで続いている\nシル・サディニアンのひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "頭頂から背まで続いている\nシル・サディニアンのひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "頭頂から背まで続いている\nシル・サディニアンのひれ。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330467",
 		"jp_text": "バリドランのあご",
 		"tr_text": "Baridran Chin",
 		"jp_explain": "一度かぶりついたら離れない\nバリドランのあご。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "一度かぶりついたら離れない\nバリドランのあご。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "一度かぶりついたら離れない\nバリドランのあご。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330468",
 		"jp_text": "ウィンディラの翼膜",
 		"tr_text": "Windira Wings",
 		"jp_explain": "ウィンディラの翼から採れた翼膜。\n薄くて軽量ながら、伸縮性に優れる。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウィンディラの翼から採れた翼膜。\n薄くて軽量ながら、伸縮性に優れる。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ウィンディラの翼から採れた翼膜。\n薄くて軽量ながら、伸縮性に優れる。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330469",
 		"jp_text": "ミクダの上質な紋様殻",
 		"tr_text": "Perfect Micda Husk",
 		"jp_explain": "個性的な柄をもつミクダの甲羅。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "個性的な柄をもつミクダの甲羅。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "個性的な柄をもつミクダの甲羅。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330470",
 		"jp_text": "ガウォンダのひれ刀",
 		"tr_text": "Ga Wonda Blade",
 		"jp_explain": "ガウォンダの左腕のひれ刀。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガウォンダの左腕のひれ刀。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ガウォンダの左腕のひれ刀。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330471",
 		"jp_text": "キュクロナーダの武器片",
 		"tr_text": "Kuklonahda Arm Weapon",
 		"jp_explain": "キュクロナーダが振り回していた\n武器の破片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "キュクロナーダが振り回していた\n武器の破片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "キュクロナーダが振り回していた\n武器の破片。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330472",
 		"jp_text": "ディガーラの皮",
 		"tr_text": "Deegalla Hide",
 		"jp_explain": "ディガーラから採れた皮。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Hide taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Hide taken from a Deegalla.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330473",
 		"jp_text": "ペンドランの爪",
 		"tr_text": "Pendran Claw",
 		"jp_explain": "細長く鋭いペンドランの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "細長く鋭いペンドランの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "細長く鋭いペンドランの爪。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330474",
 		"jp_text": "ディランダールの一角",
 		"tr_text": "Dirandal Horn",
 		"jp_explain": "ディランダールの\n頭頂部に生えた水晶角。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ディランダールの\n頭頂部に生えた水晶角。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ディランダールの\n頭頂部に生えた水晶角。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330475",
 		"jp_text": "セグレズンのサンゴ",
 		"tr_text": "Seglez'n Coral",
 		"jp_explain": "セグレズンの放電現象の元となる部位。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "セグレズンの放電現象の元となる部位。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "セグレズンの放電現象の元となる部位。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330476",
 		"jp_text": "ブルメガーラの爪",
 		"tr_text": "Blumegalla Claw",
 		"jp_explain": "ブルメガーラから採れた爪。\n少量だが毒性がある。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブルメガーラから採れた爪。\n少量だが毒性がある。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ブルメガーラから採れた爪。\n少量だが毒性がある。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330477",
 		"jp_text": "オルグブランの爪",
 		"tr_text": "Org Blan Claw",
 		"jp_explain": "岩をも引き裂くオルグブランの爪。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "岩をも引き裂くオルグブランの爪。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "岩をも引き裂くオルグブランの爪。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330478",
 		"jp_text": "カストキンディッドの装甲",
 		"tr_text": "Custom Kindidd Armor",
 		"jp_explain": "攻撃時のみ開口する\nカストキンディッドの装甲。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "攻撃時のみ開口する\nカストキンディッドの装甲。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "攻撃時のみ開口する\nカストキンディッドの装甲。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330479",
 		"jp_text": "ヴィントバルガーの装甲翼",
 		"tr_text": "Vinto Vargr Armored Wing",
 		"jp_explain": "ヴィントバルガーのもつ装甲翼。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ヴィントバルガーのもつ装甲翼。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ヴィントバルガーのもつ装甲翼。\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330480",
 		"jp_text": "ヤクトディンゲールの右腕",
 		"tr_text": "Jagd Dingell's Right Arm",
 		"jp_explain": "ヒートブレードを振り回す\nヤクトディンゲールの右腕。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ヒートブレードを振り回す\nヤクトディンゲールの右腕。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "ヒートブレードを振り回す\nヤクトディンゲールの右腕。\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330514",
@@ -3308,49 +3308,49 @@
 		"jp_text": "セヴァニアンの鱗",
 		"tr_text": "Sevanian Scales",
 		"jp_explain": "セヴァニアンの全身をおおう鱗。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Scales that covered the body of a\nSevanian.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Scales that covered the body of a\nSevanian.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330520",
 		"jp_text": "ファルカボネの角片",
 		"tr_text": "Falcabone Horn Piece",
 		"jp_explain": "ファルカボネの頭部にある角の破片。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "A fragment of the horn on the head\nof a Falcabone.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A fragment of the horn on the head\nof a Falcabone.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330521",
 		"jp_text": "タロベッコの腕角",
 		"tr_text": "Talobecko Arm Horn",
 		"jp_explain": "タロベッコの腕部にある角状の突起。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "A horn-like protrusion taken from the\narm of a Talobecko.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A horn-like protrusion taken from the\narm of a Talobecko.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330522",
 		"jp_text": "ブルトルボンの殻の欠片",
 		"tr_text": "Blutorbon Shell Fragment",
 		"jp_explain": "ブルトルボンの殻の上部を占める\n突起状の部分の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "A fragment of one of the spikes on\ntop of a Blutorbon's shell.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A fragment of one of the spikes on\ntop of a Blutorbon's shell.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330523",
 		"jp_text": "タグ・セヴァニアンのひれ",
 		"tr_text": "Tag Sevanian Fins",
 		"jp_explain": "タグ・セヴァニアンの頭部に\nはえているひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Fins taken from the head of a\nTag Sevanian.\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fins taken from the head of a\nTag Sevanian.\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330524",
 		"jp_text": "タグ・アクルプスの牙",
 		"tr_text": "Tag Aqulupus Fangs",
 		"jp_explain": "タグ・アクルプスから採れた牙。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "Fangs taken from a Tag Aqulupus.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fangs taken from a Tag Aqulupus.\n\nClient: <c a1ff6d>Farma<c> (non-repeatable)"
 	},
 	{
 		"assign": "330525",
 		"jp_text": "ウォパル観測素子ｂ",
 		"tr_text": "Wopal Observation Device b",
 		"jp_explain": "アークスが、惑星ウォパルの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330526",
@@ -3651,7 +3651,7 @@
 		"jp_text": "海王種の霜降り肉",
 		"tr_text": "Oceanid Marbled Meat",
 		"jp_explain": "海王種から採れる脂肪が細かく\n入った美味しい肉。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": "Delicious meat marbled with fat,\ntaken from an Oceanid.\nClient: <c a1ff6d>Toro<c> (one-time order)"
+		"tr_explain": "Delicious meat marbled with fat,\ntaken from an Oceanid.\nClient: <c a1ff6d>Toro<c> (non-repeatable)"
 	},
 	{
 		"assign": "330579",
@@ -3973,28 +3973,28 @@
 		"jp_text": "ハルコタン観測素子ａ",
 		"tr_text": "Harkotan Observation Dev. a",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330627",
 		"jp_text": "破損したダーカーコアｅ",
 		"tr_text": "Damaged Darker Core e",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や法撃によって破損している。\n依頼者：<c a1ff6d>カトリ<c>　再受注不可",
-		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or a Technique.\nClient: <c a1ff6d>Katori<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or a Technique.\nClient: <c a1ff6d>Katori<c> (non-repeatable)"
 	},
 	{
 		"assign": "330628",
 		"jp_text": "破損したダーカーコアｄ",
 		"tr_text": "Corrupted Darker Core d",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や射撃によって破損している。\n依頼者：<c a1ff6d>アザナミ<c>　再受注不可",
-		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or shooting.\nClient: <c a1ff6d>Azanami<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or shooting.\nClient: <c a1ff6d>Azanami<c> (non-repeatable)"
 	},
 	{
 		"assign": "330629",
 		"jp_text": "ウォパル観測素子ｃ",
 		"tr_text": "Wopal Observation Device c",
 		"jp_explain": "アークスが、惑星ウォパルの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Wopal to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330630",
@@ -4365,7 +4365,7 @@
 		"jp_text": "ハルコタン観測素子ｂ",
 		"tr_text": "Harkotan Observation Dev. b",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (non-repeatable)"
 	},
 	{
 		"assign": "330689",
@@ -4687,7 +4687,7 @@
 		"jp_text": "目覚めの花",
 		"tr_text": "Awakening Flower",
 		"jp_explain": "薬効があるとされる希少な花。\nその香りには気付け作用もあるらしい。\n依頼者：<c a1ff6d>アネット<c>　再受注不可",
-		"tr_explain": "A rare flower said to be medicinal.\nIts scent has a restorative effect.\nClient: <c a1ff6d>Annette<c> (one-time order)"
+		"tr_explain": "A rare flower said to be medicinal.\nIts scent has a restorative effect.\nClient: <c a1ff6d>Annette<c> (non-repeatable)"
 	},
 	{
 		"assign": "330738",
@@ -4701,21 +4701,21 @@
 		"jp_text": "瑠璃色の小さな花",
 		"tr_text": "Small Azure Flower",
 		"jp_explain": "瑠璃色の花弁を持つ小さな花。\n爽やかな香りがする。\n依頼者：<c a1ff6d>イツキ<c>　再受注不可",
-		"tr_explain": "A small flower with lapis-colored\npetals. It has a refreshing scent.\nClient: <c a1ff6d>Itsuki<c> (one-time order)"
+		"tr_explain": "A small flower with lapis-colored\npetals. It has a refreshing scent.\nClient: <c a1ff6d>Itsuki<c> (non-repeatable)"
 	},
 	{
 		"assign": "330740",
 		"jp_text": "漆黒のサンゴ",
 		"tr_text": "Jet Black Coral",
 		"jp_explain": "浮遊大陸で成長したサンゴ。\n艶めく黒色が目をひく。\n依頼者：<c a1ff6d>†コア†<c>　再受注不可",
-		"tr_explain": "Coral that grows on the Skyscape. Its\nglossy black color catches the eye.\nClient: <c a1ff6d>†Coa†<c> (one-time order)"
+		"tr_explain": "Coral that grows on the Skyscape. Its\nglossy black color catches the eye.\nClient: <c a1ff6d>†Coa†<c> (non-repeatable)"
 	},
 	{
 		"assign": "330741",
 		"jp_text": "浮遊大陸の白色粘土",
 		"tr_text": "Skyscape White Clay",
 		"jp_explain": "浮遊大陸でとれる粘土。焼成して磨くと\n銀細工のような光沢を帯びる。\n依頼者：<c a1ff6d>ムサシ<c>　再受注不可",
-		"tr_explain": "Clay from the Skyscape. When fired\nand polished, it shines like silver.\nClient: <c a1ff6d>Musashi<c> (one-time order)"
+		"tr_explain": "Clay from the Skyscape. When fired\nand polished, it shines like silver.\nClient: <c a1ff6d>Musashi<c> (non-repeatable)"
 	},
 	{
 		"assign": "330742",

--- a/json/Item_Stack_Orderitem.txt
+++ b/json/Item_Stack_Orderitem.txt
@@ -746,21 +746,21 @@
 		"jp_text": "破損したダーカーコアａ",
 		"tr_text": "Damaged Darker Core a",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や衝撃によって破損している。\n依頼者：<c a1ff6d>オーザ<c>　再受注不可",
-		"tr_explain": "ダーカーから採取されたコア。\n斬撃や衝撃によって破損している。\nClient: <c a1ff6d>Ohza<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a slashing weapon.\nClient: <c a1ff6d>Ohza<c> (one-time order)"
 	},
 	{
 		"assign": "330107",
 		"jp_text": "破損したダーカーコアｂ",
 		"tr_text": "Damaged Darker Core b",
 		"jp_explain": "ダーカーから採取されたコア。\n銃撃や砲撃によって破損している。\n依頼者：<c a1ff6d>リサ<c>　再受注不可",
-		"tr_explain": "ダーカーから採取されたコア。\n銃撃や砲撃によって破損している。\nClient: <c a1ff6d>Lisa<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by gunfire or shrapnel.\nClient: <c a1ff6d>Lisa<c> (one-time order)"
 	},
 	{
 		"assign": "330108",
 		"jp_text": "破損したダーカーコアｃ",
 		"tr_text": "Damaged Darker Core c",
 		"jp_explain": "ダーカーから採取されたコア。\n法撃や打撃によって破損している。\n依頼者：<c a1ff6d>マールー<c>　再受注不可",
-		"tr_explain": "ダーカーから採取されたコア。\n法撃や打撃によって破損している。\nClient: <c a1ff6d>Marlu<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by a Technique.\nClient: <c a1ff6d>Marlu<c> (one-time order)"
 	},
 	{
 		"assign": "330109",
@@ -984,14 +984,14 @@
 		"jp_text": "アギニスの小爪",
 		"tr_text": "Aginis Wing Claw",
 		"jp_explain": "アギニスの翼から生える爪。\nあまり役に立っていない。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "アギニスの翼から生える爪。\nあまり役に立っていない。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A claw that grows on the wing of an\nAginis. Not particularly useful.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330141",
 		"jp_text": "アギニスの鋭いくちばし",
 		"tr_text": "Aginis Sharp Beak",
 		"jp_explain": "アギニスのくちばし。\n鋭く獲物を攻撃する。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "アギニスのくちばし。\n鋭く獲物を攻撃する。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "The beak of an Aginis. The sharp\npoint is used to attack prey.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330142",
@@ -1003,23 +1003,23 @@
 	{
 		"assign": "330143",
 		"jp_text": "ウーダンの角",
-		"tr_text": "Oodan Horns",
+		"tr_text": "Oodan Horn",
 		"jp_explain": "ウーダンの頭に生える角。\n攻撃的な曲線を描く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウーダンの頭に生える角。\n攻撃的な曲線を描く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A horn from the head of an Oodan.\nIt has an aggressive-looking curve.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330144",
 		"jp_text": "ウーダンの爪",
-		"tr_text": "Woodan Nails",
+		"tr_text": "Oodan Claws",
 		"jp_explain": "ウーダンの爪。\nひっかいたり、地面を掴むのに使う。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウーダンの爪。\nひっかいたり、地面を掴むのに使う。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from an Oodan. Used to scratch\nand to grip the ground.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330145",
 		"jp_text": "ウーダンの鋭い爪",
 		"tr_text": "Oodan Sharp Claws",
 		"jp_explain": "ウーダンの爪。\nひっかかれると痛そう。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ウーダンの爪。\nひっかかれると痛そう。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from an Oodan. A scratch from\none is painful.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330146",
@@ -1033,19 +1033,19 @@
 		"jp_text": "ガルフの鋭い牙",
 		"tr_text": "Gulf Sharp Fangs",
 		"jp_explain": "ガルフの牙。\nかみつき攻撃に注意。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガルフの牙。\nかみつき攻撃に注意。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fangs from a Gulf.\nBeware their biting attack.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330148",
 		"jp_text": "ガルフの鋭い爪",
 		"tr_text": "Gulf Sharp Claws",
 		"jp_explain": "ガルフの爪。\n飛びかかりながらのひっかきは脅威。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ガルフの爪。\n飛びかかりながらのひっかきは脅威。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Claws from a Gulf. Their jumping\nscratch attack is dangerous.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330149",
 		"jp_text": "ガロンゴの足",
-		"tr_text": "Garongo Legs",
+		"tr_text": "Garongo Leg",
 		"jp_explain": "ガロンゴの足。\n意外と小回りが利く。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
 		"tr_explain": "ガロンゴの足。\n意外と小回りが利く。\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
@@ -3308,35 +3308,35 @@
 		"jp_text": "セヴァニアンの鱗",
 		"tr_text": "Sevanian Scales",
 		"jp_explain": "セヴァニアンの全身をおおう鱗。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "セヴァニアンの全身をおおう鱗。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Scales that covered the body of a\nSevanian.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330520",
 		"jp_text": "ファルカボネの角片",
-		"tr_text": "Falcabone Piece",
+		"tr_text": "Falcabone Horn Piece",
 		"jp_explain": "ファルカボネの頭部にある角の破片。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ファルカボネの頭部にある角の破片。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A fragment of the horn on the head\nof a Falcabone.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330521",
 		"jp_text": "タロベッコの腕角",
-		"tr_text": "Talobecko Arm",
+		"tr_text": "Talobecko Arm Horn",
 		"jp_explain": "タロベッコの腕部にある角状の突起。\n\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "タロベッコの腕部にある角状の突起。\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A horn-like protrusion taken from the\narm of a Talobecko.\n\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330522",
 		"jp_text": "ブルトルボンの殻の欠片",
-		"tr_text": "Blutorbon Piece",
+		"tr_text": "Blutorbon Shell Fragment",
 		"jp_explain": "ブルトルボンの殻の上部を占める\n突起状の部分の欠片。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "ブルトルボンの殻の上部を占める\n突起状の部分の欠片。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "A fragment of one of the spikes on\ntop of a Blutorbon's shell.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330523",
 		"jp_text": "タグ・セヴァニアンのひれ",
 		"tr_text": "Tag Sevanian Fins",
 		"jp_explain": "タグ・セヴァニアンの頭部に\nはえているひれ。\n依頼者：<c a1ff6d>ファーマ<c>　再受注不可",
-		"tr_explain": "タグ・セヴァニアンの頭部に\nはえているひれ。\nClient: <c a1ff6d>Farma<c> (one-time order)"
+		"tr_explain": "Fins taken from the head of a\nTag Sevanian.\nClient: <c a1ff6d>Farma<c> (one-time order)"
 	},
 	{
 		"assign": "330524",
@@ -3649,9 +3649,9 @@
 	{
 		"assign": "330578",
 		"jp_text": "海王種の霜降り肉",
-		"tr_text": "Sea King Marbled Meat",
+		"tr_text": "Oceanid Marbled Meat",
 		"jp_explain": "海王種から採れる脂肪が細かく\n入った美味しい肉。\n依頼者：<c a1ff6d>トロ<c>　再受注不可",
-		"tr_explain": "海王種から採れる脂肪が細かく\n入った美味しい肉。\nClient: <c a1ff6d>Toro<c> (one-time order)"
+		"tr_explain": "Delicious meat marbled with fat,\ntaken from an Oceanid.\nClient: <c a1ff6d>Toro<c> (one-time order)"
 	},
 	{
 		"assign": "330579",
@@ -3973,21 +3973,21 @@
 		"jp_text": "ハルコタン観測素子ａ",
 		"tr_text": "Harkotan Observation Dev. a",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "330627",
 		"jp_text": "破損したダーカーコアｅ",
 		"tr_text": "Damaged Darker Core e",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や法撃によって破損している。\n依頼者：<c a1ff6d>カトリ<c>　再受注不可",
-		"tr_explain": "ダーカーから採取されたコア。\n斬撃や法撃によって破損している。\nClient: <c a1ff6d>Katori<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or a Technique.\nClient: <c a1ff6d>Katori<c> (one-time order)"
 	},
 	{
 		"assign": "330628",
 		"jp_text": "破損したダーカーコアｄ",
 		"tr_text": "Corrupted Darker Core d",
 		"jp_explain": "ダーカーから採取されたコア。\n斬撃や射撃によって破損している。\n依頼者：<c a1ff6d>アザナミ<c>　再受注不可",
-		"tr_explain": "ダーカーから採取されたコア。\n斬撃や射撃によって破損している。\nClient: <c a1ff6d>Azanami<c> (one-time order)"
+		"tr_explain": "Core taken from a Darker. Has been\ndamaged by slashing or shooting.\nClient: <c a1ff6d>Azanami<c> (one-time order)"
 	},
 	{
 		"assign": "330629",
@@ -4365,7 +4365,7 @@
 		"jp_text": "ハルコタン観測素子ｂ",
 		"tr_text": "Harkotan Observation Dev. b",
 		"jp_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\n依頼者：<c a1ff6d>コフィー<c>　再受注不可",
-		"tr_explain": "アークスが、惑星ハルコタンの\n観測のためにばらまいている素子。\nClient: <c a1ff6d>Koffie<c> (one-time order)"
+		"tr_explain": "One of many devices distributed\nacross Harkotan to gather data.\nClient: <c a1ff6d>Koffie<c> (one-time order)"
 	},
 	{
 		"assign": "330689",
@@ -4615,9 +4615,9 @@
 	{
 		"assign": "330727",
 		"jp_text": "きれいな貝殻",
-		"tr_text": "Beautiful Shells",
+		"tr_text": "Beautiful Shell",
 		"jp_explain": "きらきら光るきれいな貝殻。\nちょっとしたプレゼントに喜ばれそう。\n依頼者：<c a1ff6d>ジェネ<c>　再受注可能",
-		"tr_explain": "きらきら光るきれいな貝殻。\nちょっとしたプレゼントに喜ばれそう。\nClient: <c a1ff6d>Gene<c> (repeatable)"
+		"tr_explain": "A beautiful, glittering seashell. Even\na small gift can be appreciated.\nClient: <c a1ff6d>Gene<c> (repeatable)"
 	},
 	{
 		"assign": "330728",
@@ -4685,9 +4685,9 @@
 	{
 		"assign": "330737",
 		"jp_text": "目覚めの花",
-		"tr_text": "Awakening Flowers",
+		"tr_text": "Awakening Flower",
 		"jp_explain": "薬効があるとされる希少な花。\nその香りには気付け作用もあるらしい。\n依頼者：<c a1ff6d>アネット<c>　再受注不可",
-		"tr_explain": "薬効があるとされる希少な花。\nその香りには気付け作用もあるらしい。\nClient: <c a1ff6d>Annette<c> (one-time order)"
+		"tr_explain": "A rare flower said to be medicinal.\nIts scent has a restorative effect.\nClient: <c a1ff6d>Annette<c> (one-time order)"
 	},
 	{
 		"assign": "330738",
@@ -4699,23 +4699,23 @@
 	{
 		"assign": "330739",
 		"jp_text": "瑠璃色の小さな花",
-		"tr_text": "Small Azure Flowers",
+		"tr_text": "Small Azure Flower",
 		"jp_explain": "瑠璃色の花弁を持つ小さな花。\n爽やかな香りがする。\n依頼者：<c a1ff6d>イツキ<c>　再受注不可",
-		"tr_explain": "瑠璃色の花弁を持つ小さな花。\n爽やかな香りがする。\nClient: <c a1ff6d>Itsuki<c> (one-time order)"
+		"tr_explain": "A small flower with lapis-colored\npetals. It has a refreshing scent.\nClient: <c a1ff6d>Itsuki<c> (one-time order)"
 	},
 	{
 		"assign": "330740",
 		"jp_text": "漆黒のサンゴ",
 		"tr_text": "Jet Black Coral",
 		"jp_explain": "浮遊大陸で成長したサンゴ。\n艶めく黒色が目をひく。\n依頼者：<c a1ff6d>†コア†<c>　再受注不可",
-		"tr_explain": "浮遊大陸で成長したサンゴ。\n艶めく黒色が目をひく。\nClient: <c a1ff6d>†Coa†<c> (one-time order)"
+		"tr_explain": "Coral that grows on the Skyscape. Its\nglossy black color catches the eye.\nClient: <c a1ff6d>†Coa†<c> (one-time order)"
 	},
 	{
 		"assign": "330741",
 		"jp_text": "浮遊大陸の白色粘土",
 		"tr_text": "Skyscape White Clay",
 		"jp_explain": "浮遊大陸でとれる粘土。焼成して磨くと\n銀細工のような光沢を帯びる。\n依頼者：<c a1ff6d>ムサシ<c>　再受注不可",
-		"tr_explain": "浮遊大陸でとれる粘土。焼成して磨くと\n銀細工のような光沢を帯びる。\nClient: <c a1ff6d>Musashi<c> (one-time order)"
+		"tr_explain": "Clay from the Skyscape. When fired\nand polished, it shines like silver.\nClient: <c a1ff6d>Musashi<c> (one-time order)"
 	},
 	{
 		"assign": "330742",

--- a/json/Name_Chip_AbilityEffectExplain.txt
+++ b/json/Name_Chip_AbilityEffectExplain.txt
@@ -57,7 +57,7 @@
 	{
 		"assign": "12",
 		"jp_text": "ＣＰ消費量ダウン",
-		"tr_text": "CP Usage Down"
+		"tr_text": "CP Consumption Down"
 	},
 	{
 		"assign": "13",
@@ -282,7 +282,7 @@
 	{
 		"assign": "57",
 		"jp_text": "ＣＰ増加量アップ",
-		"tr_text": "CP Usage Down"
+		"tr_text": "CP Increase Up"
 	},
 	{
 		"assign": "58",
@@ -292,7 +292,7 @@
 	{
 		"assign": "59",
 		"jp_text": "ＣＰ消費量ダウン",
-		"tr_text": "CP Usage Down"
+		"tr_text": "CP Consumption Down"
 	},
 	{
 		"assign": "60",

--- a/json/Name_Chip_AbilityEffectExplain.txt
+++ b/json/Name_Chip_AbilityEffectExplain.txt
@@ -607,7 +607,7 @@
 	{
 		"assign": "123",
 		"jp_text": "回復量アップ／ダメージ量アップ",
-		"tr_text": "recovery up/Damage boost up"
+		"tr_text": "Recovery up/Damage boost up"
 	},
 	{
 		"assign": "124",

--- a/json/Name_Chip_AbilityEffectExplain.txt
+++ b/json/Name_Chip_AbilityEffectExplain.txt
@@ -2,142 +2,142 @@
 	{
 		"assign": "1",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "2",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "3",
 		"jp_text": "パラメータ変動量アップ",
-		"tr_text": "Parameter Change Up"
+		"tr_text": "Parameter change up"
 	},
 	{
 		"assign": "4",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "5",
 		"jp_text": "属性強化値アップ",
-		"tr_text": "Element Boost Up"
+		"tr_text": "Element boost up"
 	},
 	{
 		"assign": "6",
 		"jp_text": "属性強化値アップ",
-		"tr_text": "Element Boost Up"
+		"tr_text": "Element boost up"
 	},
 	{
 		"assign": "7",
 		"jp_text": "属性強化値アップ",
-		"tr_text": "Element Boost Up"
+		"tr_text": "Element boost up"
 	},
 	{
 		"assign": "8",
 		"jp_text": "ＨＰ回復量アップ",
-		"tr_text": "HP Recovery Up"
+		"tr_text": "HP recovery up"
 	},
 	{
 		"assign": "9",
 		"jp_text": "ＣＰ回復量アップ",
-		"tr_text": "CP Recovery Up"
+		"tr_text": "CP recovery up"
 	},
 	{
 		"assign": "10",
 		"jp_text": "ＨＰ回復量アップ",
-		"tr_text": "HP Recovery Up"
+		"tr_text": "HP recovery up"
 	},
 	{
 		"assign": "11",
 		"jp_text": "ＨＰ回復量アップ",
-		"tr_text": "HP Recovery Up"
+		"tr_text": "HP recovery up"
 	},
 	{
 		"assign": "12",
 		"jp_text": "ＣＰ消費量ダウン",
-		"tr_text": "CP Consumption Down"
+		"tr_text": "CP consumption down"
 	},
 	{
 		"assign": "13",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "14",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "15",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "16",
 		"jp_text": "ダメージ量／攻撃数／状態異常率アップ",
-		"tr_text": "Damage Boost Up/ATK/Status Up"
+		"tr_text": "Damage boost/ATK/Status rate up"
 	},
 	{
 		"assign": "17",
 		"jp_text": "ダメージ／弱体化効果時間アップ",
-		"tr_text": "Damage/Weakness Timer Up"
+		"tr_text": "Damage/Weakness timer up"
 	},
 	{
 		"assign": "18",
 		"jp_text": "弱点ヒット時ダメージ量アップ",
-		"tr_text": "Weak Point Damage Boost Up"
+		"tr_text": "Weak point damage boost up"
 	},
 	{
 		"assign": "19",
 		"jp_text": "状態異常付与率アップ",
-		"tr_text": "Status Infliction Rate Up"
+		"tr_text": "Status infliction rate up"
 	},
 	{
 		"assign": "20",
 		"jp_text": "状態異常付与率／パラメータ上昇量増加",
-		"tr_text": "Status Rate/Parameter Increase Up"
+		"tr_text": "Status rate/Parameter increase up"
 	},
 	{
 		"assign": "21",
 		"jp_text": "ＨＰ回復量アップ",
-		"tr_text": "HP Recovery Up"
+		"tr_text": "HP recovery up"
 	},
 	{
 		"assign": "22",
 		"jp_text": "クリティカル発生率アップ",
-		"tr_text": "Critical Rate Up"
+		"tr_text": "Critical rate up"
 	},
 	{
 		"assign": "23",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "24",
 		"jp_text": "よろけやすさアップ",
-		"tr_text": "Stagger Up"
+		"tr_text": "Stagger up"
 	},
 	{
 		"assign": "25",
 		"jp_text": "被ダメージ量ダウン",
-		"tr_text": "Target Damage Down"
+		"tr_text": "Target damage down"
 	},
 	{
 		"assign": "26",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "27",
 		"jp_text": "よろけにくさアップ",
-		"tr_text": "Hate Up"
+		"tr_text": "Hate up"
 	},
 	{
 		"assign": "28",
 		"jp_text": "より高いＨＰで発動",
-		"tr_text": "Activates at Higher HP"
+		"tr_text": "Activates at higher HP"
 	},
 	{
 		"assign": "29",
@@ -147,771 +147,771 @@
 	{
 		"assign": "30",
 		"jp_text": "対象の種族に対して攻撃力アップ",
-		"tr_text": "Versus Species Damage Boost Up"
+		"tr_text": "Damage boost vs. species up"
 	},
 	{
 		"assign": "31",
 		"jp_text": "ダメージ量／パラメータ上昇量アップ",
-		"tr_text": "Damage Boost Up/Parameter Increase Up"
+		"tr_text": "Damage boost up/Parameter increase up"
 	},
 	{
 		"assign": "32",
 		"jp_text": "パラメータ上昇量／ＨＰ回復量アップ",
-		"tr_text": "Parameter Increase Up/HP Recovery Up"
+		"tr_text": "Parameter increase up/HP recovery up"
 	},
 	{
 		"assign": "33",
 		"jp_text": "敵へのダメージ量アップ",
-		"tr_text": "Targeted Enemy Weakness Up"
+		"tr_text": "Targeted enemy weakness up"
 	},
 	{
 		"assign": "34",
 		"jp_text": "パラメータ上昇量／属性強化値アップ",
-		"tr_text": "Parameter Increase Up/Element Boost Up"
+		"tr_text": "Parameter increase up/Element boost up"
 	},
 	{
 		"assign": "35",
 		"jp_text": "属性強化値アップ",
-		"tr_text": "Element Boost Up"
+		"tr_text": "Element boost up"
 	},
 	{
 		"assign": "36",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "37",
 		"jp_text": "効果時間アップ",
-		"tr_text": "Effect Time Up"
+		"tr_text": "Effect time up"
 	},
 	{
 		"assign": "38",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "39",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "40",
 		"jp_text": "対象の種族に対して攻撃力アップ",
-		"tr_text": "Versus Species Damage Boost Up"
+		"tr_text": "Versus species damage boost up"
 	},
 	{
 		"assign": "41",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "42",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "43",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "44",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "45",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "46",
 		"jp_text": "ダメージ量／パラメータ上昇量アップ",
-		"tr_text": "Damage Boost Up/Parameter Increase Up"
+		"tr_text": "Damage boost up/Parameter increase up"
 	},
 	{
 		"assign": "47",
 		"jp_text": "ＨＰ／ＣＰ回復量アップ",
-		"tr_text": "HP/CP Recovery Up"
+		"tr_text": "HP/CP recovery up"
 	},
 	{
 		"assign": "48",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "49",
 		"jp_text": "被ダメージ量ダウン／威力アップ",
-		"tr_text": "Damage Taken Down/Power Boost"
+		"tr_text": "Damage taken down/Power up"
 	},
 	{
 		"assign": "50",
 		"jp_text": "ＨＰ回復量アップ",
-		"tr_text": "HP Recovery Up"
+		"tr_text": "HP recovery up"
 	},
 	{
 		"assign": "51",
 		"jp_text": "パラメータ上昇量／属性強化値アップ",
-		"tr_text": "Parameter Increase/Element Boost Up"
+		"tr_text": "Parameter Increase/Element boost up"
 	},
 	{
 		"assign": "52",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "53",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "54",
 		"jp_text": "ダメージ量上限アップ",
-		"tr_text": "Max Damage Boost Up"
+		"tr_text": "Max damage boost up"
 	},
 	{
 		"assign": "55",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "56",
 		"jp_text": "属性強化値アップ",
-		"tr_text": "Element Boost Up"
+		"tr_text": "Element boost up"
 	},
 	{
 		"assign": "57",
 		"jp_text": "ＣＰ増加量アップ",
-		"tr_text": "CP Increase Up"
+		"tr_text": "CP increase up"
 	},
 	{
 		"assign": "58",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "59",
 		"jp_text": "ＣＰ消費量ダウン",
-		"tr_text": "CP Consumption Down"
+		"tr_text": "CP consumption down"
 	},
 	{
 		"assign": "60",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "61",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "62",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "63",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "64",
 		"jp_text": "対象の種族に対して攻撃力アップ",
-		"tr_text": "Versus Species Damage Boost Up"
+		"tr_text": "Versus species damage boost up"
 	},
 	{
 		"assign": "65",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "66",
 		"jp_text": "パラメータ上昇量アップ",
-		"tr_text": "Parameter Increase Up"
+		"tr_text": "Parameter increase up"
 	},
 	{
 		"assign": "67",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "68",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "69",
 		"jp_text": "ＳＰ枠効果なし",
-		"tr_text": "No SP Effect"
+		"tr_text": "No SP effect"
 	},
 	{
 		"assign": "70",
 		"jp_text": "ダメージ量アップ／被ダメージ量ダウン",
-		"tr_text": "Damage Boost Up/Damage Taken Down"
+		"tr_text": "Damage boost up/Damage taken down"
 	},
 	{
 		"assign": "71",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "72",
 		"jp_text": "ダメージ量アップ／ＨＰ回復量アップ",
-		"tr_text": "Damage Boost Up/HP Recovery Up"
+		"tr_text": "Damage boost up/HP recovery up"
 	},
 	{
 		"assign": "73",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "74",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "75",
 		"jp_text": "ダメージ量アップ／ＣＰ消費量ダウン",
-		"tr_text": "Damage Boost Up/CP Usage Down"
+		"tr_text": "Damage boost up/CP usage down"
 	},
 	{
 		"assign": "76",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "77",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "78",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "79",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "80",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "81",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "82",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "83",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "84",
 		"jp_text": "ダメージ量アップ／防御アップ",
-		"tr_text": "Damage Boost Up/HP Recovery Up"
+		"tr_text": "Damage boost up/HP recovery up"
 	},
 	{
 		"assign": "85",
 		"jp_text": "ダメージ量アップ／ＨＰ回復量アップ",
-		"tr_text": "Damage Boost Up/HP Recovery Up"
+		"tr_text": "Damage boost up/HP recovery up"
 	},
 	{
 		"assign": "86",
 		"jp_text": "ダメージ量アップ／ＣＰ回復量アップ",
-		"tr_text": "Damage Boost Up/CP Recovery Up"
+		"tr_text": "Damage boost up/CP recovery up"
 	},
 	{
 		"assign": "87",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "88",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "89",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "90",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "91",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "92",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "93",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "94",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "95",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "96",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "97",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "98",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "99",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "100",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "101",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "102",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "103",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "104",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "105",
 		"jp_text": "ダメージ量アップ／威力アップ",
-		"tr_text": "Damage Boost Up/Power Boost"
+		"tr_text": "Damage boost up/Power up"
 	},
 	{
 		"assign": "106",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "107",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "108",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "109",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "110",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "111",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "112",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "113",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "114",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "115",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "116",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "118",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "119",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "120",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "121",
 		"jp_text": "ダメージ量アップ／威力アップ",
-		"tr_text": "Damage Boost Up/Power Boost"
+		"tr_text": "Damage boost up/Power boost"
 	},
 	{
 		"assign": "122",
 		"jp_text": "ダメージアップ／パラメータ上昇アップ",
-		"tr_text": "Damage Boost Up/Parameters Up"
+		"tr_text": "Damage boost up/Parameters up"
 	},
 	{
 		"assign": "123",
 		"jp_text": "回復量アップ／ダメージ量アップ",
-		"tr_text": "Recovery Up/Damage Boost Up"
+		"tr_text": "recovery up/Damage boost up"
 	},
 	{
 		"assign": "124",
 		"jp_text": "威力アップ／回避率アップ",
-		"tr_text": "Power Boost/Dodge Rate Up"
+		"tr_text": "Power boost/Dodge rate up"
 	},
 	{
 		"assign": "125",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "126",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "127",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "128",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "129",
 		"jp_text": "ダメージ量アップ／ＣＰ回復量アップ",
-		"tr_text": "Damage Boost Up/CP Recovery Up"
+		"tr_text": "Damage boost up/CP recovery up"
 	},
 	{
 		"assign": "130",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "131",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "132",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "133",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "134",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "135",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "136",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "137",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "138",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "139",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "140",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "141",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "142",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "143",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "144",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "145",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "146",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "147",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "148",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "149",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "150",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "151",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "152",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "153",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "154",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "155",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "156",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "157",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "158",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "159",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "160",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "161",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "162",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "163",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "164",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "165",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "166",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "167",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "168",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	},
 	{
 		"assign": "169",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "170",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "171",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "172",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "173",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "174",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "175",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "176",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "177",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "178",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "179",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "180",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "181",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "997",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "998",
 		"jp_text": "ダメージ量アップ",
-		"tr_text": "Damage Boost Up"
+		"tr_text": "Damage boost up"
 	},
 	{
 		"assign": "999",
 		"jp_text": "威力アップ",
-		"tr_text": "Power Up"
+		"tr_text": "Power up"
 	}
 ]

--- a/json/Name_Chip_SPArksName.txt
+++ b/json/Name_Chip_SPArksName.txt
@@ -732,12 +732,12 @@
 	{
 		"assign": "165",
 		"jp_text": "跳空のバウンサー",
-		"tr_text": "Jumping Bouncer"
+		"tr_text": "Skyward-Jumping Bouncer"
 	},
 	{
 		"assign": "166",
 		"jp_text": "跳天のバウンサー",
-		"tr_text": "Divine Bouncer Jump"
+		"tr_text": "Heavenward-Jumping Bouncer"
 	},
 	{
 		"assign": "167",
@@ -3497,7 +3497,7 @@
 	{
 		"assign": "7076",
 		"jp_text": "熱き翼脚 ブレードスタビライザー-NT",
-		"tr_text": "Passionate Winged Boot Blade Stabilizer-NT"
+		"tr_text": "Ardent Winged Boot Blade Stabilizer-NT"
 	},
 	{
 		"assign": "7077",
@@ -3527,7 +3527,7 @@
 	{
 		"assign": "7082",
 		"jp_text": "無双槍の豪傑 新光兜槍",
-		"tr_text": "The Hero's Spear Pristine Helmet Partizan"
+		"tr_text": "Hero's Spear Pristine Helmet Partizan"
 	},
 	{
 		"assign": "7083",
@@ -3677,12 +3677,12 @@
 	{
 		"assign": "7112",
 		"jp_text": "星護の女神 アーレスカイゼル",
-		"tr_text": "Goddess of Cosmic Aegis Ares Kaiser"
+		"tr_text": "Cosmic Aegis Goddess Ares Kaiser"
 	},
 	{
 		"assign": "7113",
 		"jp_text": "真・星護の女神 アーレスカイゼル",
-		"tr_text": "Celestial Goddess of Aegis Ares Kaiser"
+		"tr_text": "The Cosmic Aegis Goddess Ares Kaiser"
 	},
 	{
 		"assign": "7114",
@@ -3762,12 +3762,12 @@
 	{
 		"assign": "7129",
 		"jp_text": "永劫無極の絶対剣 オロチアギト",
-		"tr_text": "The Eternal Blade Orochiagito"
+		"tr_text": "Eternal Blade Orochiagito"
 	},
 	{
 		"assign": "7130",
 		"jp_text": "真・永劫無極の絶対剣 オロチアギト",
-		"tr_text": "The One and Only Eternal Blade Orochiagito"
+		"tr_text": "The Eternal Blade Orochiagito"
 	},
 	{
 		"assign": "7131",
@@ -3787,7 +3787,7 @@
 	{
 		"assign": "7134",
 		"jp_text": "鋼の忠義 新光鋼弓",
-		"tr_text": "The Loyalty of Steel Pristine Steel Bow"
+		"tr_text": "Loyalty of Steel Pristine Steel Bow"
 	},
 	{
 		"assign": "7135",
@@ -3927,7 +3927,7 @@
 	{
 		"assign": "7162",
 		"jp_text": "厳粛の聖獣戦士 アーレスバスター",
-		"tr_text": "Dignified Sacred Warrior Ares Buster"
+		"tr_text": "Dignified Holy Warrior Ares Buster"
 	},
 	{
 		"assign": "7163",
@@ -3977,7 +3977,7 @@
 	{
 		"assign": "7172",
 		"jp_text": "熱情の聖獣戦士 アーレスソード",
-		"tr_text": "Passionate Sacred Warrior Ares Sword"
+		"tr_text": "Passionate Holy Warrior Ares Sword"
 	},
 	{
 		"assign": "7173",
@@ -3987,12 +3987,12 @@
 	{
 		"assign": "7174",
 		"jp_text": "期待の新兵 ヤスミノコフ８０００Ｃ",
-		"tr_text": "Expectational Recruit Yasminkov 8000C"
+		"tr_text": "Hopeful Recruit Yasminkov 8000C"
 	},
 	{
 		"assign": "7175",
 		"jp_text": "真・期待の新兵 ヤスミノコフ８０００Ｃ",
-		"tr_text": "Genuine Expectational Recruit Yasminkov 8000C"
+		"tr_text": "The Hopeful Recruit Yasminkov 8000C"
 	},
 	{
 		"assign": "7176",
@@ -4032,12 +4032,12 @@
 	{
 		"assign": "7183",
 		"jp_text": "燃やせ勇気を セイガーソード",
-		"tr_text": "Burning Courage Seiga Sword"
+		"tr_text": "Courageous Fire Seiga Sword"
 	},
 	{
 		"assign": "7184",
 		"jp_text": "真・燃やせ勇気を セイガーソード",
-		"tr_text": "Pure Burning Courage Seiga Sword"
+		"tr_text": "The Courageous Fire Seiga Sword"
 	},
 	{
 		"assign": "7185",
@@ -4047,12 +4047,12 @@
 	{
 		"assign": "7186",
 		"jp_text": "不屈の聖獣戦士 アーレスリュウガ",
-		"tr_text": "Dauntless Sacred Warrior Ares Ryuuga"
+		"tr_text": "Dauntless Holy Warrior Ares Ryuuga"
 	},
 	{
 		"assign": "7187",
 		"jp_text": "真・不屈の聖獣戦士 アーレスリュウガ",
-		"tr_text": "Pure Dauntless Sacred Warrior Ares Ryuuga"
+		"tr_text": "The Dauntless Holy Warrior Ares Ryuuga"
 	},
 	{
 		"assign": "7188",
@@ -4217,7 +4217,7 @@
 	{
 		"assign": "7220",
 		"jp_text": "真・奔放なる奏で ガイルズオービット",
-		"tr_text": "Genuine Free Spirit Gaels Orbit"
+		"tr_text": "The Free Spirit Gaels Orbit"
 	},
 	{
 		"assign": "7221",
@@ -4267,7 +4267,7 @@
 	{
 		"assign": "7230",
 		"jp_text": "染血の常夜王 血槍ヴラド・ブラム",
-		"tr_text": "Nocturnal Blood King Bloodspear Vlad Bram"
+		"tr_text": "Blood King of Night Bloodspear Vlad Bram"
 	},
 	{
 		"assign": "7231",
@@ -4287,7 +4287,7 @@
 	{
 		"assign": "7234",
 		"jp_text": "超然の聖獣戦士 アーレスブレード",
-		"tr_text": "Aloof Sacred Warrior Ares Blade"
+		"tr_text": "Aloof Holy Warrior Ares Blade"
 	},
 	{
 		"assign": "7235",
@@ -4297,7 +4297,7 @@
 	{
 		"assign": "7236",
 		"jp_text": "パーリィ聖獣戦士 アーレスランス",
-		"tr_text": "Pearly Sacred Warrior Ares Lance"
+		"tr_text": "Pearly Holy Warrior Ares Lance"
 	},
 	{
 		"assign": "7237",
@@ -4332,7 +4332,7 @@
 	{
 		"assign": "7243",
 		"jp_text": "真・想い宿す剛爪 ファルクロー",
-		"tr_text": "Pure Thoughtful Claw Falclaw"
+		"tr_text": "The Thoughtful Claw Falclaw"
 	},
 	{
 		"assign": "7244",
@@ -4717,12 +4717,12 @@
 	{
 		"assign": "7318",
 		"jp_text": "絶対正義女王 オフスティアガラン",
-		"tr_text": "Queen of Absolute Justice Austere Galland"
+		"tr_text": "Prefect of Justice Austere Galland"
 	},
 	{
 		"assign": "7319",
 		"jp_text": "真・絶対正義女王 オフスティアガラン",
-		"tr_text": "The Queen of Absolute Justice Austere Galland"
+		"tr_text": "The Prefect of Justice Austere Galland"
 	},
 	{
 		"assign": "7320",

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -17,7 +17,7 @@
 	{
 		"text_id": 1001200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、炎属性値を\n強化してくれます！",
-		"tr_text": "His ability is called \"<%abi>\".\nIt raises your ATK and your Fire\nElement!"
+		"tr_text": "His ability is called \"<%abi>\".\nIt raises your ATK and your\nFire Element!"
 	},
 	{
 		"text_id": 1001200,
@@ -87,7 +87,7 @@
 	{
 		"text_id": 1003200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、氷属性値を\n強化してくれます！",
-		"tr_text": "Her ability is called \"<%abi>\".\nIt raises your ATK and your Ice\nElement!"
+		"tr_text": "Her ability is called \"<%abi>\".\nIt raises your ATK and your\nIce Element!"
 	},
 	{
 		"text_id": 1003200,
@@ -147,27 +147,27 @@
 	{
 		"text_id": 1005200,
 		"jp_text": "<%CHARANAME>さんと\n同期のアークス\nアフィンさんのチップです。",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>, this is a chip of\nAfin, your classmate in ARKS."
 	},
 	{
 		"text_id": 1005200,
 		"jp_text": "アビリティは\n「<%abi>」。\n攻撃力、および、雷属性値を\n強化してくれます！",
-		"tr_text": ""
+		"tr_text": "His ability is called \"<%abi>\".\nIt raises your ATK and your\nLightning Element!"
 	},
 	{
 		"text_id": 1005200,
 		"jp_text": "雷属性で装備を固めれば\nより高いパフォーマンスを\n期待できます！\nぜひ、活用してみてくださいね！",
-		"tr_text": ""
+		"tr_text": "It's even more effective if you equip\nLightning-element equipment!\nUse that to your advantage!"
 	},
 	{
 		"text_id": 1005200,
 		"jp_text": "そうそう、アフィンさんは\n誰かをお探しになるために\nアークスになられたのだとか……",
-		"tr_text": ""
+		"tr_text": "Oh, that's right, Afin said he\njoined ARKS because he was\nsearching for someone..."
 	},
 	{
 		"text_id": 1005200,
 		"jp_text": "……なんだか共感してしまいます。\n早く見つかるといいなぁ……",
-		"tr_text": ""
+		"tr_text": "...Somehow, I know how he feels.\nI, too, hope to find..."
 	},
 	{
 		"text_id": 1006000,

--- a/json/SeraphyRoom_SeraphyNote.txt
+++ b/json/SeraphyRoom_SeraphyNote.txt
@@ -54937,17 +54937,17 @@
 	{
 		"text_id": 7701200,
 		"jp_text": "エルジマルトの詩族が使用する\n巨大な大砲を背負った\n竜にも獣にも見える、機改種\nヴリマ・レオパードのチップです。",
-		"tr_text": ""
+		"tr_text": "This is a chip of Vlima Leopard, a\nReconfigured Mech used by the Bards\nof Erzimarut. It resembles a cross\nbetween a dragon and a beast, and\ncarries two huge cannons on its back."
 	},
 	{
 		"text_id": 7701200,
 		"jp_text": "アビリティは\n「<%abi>」。\n機改種に対して与えるダメージが\n増加され、さらに消費ＣＰが\nカットされます！",
-		"tr_text": ""
+		"tr_text": "Its ability is \"<%abi>\".\nIt boosts the damage you deal to\nReconfigured Mechs, while also\ncutting your CP consumption!"
 	},
 	{
 		"text_id": 7701200,
 		"jp_text": "エネミーの力さえも味方にして\n戦闘を有利に進めちゃいましょう！",
-		"tr_text": ""
+		"tr_text": "Even the power of our enemies can\nbe used to our advantage in battle!"
 	},
 	{
 		"text_id": 7702000,

--- a/json/SeraphyRoom_TalkGreeting.txt
+++ b/json/SeraphyRoom_TalkGreeting.txt
@@ -22,22 +22,22 @@
 	{
 		"text_id": 60002,
 		"jp_text": "……えっと、たしかこの辺に\n昔お父さんにもらった\nぬいぐるみが……\n……うーん、ないよー……",
-		"tr_text": ""
+		"tr_text": "...Let's see, I'm sure that stuffed\nanimal my father gave me was\naround here somewhere...\n...Hmm, not over here..."
 	},
 	{
 		"text_id": 60002,
 		"jp_text": "……はっ！\n<%CHARANAME>さん！\nいらっしゃってたんですか！\n失礼しました。久しぶりに部屋を\n整理しようと思いまして……",
-		"tr_text": ""
+		"tr_text": "...Ah! <%CHARANAME>!\nI didn't see you there!\nPlease excuse me. I was thinking\nabout tidying up in here, since\nit's been a while..."
 	},
 	{
 		"text_id": 60003,
 		"jp_text": "これはもう少し上に……\nうーん……\n決まらないなあ……",
-		"tr_text": ""
+		"tr_text": "Put this a bit higher...\nHm...\nNo, I can't decide..."
 	},
 	{
 		"text_id": 60003,
 		"jp_text": "……はっ！\n<%CHARANAME>さん！\nいらっしゃってたんですか！\nすみません、ちょっと部屋の\n模様替えを考えていまして……",
-		"tr_text": ""
+		"tr_text": "...Ah! <%CHARANAME>!\nI didn't see you there!\nPlease excuse me. I was thinking\nabout redecorating in here, since\nit's been a while..."
 	},
 	{
 		"text_id": 70000,

--- a/json/SeraphyRoom_TalkTouch2nd.txt
+++ b/json/SeraphyRoom_TalkTouch2nd.txt
@@ -2,17 +2,17 @@
 	{
 		"text_id": 535000,
 		"jp_text": "父のこと\nここまで巻き込んでしまって\nすみません。",
-		"tr_text": ""
+		"tr_text": "I'm sorry for dragging you into\nthis business with my father."
 	},
 	{
 		"text_id": 535000,
 		"jp_text": "でも、今でははっきり言えます。\n<%CHARANAME>さんに\nお願いして、本当に良かった。",
-		"tr_text": ""
+		"tr_text": "But now I can say this for certain.\nI'm glad I came to you for help,\n<%CHARANAME>."
 	},
 	{
 		"text_id": 535000,
 		"jp_text": "<%CHARANAME>さん。\nこれからも\nどうか、よろしくお願いします！",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>.\nWhatever happens in the future,\nyou have my thanks!"
 	},
 	{
 		"text_id": 540000,
@@ -87,7 +87,7 @@
 	{
 		"text_id": 570000,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nお疲れになったら\nいつでも休みにきてくださいね。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nWhenever you feel tired, come\nhere and get some rest."
 	},
 	{
 		"text_id": 570001,
@@ -107,12 +107,12 @@
 	{
 		"text_id": 570004,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nこれからも、よろしくお願いします。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nI look forward to working\nwith you in the future."
 	},
 	{
 		"text_id": 570000,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nお疲れになったら\nいつでも休みにきてくださいね。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nWhenever you feel tired, come\nhere and get some rest."
 	},
 	{
 		"text_id": 570001,
@@ -132,12 +132,12 @@
 	{
 		"text_id": 570004,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nこれからも、よろしくお願いします。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nI look forward to working\nwith you in the future."
 	},
 	{
 		"text_id": 570000,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nお疲れになったら\nいつでも休みにきてくださいね。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nWhenever you feel tired, come\nhere and get some rest."
 	},
 	{
 		"text_id": 570001,
@@ -157,12 +157,12 @@
 	{
 		"text_id": 570004,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nこれからも、よろしくお願いします。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nI look forward to working\nwith you in the future."
 	},
 	{
 		"text_id": 570000,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nお疲れになったら\nいつでも休みにきてくださいね。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nWhenever you feel tired, come\nhere and get some rest."
 	},
 	{
 		"text_id": 570001,
@@ -182,12 +182,12 @@
 	{
 		"text_id": 570004,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nこれからも、よろしくお願いします。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nI look forward to working\nwith you in the future."
 	},
 	{
 		"text_id": 570000,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nお疲れになったら\nいつでも休みにきてくださいね。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nWhenever you feel tired, come\nhere and get some rest."
 	},
 	{
 		"text_id": 570001,
@@ -207,7 +207,7 @@
 	{
 		"text_id": 570004,
 		"jp_text": "<%CHARANAME>さん\nいつもありがとうございます。\nこれからも、よろしくお願いします。",
-		"tr_text": ""
+		"tr_text": "Thank you for everything,\n<%CHARANAME>.\nI look forward to working\nwith you in the future."
 	},
 	{
 		"text_id": 580000,
@@ -222,121 +222,121 @@
 	{
 		"text_id": 580002,
 		"jp_text": "装備は万全ですか？\nクエストに合わせて\nしっかり整えてくださいね！",
-		"tr_text": ""
+		"tr_text": "Is your equipment ready?\nPlease make sure you consider the\nquest you're doing when you prepare!"
 	},
 	{
 		"text_id": 580003,
 		"jp_text": "危険なお仕事\nいつもお疲れ様です。",
-		"tr_text": ""
+		"tr_text": "Thank you for all the dangerous\nwork you do."
 	},
 	{
 		"text_id": 580003,
 		"jp_text": "お疲れになったら\nいつでもこちらへいらしてくださいね。",
-		"tr_text": ""
+		"tr_text": "If you get tired, feel free to come\nhere any time you like."
 	},
 	{
 		"text_id": 590000,
 		"jp_text": "チップのアビリティには\n任意に発動できる「アクティブ」と\n一定確率で自動発動する\n「サポート」があるんですよ。",
-		"tr_text": ""
+		"tr_text": "Chip abilities can be \"Active\",\nmeaning you choose when to\nactivate them, or \"Support\",\nmeaning they have a set chance\nto activate automatically."
 	},
 	{
 		"text_id": 590000,
 		"jp_text": "アビリティレベルをあげると\n消費ＣＰが減少したり\n発動確率が上がるなど\n様々ないいことがありますよ！",
-		"tr_text": ""
+		"tr_text": "When you increase an ability's level,\nyou get various benefits, such as\nincreasing the activation chance\nor decreasing the CP cost!"
 	},
 	{
 		"text_id": 590001,
 		"jp_text": "<%CHARANAME>さん\nお気づきでしたか？",
-		"tr_text": ""
+		"tr_text": "<%CHARANAME>,\nhave you noticed this?"
 	},
 	{
 		"text_id": 590001,
 		"jp_text": "チップの左上の白と黒の模様は\nアビリティが「アクティブ」か\n「サポート」かを表しているんです。\n装備の参考にしてくださいね！",
-		"tr_text": ""
+		"tr_text": "The black and white pattern on the\nupper left of a chip indicates\nwhether it's an \"Active\" chip\nor a \"Support\" chip. Please\nchoose your equipment carefully!"
 	},
 	{
 		"text_id": 590002,
 		"jp_text": "チップのレベルをあげると\n性能があがりますよ！\n不要なチップはどんどん合成して\nしまいましょう！",
-		"tr_text": ""
+		"tr_text": "Increasing a chip's level improves\nits performance! Grind up chips that\nyou don't need as often as you can!"
 	},
 	{
 		"text_id": 590003,
 		"jp_text": "交換ショップは\nもうご覧になりましたか？",
-		"tr_text": ""
+		"tr_text": "Have you been to the Exchange Shop?"
 	},
 	{
 		"text_id": 590003,
 		"jp_text": "そこでしか手に入らない\n特別なチップもあるみたいです。\nぜひ一度のぞいてみてくださいね！",
-		"tr_text": ""
+		"tr_text": "I hear there are special chips that\nyou can only get there. Please\ndo take a look!"
 	},
 	{
 		"text_id": 590004,
 		"jp_text": "チップの力を解放させると\nアビリティが\nさらに高性能になりますよ！",
-		"tr_text": ""
+		"tr_text": "If you release a chip, its ability will\nbecome even more powerful!"
 	},
 	{
 		"text_id": 590004,
 		"jp_text": "解放には素材チップが必要です。\nデイリークエスト等で\n入手できますよ！",
-		"tr_text": ""
+		"tr_text": "To release a chip, you need material\nchips. You can get material chips from\nDaily Quests, and other places too!"
 	},
 	{
 		"text_id": 590005,
 		"jp_text": "チップには、特定の武器にしか\nセットできないものもあります。",
-		"tr_text": ""
+		"tr_text": "Some chips can only be equipped\nalongside specific weapons."
 	},
 	{
 		"text_id": 590005,
 		"jp_text": "主に必殺技や法術のチップですね。\n装備する際は、クラスや武器に\n合ったものを選んでくださいね！",
-		"tr_text": ""
+		"tr_text": "Generally, that only applies to Photon\nArt and Technique chips. When\nequipping chips, make sure to pick\nones that fit your class and weapon!"
 	},
 	{
 		"text_id": 590006,
 		"jp_text": "ラッピーなど、一部のチップは\n合成時にたくさんの経験値を\n得ることができます。",
-		"tr_text": ""
+		"tr_text": "Some chips, such as Rappy chips,\ngive a lot of EXP when used as\ngrind material."
 	},
 	{
 		"text_id": 590006,
 		"jp_text": "ラッピーは、まれに発生する\n「特別クエスト」で入手できます！\nぜひ、おしらせを\nチェックしてみてくださいね！",
-		"tr_text": ""
+		"tr_text": "Rappy chips can be obtained in a\n\"Special Quest\" that occurs from\ntime to time. Please keep an eye\non your notifications for it!"
 	},
 	{
 		"text_id": 590007,
 		"jp_text": "クエストに向かう際は\n有効属性に気をつけてみてください。",
-		"tr_text": ""
+		"tr_text": "When starting a quest, be mindful\nof its weakness elements."
 	},
 	{
 		"text_id": 590007,
 		"jp_text": "有利な属性で装備を整えれば\nより安全に調査を行えます！\n出発前のクエスト一覧の\n詳細情報に記載されていますので\nぜひチェックしてみてくださいね！",
-		"tr_text": ""
+		"tr_text": "You can explore much more safely\nif you equip matching elements!\nThey're written in the quest details,\nso please check them before you\nstart the quest."
 	},
 	{
 		"text_id": 590008,
 		"jp_text": "クエストの「スコア」には\n注目されていますか？\nいいスコアを出すと特別報酬が\nもらえるんですよ！",
-		"tr_text": ""
+		"tr_text": "Are you paying attention to your\nquests' \"Score\"? If you get a\ngood Score on a quest, you'll earn\na special reward!"
 	},
 	{
 		"text_id": 590008,
 		"jp_text": "スコアは、受けたダメージの量や\nクリアタイムによって決まります。\nより早く、安全にクリアするのが\nポイントですね！",
-		"tr_text": ""
+		"tr_text": "Your Score is based on the amount\nof damage you take, as well as\nyour clear time. Make a point of\nclearing quests quickly and safely!"
 	},
 	{
 		"text_id": 590009,
 		"jp_text": "クエストで\nなかなか倒せないエネミーに\n出会ったことはありますか？",
-		"tr_text": ""
+		"tr_text": "Have you ever encountered an enemy\nin a quest that you can't defeat easily?"
 	},
 	{
 		"text_id": 590009,
 		"jp_text": "そんなときは、相手の攻撃体勢に\n注意してみてください。\n危ない！　と思ったら、無理せず\nスライドで避けてくださいね！",
-		"tr_text": ""
+		"tr_text": "If that happens, please pay attention\nto see when the enemy attacks.\nLook out! Don't put yourself at risk,\nuse a Slide Action to get out of the way!"
 	},
 	{
 		"text_id": 590010,
 		"jp_text": "アークスシップの生活には\nもう慣れましたか？",
-		"tr_text": ""
+		"tr_text": "Have you gotten used to\nlife on the ARKS Ship yet?"
 	},
 	{
 		"text_id": 590010,
 		"jp_text": "お友達を\nたくさん作ってくださいね！",
-		"tr_text": ""
+		"tr_text": "Please make lots of friends!"
 	}
 ]


### PR DESCRIPTION
- Translates a bunch of Seraphy's lab dialogue
- Translates Seraphy's notes on Afin and Vlima Leopard
- Decapitalises the SP frame effects
- Changes the wording on Chase Boost effects
- Shortens and standardises various Weaponoid titles
- Changes "one-time order" to "non-repeatable" in order item descriptions
- Translates descriptions for a couple of dozen Farma order items and all remaining non-Farma order items
- Other minor fixes and tweaks