### PR TITLE
Ares 2 week 3 + tips + others

### DIFF
--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -6076,7 +6076,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "あれは……彼も、アーレスの……",
-		"tr_text": "That man... Another Ares...",
+		"tr_text": "That man... He, too, is an Ares...",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -6204,7 +6204,7 @@
 		"jp_name": "？？？",
 		"tr_name": "???",
 		"jp_text": "まさか俺の全力射撃を耐えきるなんてね。<%br>だが、今度はどうかな？",
-		"tr_text": "They cannot withstand my full-power bombardment.<%br>Still, what about next time?",
+		"tr_text": "They cannot withstand my full-power bombardment.<%br>Still, perhaps under different cirumstances...?",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -6196,7 +6196,7 @@
 		"jp_name": "？？？",
 		"tr_name": "???",
 		"jp_text": "……なかなかやるじゃないか。",
-		"tr_text": "",
+		"tr_text": "...This is child's play.",
 		"fileID": 2
 	},
 	{
@@ -6204,7 +6204,7 @@
 		"jp_name": "？？？",
 		"tr_name": "???",
 		"jp_text": "まさか俺の全力射撃を耐えきるなんてね。<%br>だが、今度はどうかな？",
-		"tr_text": "",
+		"tr_text": "They cannot withstand my full-power bombardment.<%br>Still, what about next time?",
 		"fileID": 2
 	},
 	{
@@ -6212,7 +6212,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "ま、また攻撃してくるのか……！？",
-		"tr_text": "",
+		"tr_text": "A-are they going to attack again...?!",
 		"fileID": 2
 	},
 	{
@@ -6220,7 +6220,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "……「アーレスランチャー」。<%br>こちらへ。",
-		"tr_text": "",
+		"tr_text": "...Ares Launcher.<%br>This way.",
 		"fileID": 2
 	},
 	{
@@ -6228,7 +6228,7 @@
 		"jp_name": "アーレスランチャー",
 		"tr_name": "Ares Launcher",
 		"jp_text": "……仰せのままに。",
-		"tr_text": "",
+		"tr_text": "...As you command.",
 		"fileID": 2
 	},
 	{
@@ -6236,7 +6236,7 @@
 		"jp_name": "アーレスパルチザン",
 		"tr_name": "Ares Partizan",
 		"jp_text": "リーダー……か、カイゼル様は……",
-		"tr_text": "",
+		"tr_text": "Leader... Lady K-Kaiser is...",
 		"fileID": 2
 	},
 	{
@@ -6244,7 +6244,7 @@
 		"jp_name": "アーレスソード",
 		"tr_name": "Ares Sword",
 		"jp_text": "くっそ……！<%br>カイゼル様を……守らな、きゃ……",
-		"tr_text": "",
+		"tr_text": "Damn it...!<%br>Lady Kaiser... I couldn't protect you... ",
 		"fileID": 2
 	},
 	{
@@ -6252,7 +6252,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "貴方たち、無理をしないで。<%br>カイゼルは……私たちでなんとかするわ。",
-		"tr_text": "",
+		"tr_text": "Don't push yourselves too hard.<%br>Kaiser is... We will find some way to help her.",
 		"fileID": 2
 	},
 	{
@@ -6260,7 +6260,7 @@
 		"jp_name": "アーレスランス",
 		"tr_name": "Ares Lance",
 		"jp_text": "でも、今攻撃を食らったらマジヤバっしょ！<%br>あたしたちでも、壁くらいにはなれるからさ！！",
-		"tr_text": "",
+		"tr_text": "But if you get attacked now, it's game over!<%br>We could make a wall and block the shots!!",
 		"fileID": 2
 	},
 	{
@@ -6268,7 +6268,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "そ、そんなのダメです！<%br>みなさんは安全な場所に……！",
-		"tr_text": "",
+		"tr_text": "Don't you dare!<%br>You all need to get to safety...!",
 		"fileID": 2
 	},
 	{
@@ -6276,7 +6276,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "……ブーツ、バスター。<%br>カイゼルにとどめを。",
-		"tr_text": "",
+		"tr_text": "...Boots, Buster.<%br>Stay with Kaiser.",
 		"fileID": 2
 	},
 	{
@@ -6284,7 +6284,7 @@
 		"jp_name": "アーレスブーツ",
 		"tr_name": "Ares Boots",
 		"jp_text": "えっ？<%br>で……でも……",
-		"tr_text": "",
+		"tr_text": "Huh?<%br>Bu... But...",
 		"fileID": 2
 	},
 	{
@@ -6292,7 +6292,7 @@
 		"jp_name": "アーレスバスター",
 		"tr_name": "Ares Buster",
 		"jp_text": "そこまですることは……",
-		"tr_text": "",
+		"tr_text": "If we do that...",
 		"fileID": 2
 	},
 	{
@@ -6300,7 +6300,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "……なにをためらうのです？<%br>役に立つ気がないのなら……あなたたちも無用です。",
-		"tr_text": "",
+		"tr_text": "...Why are you hesitating?<%br>If you won't help me... Then you're useless to me.",
 		"fileID": 2
 	},
 	{
@@ -6308,7 +6308,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "……ランチャー、消してください。",
-		"tr_text": "",
+		"tr_text": "...Launcher, erase them for me.",
 		"fileID": 2
 	},
 	{
@@ -6316,7 +6316,7 @@
 		"jp_name": "アーレスランチャー",
 		"tr_name": "Ares Launcher",
 		"jp_text": "女神の望むままに。",
-		"tr_text": "",
+		"tr_text": "As you wish, my Goddess.",
 		"fileID": 2
 	},
 	{
@@ -6324,7 +6324,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "うわぁぁぁっ！！",
-		"tr_text": "",
+		"tr_text": "Waaaah!!",
 		"fileID": 2
 	},
 	{
@@ -6332,7 +6332,7 @@
 		"jp_name": "アーレスパルチザン",
 		"tr_name": "Ares Partizan",
 		"jp_text": "くっ……こんなケガくらい……<%br>カイゼル様は、オレたちが守る！！",
-		"tr_text": "",
+		"tr_text": "Damn... This injury...<%br>Lady Kaiser, I'll protect you!!",
 		"fileID": 2
 	},
 	{
@@ -6340,7 +6340,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "パルチザン！？<%br>なにをしているの！",
-		"tr_text": "",
+		"tr_text": "Partizan?!<%br>What are you doing?!",
 		"fileID": 2
 	},
 	{
@@ -6348,7 +6348,7 @@
 		"jp_name": "アーレスパルチザン",
 		"tr_name": "Ares Partizan",
 		"jp_text": "砲撃はオレたちが防ぐ！<%br>先生たちは、カイゼル様の治療を！",
-		"tr_text": "",
+		"tr_text": "We'll hold back the shelling!<%br>All of you, treat Lady Kaiser!",
 		"fileID": 2
 	},
 	{
@@ -6356,7 +6356,7 @@
 		"jp_name": "アーレスランス",
 		"tr_name": "Ares Lance",
 		"jp_text": "ここが正念場ってヤツよね！<%br>あたしだって……やる時はやるんだから！",
-		"tr_text": "",
+		"tr_text": "It's do or die, right?!<%br>I can do this... I have to!",
 		"fileID": 2
 	},
 	{
@@ -6364,7 +6364,7 @@
 		"jp_name": "アーレスソード",
 		"tr_name": "Ares Sword",
 		"jp_text": "カイゼル様を守る……<%br>それがオレたち、ユニコーンの役目だ！！",
-		"tr_text": "",
+		"tr_text": "To protect Lady Kaiser...<%br>That's our job as Unicorns!!",
 		"fileID": 2
 	},
 	{
@@ -6372,7 +6372,7 @@
 		"jp_name": "アーレスバスター",
 		"tr_name": "Ares Buster",
 		"jp_text": "キャァァッ！",
-		"tr_text": "",
+		"tr_text": "Yaaaah!",
 		"fileID": 2
 	},
 	{
@@ -6380,7 +6380,7 @@
 		"jp_name": "アーレスブーツ",
 		"tr_name": "Ares Boots",
 		"jp_text": "うぅ……ネスト様……<%br>どうしてボクたちまで……",
-		"tr_text": "",
+		"tr_text": "Huh... Lady Nest...<%br>What should we do...",
 		"fileID": 2
 	},
 	{
@@ -6388,7 +6388,7 @@
 		"jp_name": "アーレスバスター",
 		"tr_name": "Ares Buster",
 		"jp_text": "……わたしたちは無用、って……<%br>ネスト様は……わたしたちを捨てたの……？",
-		"tr_text": "",
+		"tr_text": "...She said we were useless...<%br>Lady Nest... You threw us away...?",
 		"fileID": 2
 	},
 	{
@@ -6396,7 +6396,7 @@
 		"jp_name": "アーレスブーツ",
 		"tr_name": "Ares Boots",
 		"jp_text": "そんな……",
-		"tr_text": "",
+		"tr_text": "That...",
 		"fileID": 2
 	},
 	{
@@ -6404,7 +6404,7 @@
 		"jp_name": "アーレスブレード",
 		"tr_name": "Ares Blade",
 		"jp_text": "……なにをグズグズしてるの。<%br>このまま死ぬつもり？",
-		"tr_text": "",
+		"tr_text": "...What are you doing?<%br>Do you plan to die here?",
 		"fileID": 2
 	},
 	{
@@ -6412,7 +6412,7 @@
 		"jp_name": "アーレスバスター",
 		"tr_name": "Ares Buster",
 		"jp_text": "ブレード……",
-		"tr_text": "",
+		"tr_text": "Blade...",
 		"fileID": 2
 	},
 	{
@@ -6420,7 +6420,7 @@
 		"jp_name": "アーレスブレード",
 		"tr_name": "Ares Blade",
 		"jp_text": "……逃げる手伝いはしてあげるわ。<%br>そこから先は……好きにしなさい。",
-		"tr_text": "",
+		"tr_text": "...I will help you escape.<%br>After that... Do as you please.",
 		"fileID": 2
 	},
 	{
@@ -6428,7 +6428,7 @@
 		"jp_name": "アーレスブーツ",
 		"tr_name": "Ares Boots",
 		"jp_text": "……バスター。<%br>今は、ここを離れよう……",
-		"tr_text": "",
+		"tr_text": "...Buster.<%br>Please, let's go...",
 		"fileID": 2
 	},
 	{
@@ -6436,7 +6436,7 @@
 		"jp_name": "アーレスバスター",
 		"tr_name": "Ares Buster",
 		"jp_text": "ネスト様……",
-		"tr_text": "",
+		"tr_text": "Lady Nest...",
 		"fileID": 2
 	},
 	{
@@ -6444,7 +6444,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "消える……すべてが消えれば……<%br>星は、再びよみがえる……",
-		"tr_text": "",
+		"tr_text": "Disappear... If they all disappear...<%br>The planets will return to their former glory...",
 		"fileID": 2
 	},
 	{
@@ -6452,7 +6452,7 @@
 		"jp_name": "アーレスネスト",
 		"tr_name": "Ares Nest",
 		"jp_text": "ふふッ……さぁ、終焉を始めましょう。<%br>星の再生のために……全部消し去るのです！",
-		"tr_text": "",
+		"tr_text": "Heheh... Now, let the end begin.<%br>For the planets to live... they all must die!",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -5708,7 +5708,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "さて、リリーパ族も見つかったし……<%br>ブルーノ、これで問題は解決よね？",
-		"tr_text": "",
+		"tr_text": "Well, we found a Lillipan...<%br>Does this resolve our problem, Bruno?",
 		"fileID": 2
 	},
 	{
@@ -5716,7 +5716,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ああ、だが……<%br>なにかが引っかかるんだ……",
-		"tr_text": "",
+		"tr_text": "I'm not so sure...<%br>There's something bothering me about this...",
 		"fileID": 2
 	},
 	{
@@ -5724,7 +5724,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "……はっきりしないわね。",
-		"tr_text": "",
+		"tr_text": "...You aren't being especially clear.",
 		"fileID": 2
 	},
 	{
@@ -5732,7 +5732,7 @@
 		"jp_name": "リリーパ族",
 		"tr_name": "Lillipan",
 		"jp_text": "りーりー……",
-		"tr_text": "",
+		"tr_text": "Lii lii...",
 		"fileID": 2
 	},
 	{
@@ -5740,7 +5740,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "どうしたんです？　もう大丈夫ですよ。<%br>送っていきますから、地上へ戻りましょう？",
-		"tr_text": "",
+		"tr_text": "What's wrong? Everything's alright now.<%br>If we go with you, will you go back to the surface?",
 		"fileID": 2
 	},
 	{
@@ -5748,7 +5748,7 @@
 		"jp_name": "リリーパ族",
 		"tr_name": "Lillipan",
 		"jp_text": "りー……りーりりっ！",
-		"tr_text": "",
+		"tr_text": "Lii... Lii lili!",
 		"fileID": 2
 	},
 	{
@@ -5756,7 +5756,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "な、なんか嫌がってるぞ……？<%br>ここにいたいのか？",
-		"tr_text": "",
+		"tr_text": "Huh, you don't wanna go...?<%br>You'd rather stay here?",
 		"fileID": 2
 	},
 	{
@@ -5764,7 +5764,7 @@
 		"jp_name": "リリーパ族",
 		"tr_name": "Lillipan",
 		"jp_text": "りりっ！",
-		"tr_text": "",
+		"tr_text": "Lili!",
 		"fileID": 2
 	},
 	{
@@ -5772,7 +5772,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "えっと……<%br>リリーパ族さんは、ここに残るみたいです……",
-		"tr_text": "",
+		"tr_text": "Um...<%br>It really seems like the Lillipan wants to stay here...",
 		"fileID": 2
 	},
 	{
@@ -5780,7 +5780,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "あっ！　奥にもリリーパ族がいるぞ！<%br>すげー、いっぱいいる！",
-		"tr_text": "",
+		"tr_text": "Hey! There's more Lillipans behind it!<%br>Woah, there's loads back here!",
 		"fileID": 2
 	},
 	{
@@ -5788,7 +5788,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "本当だ。集団で地下坑道に移動してきたのか？<%br>まるで……",
-		"tr_text": "",
+		"tr_text": "You're not wrong. Did these guys all come<%br>down here together? It's almost as if...",
 		"fileID": 2
 	},
 	{
@@ -5802,8 +5802,8 @@
 			"地下坑道に引っ越したんだろう。"
 		],
 		"tr_buttons": [
-			"",
-			""
+			"It's like they're evacuating.",
+			"I guess they've just moved house."
 		],
 		"fileID": 2
 	},
