### PR TITLE
Spelling and Consistency Fixes

### DIFF
--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -23879,9 +23879,9 @@
 	{
 		"assign": "3803710",
 		"jp_text": "カジュアルブーツ　黒",
-		"tr_text": "Casual Boots Black",
+		"tr_text": "Black Casual Boots",
 		"jp_explain": "使用すると、新しいアクセサリーの\nカジュアルブーツ　黒が選択可能。",
-		"tr_explain": "Unlocks the accessory\n\"Casual Boots Black\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the accessory\n\"Black Casual Boots\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "3803711",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -1278,7 +1278,7 @@
 		"jp_text": "アプレスグラッジ・オメガ",
 		"tr_text": "Appress Grudge Omega",
 		"jp_explain": "オメガ・アプレジナの持つ妖刃の\n力を秘めた双小剣。艷麗なる輝きにより\n相手を魅了し、死へと誘う。 ",
-		"tr_explain": "Twin daggers haboring the power\nof Omega Apprenzia. Its seductive\nglimmer has claimed many lives."
+		"tr_explain": "Twin daggers harboring the power of\nOmega Apprenzia. Their seductive\nglimmer has claimed many lives."
 	},
 	{
 		"assign": "140331",


### PR DESCRIPTION
- Fixed Appress Grudge Omega's description which contained spelling errors
- Fixed a consistency error related to the item `Casual Boots`