@@ -5812,7 +5812,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ああ。集団で身を寄せ合って……<%br>地下へ避難してきたように見える。",
-		"tr_text": "",
+		"tr_text": "Huh. If they're moving as a group like this...<%br>Yeah, evacuation is the word...",
 		"fileID": 2
 	},
 	{
@@ -5820,7 +5820,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "引っ越しにしては、生活感がないです。<%br>みんなで一ヶ所に固まっていますし……",
-		"tr_text": "",
+		"tr_text": "No, it doesn't look like they're living here to me.<%br>It's more like they've all gathered in one place...",
 		"fileID": 2
 	},
 	{
@@ -5828,7 +5828,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "一時的にここにいるだけ……<%br>まるで避難してきたみたいだわ。",
-		"tr_text": "",
+		"tr_text": "If they've only come here temporarily...<%br>That seems more like an evacuation to me.",
 		"fileID": 2
 	},
 	{
@@ -5836,7 +5836,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "避難？　リリーパ族はなにから逃げてるんだ？<%br>アーレスバトルか？",
-		"tr_text": "",
+		"tr_text": "Evacuation? What are they evacuating from?<%br>Just the Ares Battle?",
 		"fileID": 2
 	},
 	{
@@ -5844,7 +5844,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "アーレスバトルは機甲種の戦闘と<%br>同じくらいの規模よ。避難するほどじゃないわ。",
-		"tr_text": "",
+		"tr_text": "The Ares Battle is no larger than when we fight<%br>Mechs. It shouldn't be a reason to evacuate.",
 		"fileID": 2
 	},
 	{
@@ -5852,7 +5852,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "じゃあ、もっと大規模ななにかが<%br>地上で起きてるってことです……？",
-		"tr_text": "",
+		"tr_text": "So, does that mean something bigger<%br>is happening on the surface...?",
 		"fileID": 2
 	},
 	{
@@ -5860,7 +5860,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "地上じゃなにも起きてない。<%br>……もしかして、これから起きるのか……？",
-		"tr_text": "",
+		"tr_text": "No, nothing's happened on the surface.<%br>Unless... Something's about to happen...?",
 		"fileID": 2
 	},
 	{
@@ -5868,7 +5868,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "こ、これから……？<%br>これからなにが起きるんだよ？",
-		"tr_text": "",
+		"tr_text": "A-about to happen...?<%br>What's about to happen?",
 		"fileID": 2
 	},
 	{
@@ -5876,7 +5876,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "……ネストは機甲種を疎んでいた。<%br>地上の機甲種を一掃する可能性はないかしら？",
-		"tr_text": "",
+		"tr_text": "Nest was very insistent about the Mechs. Perhaps<%br>she needed the surface Mechs out of the way?",
 		"fileID": 2
 	},
 	{
@@ -5884,7 +5884,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "だからリリーパ族を巻き込まないよう<%br>あらかじめ地下に避難させておいて……",
-		"tr_text": "",
+		"tr_text": "And she had the Lillipans evacuate to the Tunnels<%br>ahead of time so as not to get involved...",
 		"fileID": 2
 	},
 	{
@@ -5892,7 +5892,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "……そうか！　まずいぞ、リーダー！<%br>すぐに地上に戻ろう！",
-		"tr_text": "",
+		"tr_text": "...Oh no! This is bad, Leader!<%br>We've got to get back up there, now!",
 		"fileID": 2
 	},
 	{
@@ -5900,7 +5900,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "カイゼルが危ない！",
-		"tr_text": "",
+		"tr_text": "Kaiser's in danger!",
 		"fileID": 2
 	},
 	{
@@ -5908,7 +5908,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "えっ……？<%br>じゃあ、アーレスネストさんの狙いは……",
-		"tr_text": "",
+		"tr_text": "Huh...?<%br>Then, Ares Nest's real plan was...",
 		"fileID": 2
 	},
 	{
@@ -5916,7 +5916,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "……アーレスバトルはめくらましだ。<%br>ネストの真の目的は、別にある！",
-		"tr_text": "",
+		"tr_text": "...The Ares Battle was just a cover.<%br>Nest's after something much worse!",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -6076,7 +6076,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "あれは……彼も、アーレスの……",
-		"tr_text": "That man... He, too, is an Ares...",
+		"tr_text": "That's... an Ares...",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Text.txt
+++ b/json/Arles_Text.txt
@@ -5924,7 +5924,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "バトル会場が見えてきたぞ！<%br>……ソードとブレードが戦ってる！",
-		"tr_text": "",
+		"tr_text": "We're nearly at the arena!<%br>...Sword and Blade are fighting!",
 		"fileID": 2
 	},
 	{
@@ -5932,7 +5932,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "カイゼルは……いたわ！　まだ無事よ！",
-		"tr_text": "",
+		"tr_text": "Kaiser is... She's still there! We aren't safe yet!",
 		"fileID": 2
 	},
 	{
@@ -5940,7 +5940,7 @@
 		"jp_name": "？？？",
 		"tr_name": "???",
 		"jp_text": "ふむ……ようやく役者が揃ったね。<%br>では、はじめようか。",
-		"tr_text": "",
+		"tr_text": "Hmm... The actors are finally assembled.<%br>Well then, let us begin.",
 		"fileID": 2
 	},
 	{
@@ -5948,7 +5948,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "カイゼルさーん！<%br>すぐにバトルを中止してください！",
-		"tr_text": "",
+		"tr_text": "Kaiseeer!<%br>Please, stop the battle now!",
 		"fileID": 2
 	},
 	{
@@ -5956,7 +5956,7 @@
 		"jp_name": "アーレスカイゼル",
 		"tr_name": "Ares Kaiser",
 		"jp_text": "ジェネ……？　どうしたのですか？",
-		"tr_text": "",
+		"tr_text": "Gene...? What has happened?",
 		"fileID": 2
 	},
 	{
@@ -5964,7 +5964,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "アーレスネストさんの目的は……キャアァッ！",
-		"tr_text": "",
+		"tr_text": "Ares Nest is planning... Aaaaah!",
 		"fileID": 2
 	},
 	{
@@ -5972,7 +5972,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "ば、爆撃！？　どこから……",
-		"tr_text": "",
+		"tr_text": "B-bombardment?! From where...",
 		"fileID": 2
 	},
 	{
@@ -5980,7 +5980,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "うぅわぁぁぁっ！　あぶ、あぶないってば！",
-		"tr_text": "",
+		"tr_text": "Waaaaaah! We- we're in danger!",
 		"fileID": 2
 	},
 	{
@@ -5988,7 +5988,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "もしかして、ネストの狙いはカイゼルだけでなく……<%br>この場にいる私たち全員なの！？",
-		"tr_text": "",
+		"tr_text": "What if Nest wasn't just targeting Kaiser...<%br>What if she was targeting all of us here?!",
 		"fileID": 2
 	},
 	{
@@ -5996,7 +5996,7 @@
 		"jp_name": "アーレスパルチザン",
 		"tr_name": "Ares Partizan",
 		"jp_text": "な、なにが起きてるんだ！？<%br>とにかくカイゼル様を、守ら……ねば……",
-		"tr_text": "",
+		"tr_text": "W-what's going on?!<%br>We have to protect... Lady... Kaiser...",
 		"fileID": 2
 	},
 	{
@@ -6004,7 +6004,7 @@
 		"jp_name": "アーレスブレード",
 		"tr_name": "Ares Blade",
 		"jp_text": "……この先には行かせない。<%br>ま、そのケガじゃ動けないだろうけど。",
-		"tr_text": "",
+		"tr_text": "...I won't let you leave this spot.<%br>You wouldn't get far with that injury, anyway.",
 		"fileID": 2
 	},
 	{
@@ -6012,7 +6012,7 @@
 		"jp_name": "アーレスソード",
 		"tr_name": "Ares Sword",
 		"jp_text": "そこを……どけぇぇぇっ！！",
-		"tr_text": "",
+		"tr_text": "Get out... of my way!!",
 		"fileID": 2
 	},
 	{
@@ -6020,7 +6020,7 @@
 		"jp_name": "アーレスブレード",
 		"tr_name": "Ares Blade",
 		"jp_text": "甘いっ！！",
-		"tr_text": "",
+		"tr_text": "Weak!!",
 		"fileID": 2
 	},
 	{
@@ -6036,7 +6036,7 @@
 		"jp_name": "アーレスソード",
 		"tr_name": "Ares Sword",
 		"jp_text": "ぐうっ……！<%br>ぶ、ブレード……てめぇ……",
-		"tr_text": "",
+		"tr_text": "Gah...!<%br>B-Blade... You...",
 		"fileID": 2
 	},
 	{
@@ -6044,7 +6044,7 @@
 		"jp_name": "アーレスブレード",
 		"tr_name": "Ares Blade",
 		"jp_text": "大人しくしてなさい。元兄弟のよしみ……<%br>ここにいれば、アンタたちは助けてあげる。",
-		"tr_text": "",
+		"tr_text": "Be silent. If you care about your comrades...<%br>You can help them by staying here.",
 		"fileID": 2
 	},
 	{
@@ -6052,7 +6052,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "か、カイゼルさんは……キャアッ！",
-		"tr_text": "",
+		"tr_text": "K-Kaiser is... Yaah!",
 		"fileID": 2
 	},
 	{
@@ -6060,7 +6060,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "奇襲、ね……<%br>ネストにこんな隠し玉があったとは。",
-		"tr_text": "",
+		"tr_text": "An ambush, huh...<%br>So this is what Nest had hidden up her sleeve.",
 		"fileID": 2
 	},
 	{
@@ -6068,7 +6068,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "リーダー、みんな！　見つけたぞ！<%br>爆撃はあそこにいるヤツだ！",
-		"tr_text": "",
+		"tr_text": "Leader, everyone! I found them!<%br>The shooter is that guy over there!",
 		"fileID": 2
 	},
 	{
@@ -6076,7 +6076,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "あれは……彼も、アーレスの……",
-		"tr_text": "",
+		"tr_text": "That man... Another Ares...",
 		"fileID": 2
 	},
 	{
@@ -6084,7 +6084,7 @@
 		"jp_name": "？？？",
 		"tr_name": "???",
 		"jp_text": "……気づかれたな。<%br>ならば、終わらせる！",
-		"tr_text": "",
+		"tr_text": "...I was seen.<%br>In that case, it's time to end this!",
 		"fileID": 2
 	},
 	{
@@ -6092,7 +6092,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "うおおっ！？<%br>爆発がもっと激しくなったってば！！",
-		"tr_text": "",
+		"tr_text": "Whaaa?!<%br>The explosions got way more intense!!",
 		"fileID": 2
 	},
 	{
@@ -6100,7 +6100,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "ダメです……このままじゃ……！",
-		"tr_text": "",
+		"tr_text": "Is this... the end...?",
 		"fileID": 2
 	},
 	{
@@ -6108,7 +6108,7 @@
 		"jp_name": "アーレスカイゼル",
 		"tr_name": "Ares Kaiser",
 		"jp_text": "させません！！",
-		"tr_text": "",
+		"tr_text": "I will not let you!!",
 		"fileID": 2
 	},
 	{
@@ -6116,7 +6116,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "うぅ……やっと止んだか……<%br>みんな、無事か？",
-		"tr_text": "",
+		"tr_text": "Ugh... It finally stopped...<%br>Is everyone alright?",
 		"fileID": 2
 	},
 	{
@@ -6124,7 +6124,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "あ、あれ……？　ぜんぜん平気だぞ……？",
-		"tr_text": "",
+		"tr_text": "What the heck...? I'm OK...?",
 		"fileID": 2
 	},
 	{
@@ -6132,7 +6132,7 @@
 		"jp_name": "アーレスカイゼル",
 		"tr_name": "Ares Kaiser",
 		"jp_text": "無事、のようです……ね……<%br>よ、よかった……",
-		"tr_text": "",
+		"tr_text": "It seems... you all are... safe...<%br>I... am glad...",
 		"fileID": 2
 	},
 	{
@@ -6140,7 +6140,7 @@
 		"jp_name": "ジェネ",
 		"tr_name": "Gene",
 		"jp_text": "カイゼルさん！？<%br>どうしたんですか！？　カイゼルさん！",
-		"tr_text": "",
+		"tr_text": "Kaiser?!<%br>What happened?! Kaiser!",
 		"fileID": 2
 	},
 	{
@@ -6148,7 +6148,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "ひどいケガ……<%br>まさか、私たちをかばったの……？",
-		"tr_text": "",
+		"tr_text": "She's badly injured...<%br>You put yourself in harm's way to protect us...?",
 		"fileID": 2
 	},
 	{
@@ -6156,7 +6156,7 @@
 		"jp_name": "アーレスカイゼル",
 		"tr_name": "Ares Kaiser",
 		"jp_text": "……これでいいのです。<%br>わたくしの希望は……守られたのですから……",
-		"tr_text": "",
+		"tr_text": "...This is fine.<%br>My wishes... have been preserved...",
 		"fileID": 2
 	},
 	{
@@ -6164,7 +6164,7 @@
 		"jp_name": "モア",
 		"tr_name": "More",
 		"jp_text": "お……おい……カイゼル……？<%br>しっかりしろよ！",
-		"tr_text": "",
+		"tr_text": "Huh... Hey... Kaiser...?<%br>Stay with us, y'hear!",
 		"fileID": 2
 	},
 	{
@@ -6172,7 +6172,7 @@
 		"jp_name": "アネット",
 		"tr_name": "Annette",
 		"jp_text": "……まだ息はあるわ。すぐにレスタを……",
-		"tr_text": "",
+		"tr_text": "...She's still breathing.<%br>She needs immediate Resta treatment...",
 		"fileID": 2
 	},
 	{
@@ -6180,7 +6180,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "待て、アネット。機甲種が集まってきてる。<%br>カイゼルの手当ては安全な場所へ移動してからだ。",
-		"tr_text": "",
+		"tr_text": "Hold up, Annette. There's Mechs outside. We can<%br>take care of Kaiser after we get her to safety.",
 		"fileID": 2
 	},
 	{
@@ -6188,7 +6188,7 @@
 		"jp_name": "ブルーノ",
 		"tr_name": "Bruno",
 		"jp_text": "リーダー、まずは機甲種を追い払うぞ！",
-		"tr_text": "",
+		"tr_text": "Leader, let's take out those Mechs!",
 		"fileID": 2
 	},
 	{

--- a/json/Arles_Title.txt
+++ b/json/Arles_Title.txt
@@ -112,12 +112,12 @@
 	{
 		"title_id": 2,
 		"jp_title": "第７話<%br>対話　前編",
-		"tr_title": "Chapter 7<%br>Dialogue Part 1"
+		"tr_title": "Chapter 7<%br>A Conversation Part 1"
 	},
 	{
 		"title_id": 2,
 		"jp_title": "第８話<%br>対話　後編",
-		"tr_title": "Chapter 8<%br>Dialogue Part 2"
+		"tr_title": "Chapter 8<%br>A Conversation Part 2"
 	},
 	{
 		"title_id": 2,

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -2139,21 +2139,21 @@
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② エターナルタワーで敵に与えるダメージを\n　　アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[?-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31850",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② エターナルタワーで敵に与えるダメージを\n　　アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[?-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31851",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② エターナルタワーで敵に与えるダメージを\n　　アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[?-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in the\n    Eternal Tower based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31852",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2027,7 +2027,7 @@
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31317",
@@ -2328,14 +2328,14 @@
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31372",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31373",
@@ -2538,14 +2538,14 @@
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n   Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31408",
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋大軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n   and Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n    and Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31411",
@@ -3497,14 +3497,14 @@
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n   ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31603",
@@ -3931,21 +3931,21 @@
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n   number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31690",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n   number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31691",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n   number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31692",

--- a/json/Item_Stack_Boost.txt
+++ b/json/Item_Stack_Boost.txt
@@ -751,9 +751,9 @@
 	{
 		"assign": "320139",
 		"jp_text": "プレーンショコラ’１９",
-		"tr_text": "",
+		"tr_text": "Plain Chocolate '19",
 		"jp_explain": "ホワイトデーイベント用に\n作られた特製ショコラ。\n【５分間】全ステータス＋１０\nレアドロップ倍率＋５０％",
-		"tr_explain": ""
+		"tr_explain": "Chocolate made for White Day.\n[5 min] All +10\nRare Drop Rate +50%"
 	},
 	{
 		"assign": "320140",

--- a/json/Name_Quest_QuestName.txt
+++ b/json/Name_Quest_QuestName.txt
@@ -5607,7 +5607,7 @@
 	{
 		"assign": "5021204",
 		"jp_text": "対話",
-		"tr_text": "Dialogue"
+		"tr_text": "A Conversation"
 	},
 	{
 		"assign": "5021205",

--- a/json/UI_QuestTips.txt
+++ b/json/UI_QuestTips.txt
@@ -267,7 +267,6 @@
 	{
 		"assign": "0053",
 		"jp_text": "<color=#f0df60>＜交換ショップ＞</color>\n不要になったチップやコスチュームは\n交換ショップで別のチップなどのアイテムに\n交換できる場合がありますよ。\n交換ショップを活用しましょう！",
-		"tr_text": ""
 	},
 	{
 		"assign": "0054",
@@ -472,7 +471,7 @@
 	{
 		"assign": "0094",
 		"jp_text": "<color=#f0df60>＜ダーカーの第三波＞</color>\n数で押してきた、第二波はなんとかしのぎました。\n第三波では、大型のダーカーが確認されています。\nがんばってください！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Third Darker Attack></color>\nDespite their numbers, you held off the\nsecond wave. A large Darker has been\ndetected in the third wave. Good luck!"
 	},
 	{
 		"assign": "0095",
@@ -612,7 +611,7 @@
 	{
 		"assign": "0122",
 		"jp_text": "<color=#f0df60>＜「オペレーションスコア」とは＞</color>\n緊急クエストをクリアすると、\n作戦への貢献度を示す\nオペレーションスコアが獲得できますよ。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60>What is \"Operation Score\"?</color>\nWhen you clear an Emergency Quest, you\nearn Operation Score points based on how\nmuch you contributed to the battle."
 	},
 	{
 		"assign": "0123",

--- a/json/UI_QuestTips.txt
+++ b/json/UI_QuestTips.txt
@@ -12,7 +12,7 @@
 	{
 		"assign": "0002",
 		"jp_text": "<color=#f0df60>＜敵の攻撃をかわそう＞</color>\nバトル中に画面を左にスライドすると左に移動、\n右にスライドすると右に移動することができます。\nエネミーの攻撃を左右に移動して、かわしましょう。",
-		"tr_text": "<color=#f0df60><Avoiding enemy attacks></color>\nDuring a battle, sliding across the screen to the left\nmakes you dodge left, and sliding to the right makes\nyou dodge right. Dodge left and right to avoid\nenemy attacks."
+		"tr_text": "<color=#f0df60><Avoiding Enemy Attacks></color>\nDuring a battle, sliding across the screen to the left\nmakes you dodge left, and sliding to the right makes\nyou dodge right. Dodge left and right to avoid\nenemy attacks."
 	},
 	{
 		"assign": "0003",
@@ -152,17 +152,17 @@
 	{
 		"assign": "0030",
 		"jp_text": "<color=#f0df60>＜チップとクラスの組み合わせ＞</color>\nチップの中には「クラスボーナス」という効果が\nついているものがあります。\n対応するクラスのときに装備すると\n上昇するパラメータにボーナスがつくんですよ。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Combining Chips And Classes></color>\nSome chips have an effect called \"Class Bonus\".\nWhile equipped to a character of a matching class,\nthe chip's HP, CP and Element value will increase."
 	},
 	{
 		"assign": "0031",
 		"jp_text": "<color=#f0df60>＜『PSO2』との連動メリット＞</color>\n『PSO2es』のキャラクターを『PSO2』と連動させると\n所持アイテムの枠数が増えるなど、いろいろな\nいいことがありますよ！\nよかったらぜひ、お試しください！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Benefits Of Linking With PSO2></color>\nIf you link a character from PSO2es to PSO2,\nyou will gain many benefits, such as being\nable to store more items. Give PSO2 a try!"
 	},
 	{
 		"assign": "0032",
 		"jp_text": "<color=#f0df60>＜追加データダウンロード＞</color>\n「メニュー」の「その他」から「システム」にある\n「データダウンロード」を選ぶと、ゲームで使用する\nすべてのアイテムのデータを追加ダウンロードします。\nただし、ダウンロードに非常に長い時間がかかり\n容量もかなり必要です。ご注意ください。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Additional Data Download></color>\nIf you go to the \"Other\" menu, select \"System\"\nand then \"Data Download\", you will be able to\ndownload additional data for every item in the\ngame. This takes a long time, and requires a lot of\nstorage space. Please be careful."
 	},
 	{
 		"assign": "0033",
@@ -177,32 +177,32 @@
 	{
 		"assign": "0035",
 		"jp_text": "<color=#f0df60>＜チップでもジャストアタック＞</color>\nジャストアタックは、通常攻撃だけでなく\nアクティブチップでも発動することができますよ。\nチップを使うときに、赤い円にタイミングをあわせて\n発動してみましょう。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Just Attacking Chips></color>\nJust Attacks don't just apply to normal attacks -\nyou can do them with Active Chips too! Try to\ntime your chip activations to the red circle."
 	},
 	{
 		"assign": "0036",
 		"jp_text": "<color=#f0df60>＜武器の習熟について＞</color>\n『PSO2es』では、武器に「習熟」という値があり\nどんな武器もクラスレベル１から装備できますが\n習熟度が低いうちは、威力も抑えられています。\nクラスレベルがあがると「習熟」もあがっていき\n１００％になると、本来の性能が発揮可能になります。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Weapon Proficiency></color>\nIn PSO2es, weapons have a \"Proficiency Level\".\nYou can use any weapon even at level 1, but if\nyou haven't reached the Proficiency level, their\npower will be reduced. As your level rises, your\nproficiency increases, reaching full power at 100%."
 	},
 	{
 		"assign": "0037",
 		"jp_text": "<color=#f0df60>＜侵食エネミーについて＞</color>\n侵食エネミーは、赤い体色をしており\n画面左上のエネミー名に「侵食」の文字が冠されます。\nとても強力なエネミーですが、そのぶん\n良いアイテムが出る確率も高くなるようです。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Infected Enemies></color>\nInfected enemies appear red, and have the word\n\"Infected\" at the start of their names in the top-\nleft corner. Infected enemies are more powerful,\nbut they have a high chance to drop good items."
 	},
 	{
 		"assign": "0038",
 		"jp_text": "<color=#f0df60>＜装備セットを作ろう＞</color>\n武器とチップの装備のセットは\n６つまで保存しておくことができますよ。\n「装備パレット」画面の、右上の矢印で\n切り替えることが可能です。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Saved Palettes></color>\nYou can have up to six palettes of weapons, units\nand chips saved. You can switch between these\npalettes at any time using the arrows in the top-\nright corner of the Equip screen."
 	},
 	{
 		"assign": "0039",
 		"jp_text": "<color=#f0df60>＜お得な行動力回復＞</color>\nレベルがあがりにくくなって、行動力が足りないときは\nレベルが低いクラスにクラス変更してみましょう。\n簡単にレベルアップできるので\n行動力が回復しやすいですよ。",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Easy Drive Recovery></color>\nIf your level is high and levelling up is becoming\ndifficult, switch to a lower-levelled class. You will\nfind it easy to level up again, which fully restores\nyour Drive and lets you continue playing."
 	},
 	{
 		"assign": "0040",
 		"jp_text": "<color=#f0df60>＜スペシャルクエストの活用＞</color>\n日替わりのスペシャルクエストは、曜日によって\n手に入る解放素材が異なります。\nクエストカウンターでチェックしましょう！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Daily Special Quests></color>\nDaily Special Quests change withthe day of the week.\nBe sure to check them at the\nQuest Counter!"
 	},
 	{
 		"assign": "0041",
@@ -232,7 +232,7 @@
 	{
 		"assign": "0046",
 		"jp_text": "<color=#f0df60>＜フレンドアシストの追撃＞</color>\nフレンドの装備しているチップが\nエクストラ系（必殺技や法術）の場合\nフレンドアシストをした際に、最後にそのチップで\n追加攻撃をしてくれますよ！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Extended Friend Assist></color>\nWhen your Friend Partner's chip is a Photon Art or\nTechnique, if you activate Friend Assist, your\nFriend Partner will perform an additional attack at\nthe end using that chip!"
 	},
 	{
 		"assign": "0047",
@@ -1067,12 +1067,12 @@
 	{
 		"assign": "0213",
 		"jp_text": "<color=#f0df60>＜★１３チップの解放＞</color>\n★１３チップをパレットに装備すると同じ属性の\n必殺技、法術チップのコストが半分になるんです！\n★１３チップと一緒に必殺技や法術のチップを\n装備する時は属性も考慮してくださいね！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><★13 Chips></color>\nWhen you equip a ★13 chip on your palette, it willhalve the equip cost of PAs and Techniques of the\nsame element. When choosing a PA to go with your\n★13 chip, pay attention to its element!"
 	},
 	{
 		"assign": "0214",
 		"jp_text": "<color=#f0df60>＜★１３チップの最大解放＞</color>\n★１３チップには二段階の解放があります。\n最大解放した★13チップをパレットに装備した時\n全属性の必殺技、法術チップのコストが半分になります。\n強いチップを装備したいけどコストが……\nなんて悩みが解決しちゃいますよ！",
-		"tr_text": ""
+		"tr_text": "<color=#f0df60><Fully Releasing ★13 Chips></color>\n★13 chips can be released twice. When you equip\na fully released ★13 chip, it halves the equip cost\nof PAs and Techniques of all elements. If you've\never been unable to equip a strong chip because\nof its cost, ★13 chips are the answer!"
 	},
 	{
 		"assign": "0215",

--- a/json/UI_QuestTips.txt
+++ b/json/UI_QuestTips.txt
@@ -267,6 +267,7 @@
 	{
 		"assign": "0053",
 		"jp_text": "<color=#f0df60>＜交換ショップ＞</color>\n不要になったチップやコスチュームは\n交換ショップで別のチップなどのアイテムに\n交換できる場合がありますよ。\n交換ショップを活用しましょう！",
+		"tr_text": "<color=#f0df60><The Exchange Shop></color>\nAt the Exchange Shop, you can trade chips\nand costumes that you no longer want for\nother items, including new chips. Check out\nwhat the Exchange Shop has to offer!"
 	},
 	{
 		"assign": "0054",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -12352,7 +12352,7 @@
 	{
 		"assign": "es_0006_n08_b",
 		"jp_text": "<color=black>侵食エネミーは非常に強力ですから\nチップの効果を活かすことが\nとても重要になってきます。\nクエスト出撃前に、弱点属性を\nよく確認しておいてくださいね。</color>",
-		"tr_text": "<color=black>Infected enemies are powerful.\nEnsure that you take advantage of\neach chip, as well as the weakness\nattribute, before deploying yourself.</color>"
+		"tr_text": "<color=black>Infected enemies are powerful.\nEnsure that you take advantage of\neach chip, as well as the weakness\element, before deploying yourself.</color>"
 	},
 	{
 		"assign": "es_0006_n09_b",
@@ -19217,7 +19217,7 @@
 	{
 		"assign": "quest_linkskill_week_element",
 		"jp_text": "有効属性予想",
-		"tr_text": "Weak Attr. Predict"
+		"tr_text": "Weak Elem. Predict"
 	},
 	{
 		"assign": "quest_lobby_guide_01",
@@ -19282,7 +19282,7 @@
 	{
 		"assign": "chip_details_attribute",
 		"jp_text": "属性",
-		"tr_text": "Attr."
+		"tr_text": "Elem."
 	},
 	{
 		"assign": "chip_details_hp",
@@ -19732,12 +19732,12 @@
 	{
 		"assign": "towerquest_fp_weakpoint_title",
 		"jp_text": "　　　　弱点属性",
-		"tr_text": "　　　　Weak Attr."
+		"tr_text": "　　　　Weak Elem."
 	},
 	{
 		"assign": "towerquest_fp_ls_weakpoint_title",
 		"jp_text": "　　　弱点属性",
-		"tr_text": "　　　Weak Attr."
+		"tr_text": "　　　Weak Elem."
 	},
 	{
 		"assign": "towerquest_top_floor_unit",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -12352,7 +12352,7 @@
 	{
 		"assign": "es_0006_n08_b",
 		"jp_text": "<color=black>侵食エネミーは非常に強力ですから\nチップの効果を活かすことが\nとても重要になってきます。\nクエスト出撃前に、弱点属性を\nよく確認しておいてくださいね。</color>",
-		"tr_text": "<color=black>Infected enemies are powerful.\nEnsure that you take advantage of\neach chip, as well as the weakness\element, before deploying yourself.</color>"
+		"tr_text": "<color=black>Infected enemies are powerful.\nEnsure that you take advantage of\neach chip, as well as the weakness\nelement, before deploying yourself.</color>"
 	},
 	{
 		"assign": "es_0006_n09_b",


### PR DESCRIPTION
- Translates scenes 9-12 from Story of Ares 2. Struggled with a few lines and would appreciate a second opinion on them.
- Renames the Ares 2 quest "Dialogue" to "A Conversation"
- Translates speakers' names in gaidens
- Translates a few tips
- Fixes inconsistent spacing in chip descriptions
- Correctly identifies Saika Hyouri's other frame as X
- Fixes the last few cases of 'attribute' instead of 'element'
- Translates plain chocolate '19