### PR TITLE
Add full details to all chip abilities (except PAs/Techs)

### DIFF
--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -4,2681 +4,2681 @@
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Fire Element by 90.\n<color=yellow>SP: </color>Increases your Fire Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Ice Element by 70.\n<color=yellow>SP: </color>Increases your Ice Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Ice Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Ice Element by 90.\n<color=yellow>SP: </color>Increases your Ice Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Lightning Element by 90.\n<color=yellow>SP: </color>Increases your Lightning Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Wind Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Wind Element by 90.\n<color=yellow>SP: </color>Increases your Wind Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Light Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Light Element by 90.\n<color=yellow>SP: </color>Increases your Light Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Dark Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Dark Element by 90.\n<color=yellow>SP: </color>Increases your Dark Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "910",
 		"jp_explainShort": "全体に大ダメージ＋確率で「バーン」",
 		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy damage to all enemies.\n② Has a chance to inflict [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1200% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1400% shooting damage to all enemies.\n②  Has a chance to inflict [Burn]."
 	},
 	{
 		"assign": "920",
 		"jp_explainShort": "全体に特大ダメージ＋確率で「バーン」",
 		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に特大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive damage to all enemies.\n② Has a chance to inflict [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 2000% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 2400% shooting damage to all enemies.\n②  Has a chance to inflict [Burn]."
 	},
 	{
 		"assign": "1110",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces your DEF by 100.\n<color=yellow>SP: </color>Reduces your DEF by 150.\n②  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces DEF.\n② Dramatically increases ATK.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces your DEF by 200.\n<color=yellow>SP: </color>Reduces your DEF by 250.\n②  Increases your ATK by 720.\n<color=yellow>SP: </color>Increases your ATK by 770.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your ATK by 35% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 50% against enemy\n     elemental weaknesses.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your ATK by 65% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 80% against enemy\n     elemental weaknesses.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "1510",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Light damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Light damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Light damage to the target.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Light damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Light damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Light damage to the target.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Lightning damage to the target.\n[Effect Duration] Long."
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Lightning damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Lightning damage to the target.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Lightning damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Lightning damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Lightning damage to the target.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Wind damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Wind damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Wind damage to the target.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Wind damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Wind damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Wind damage to the target.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "1570",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive Fire Tech damage to all enemies,\n    while also damaging you by 30% of your maximum\n    HP.\n    You cannot activate this chip when below 30% HP."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 3000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n<color=yellow>SP: </color>Deals 3500% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n     You cannot activate this chip when below 30% HP."
 	},
 	{
 		"assign": "1580",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive Fire Tech damage to all enemies,\n    while also damaging you by 30% of your maximum\n    HP.\n    You cannot activate this chip when below 30% HP."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 4000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n<color=yellow>SP: </color>Deals 5000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n     You cannot activate this chip when below 30% HP."
 	},
 	{
 		"assign": "1590",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Fire damage to the target.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Fire damage to the target.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 5% of damage dealt as HP.\n<color=yellow>SP: </color>Recovers 7% of damage dealt as HP.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 8% of damage dealt as HP.\n<color=yellow>SP: </color>Recovers 10% of damage dealt as HP.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "1610",
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 5% every second.\n<color=yellow>SP: </color>Recovers HP by 7% every second.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 8% every second.\n<color=yellow>SP: </color>Recovers HP by 10% every second.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 85% damage to Mechs.\n<color=yellow>SP: </color>Deals an additional 90% damage to Mechs.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 95% damage to Mechs.\n<color=yellow>SP: </color>Deals an additional 100% damage to Mechs.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 85% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 90% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 95% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 100% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30007",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness Elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 120.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 130.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "30008",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness Elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 140.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 150.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Dragonkin",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Dragonkin.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 85% damage to Dragonkin.\n<color=yellow>SP: </color>Deals an additional 90% damage to Dragonkin.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Dragonkin",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Dragonkin.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 95% damage to Dragonkin.\n<color=yellow>SP: </color>Deals an additional 100% damage to Dragonkin.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 85% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 90% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 95% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 100% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30017",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up in proportion to remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK, increasing as\n    remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 10.5 x your current CP.\n<color=yellow>SP: </color>Increases your ATK by 11.5 x your current CP.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up in proportion to remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK, increasing as\n    remaining CP increases.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 13 x your current CP.\n<color=yellow>SP: </color>Increases your ATK by 15 x your current CP.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Wind chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Wind chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Ice chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Ice chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Lightning chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Lightning chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30033",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "[Panic] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "[Panic] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "1690",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
 		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional to your HP\n    on activation.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by up to 1200, inversely\n     proportional to your remaining HP on activation.\n<color=yellow>SP: </color>Increases your ATK by up to 1400, inversely\n     proportional to your remaining HP on activation.\n②  Deals 2700% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Fire damage to the target.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "1700",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
 		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional to your HP\n    on activation.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
+		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by up to 1600, inversely\n     proportional to your remaining HP on activation.\n<color=yellow>SP: </color>Increases your ATK by up to 1800, inversely\n     proportional to your remaining HP on activation.\n②  Deals 4500% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Fire damage to the target.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "30043",
 		"jp_explainShort": "ダメージ軽減＋長槍の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "30044",
 		"jp_explainShort": "ダメージ大軽減＋長槍の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "30047",
 		"jp_explainShort": "ダメージ軽減＋長銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "30048",
 		"jp_explainShort": "ダメージ大軽減＋長銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "30053",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Grants knockdown immunity.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Grants knockdown immunity.\n[Effect Duration] 45 seconds"
 	},
 	{
 		"assign": "30067",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     different chip elements equipped.\n②  Increases your DEF by 110 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your DEF by 100 x the number of\n     different chip elements equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your ATK by 140 x the number of\n     different chip elements equipped.\n②  Increases your DEF by 120 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your DEF by 140 x the number of\n     different chip elements equipped.\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "30071",
 		"jp_explainShort": "定期的に攻撃力を上昇",
 		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 85 every 3.6 seconds.\n<color=yellow>SP: </color>Increases your ATK by 100 every 3.6 seconds.\n[Effect Duration] 45 seconds"
 	},
 	{
 		"assign": "30072",
 		"jp_explainShort": "定期的に攻撃力を上昇",
 		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 115 every 3.6 seconds.\n<color=yellow>SP: </color>Increases your ATK by 130 every 3.6 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "30081",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Light chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30082",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Light chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30083",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Dark chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30084",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Dark chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30085",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Fire chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30086",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Fire chips equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30089",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Cuts current HP by 90%.\n②  Increases your ATK by 720.\n<color=yellow>SP: </color>Increases your ATK by 840.\n③  Recovers HP by 10% every 1.8 seconds.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Cuts current HP by 90%.\n②  Increases your ATK by 960.\n<color=yellow>SP: </color>Increases your ATK by 1080.\n③  Recovers HP by 10% every 1.8 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31009",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your maximum CP by 30.\n<color=yellow>SP: </color>Increases your maximum CP by 40.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31010",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your maximum CP by 50.\n<color=yellow>SP: </color>Increases your maximum CP by 60.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31011",
 		"jp_explainShort": "ダーカー以外にダメージ増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 30%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31012",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 45%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 55%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31025",
 		"jp_explainShort": "ダメージ軽減＋飛翔剣の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31026",
 		"jp_explainShort": "ダメージ大軽減＋飛翔剣の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31029",
 		"jp_explainShort": "ダメージ軽減＋双機銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     50%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31030",
 		"jp_explainShort": "ダメージ大軽減＋双機銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     70%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31061",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Wind\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Wind\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Wind\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Wind\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31071",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Converts your highest value Element to\n     the targeted enemy's weakness Element.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31072",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Converts your highest value Element to\n     the targeted enemy's weakness Element.\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31085",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Dark\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Dark\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Dark\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Dark\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31093",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Inflicts [Burn] on the target.\n②  Boosts damage by 50% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 21 seconds"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Inflicts [Burn] on the target.\n②  Boosts damage by 75% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 95% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 21 seconds"
 	},
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with a Katana.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n②  Further boosts damage if equipped with a Katana.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31099",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces CP consumption by 40%.\n<color=yellow>SP: </color>Reduces CP consumption by 50%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31100",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces CP consumption by 60%.\n<color=yellow>SP: </color>Reduces CP consumption by 70%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31119",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31131",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
-		"tr_explainShort": "ATK boosted x chip ability level",
+		"tr_explainShort": "Damage boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 30% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
-		"tr_explainShort": "ATK boosted x chip ability level",
+		"tr_explainShort": "Damage boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 0.4 x the number of different chip\n     elements equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers CP by 0.8 x the number of different chip\n     elements equipped every 5 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of different chip elements equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 1 x the number of different chip\n     elements equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers CP by 1.2 x the number of different chip\n     elements equipped every 5 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + barrier",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% of your maximum HP x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% of your maximum HP x the number of\n     different chip elements equipped.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + barrier",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     8% of your maximum HP x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     9% of your maximum HP x the number of\n     different chip elements equipped.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31145",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
 		"tr_explainShort": "[Freeze] + damage boost vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Immensely boosts damage against enemies\n    affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Inflicts [Freeze] on the target.\n②  Boosts damage by 120% against enemies\n     affected by [Freeze].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Freeze].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
 		"tr_explainShort": "[Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Immensely boosts damage against enemies\n    affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Inflicts [Freeze] on the target.\n②  Boosts damage by 160% against enemies\n     affected by [Freeze].\n<color=yellow>SP: </color>Boosts damage by 200% against enemies\n     affected by [Freeze].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31163",
 		"jp_explainShort": "定期的に劇的ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた劇的ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals regular dramatic damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals 1300% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 1600% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 500,000)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "定期的に絶大ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた絶大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals regular massive damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals 1900% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 2200% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 500,000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31175",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 3 every 3.3 seconds.\n<color=yellow>SP: </color>Recovers CP by 4 every 3.3 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 3.3 seconds.\n<color=yellow>SP: </color>Recovers CP by 6 every 3.3 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31189",
 		"jp_explainShort": "必殺技の威力大強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31190",
 		"jp_explainShort": "必殺技の威力劇的強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31197",
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20% every 3 seconds.\n     (Maximum boost: 120%)\n<color=yellow>SP: </color>Boosts damage by 24% every 3 seconds.\n     (Maximum boost: 140%)\n     <color=yellow>[G-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n<color=yellow>SP: </color>Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n     <color=yellow>[G-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    activate an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 2% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 5 seconds.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    activate an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 2% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 5 seconds.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage each time you activate\n    an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 2 seconds.\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage each time you activate\n    an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 2 seconds.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 3% of max HP)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 3% of max HP)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31227",
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 70.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 80.\n<color=yellow>SP: </color>Increases your Lightning Element by 90.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31241",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of Techs by 20%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>  Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 4 every 10 seconds.\n<color=yellow>SP: </color>Recovers CP by 6 every 10 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 10 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 10 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31249",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 20% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31255",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 18% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of other Active Chip effects\n     by 10 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 19% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of other Active Chip effects\n     by 10 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31259",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Light Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Light Techs by 30% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 40% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 35%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31260",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Light Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Light Techs by 50% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 60% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 35%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31269",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Elements.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements by 50.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31270",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Elements.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements by 50.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31277",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31278",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31291",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
 		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 100.\n②  Deals an additional 45% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31292",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
 		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 100.\n②  Deals an additional 55% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31311",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31312",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 1000 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 10000)\n<color=yellow>SP: </color>Increases your ATK by 1100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 11000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31315",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31316",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 33% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31319",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120% against enemies that\n     are weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies that\n     are weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31320",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 140% against enemies that\n     are weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 150% against enemies that\n     are weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 25%.\n<color=yellow>SP: </color>Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31327",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 20%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31328",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 95%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 20%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31335",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 1.65% x the number of Light chips\n     equipped every 6.5 seconds.\n<color=yellow>SP: </color>Recovers HP by 2.30% x the number of Light chips\n     equipped every 6.5 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31336",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP at regular intervals based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 2.65% x the number of Light chips\n     equipped every 6.5 seconds.\n<color=yellow>SP: </color>Recovers HP by 3.30% x the number of Light chips\n     equipped every 6.5 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31339",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Wind weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 25% if using a Wind\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31340",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Wind weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 25% if using a Wind\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31345",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 砂漠か地下坑道か採掘場での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% if fighting in the\n     Desert, the Tunnels or the Quarry.\n     <color=yellow>[I-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31346",
 		"jp_explainShort": "攻撃力大増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 砂漠か地下坑道か採掘場での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% if fighting in the\n     Desert, the Tunnels or the Quarry.\n     <color=yellow>[I-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31355",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 20 CP every 9.8 seconds.\n<color=yellow>SP: </color>Recovers 21 CP every 9.8 seconds.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31356",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 21 CP every 9.8 seconds.\n<color=yellow>SP: </color>Recovers 22 CP every 9.8 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31379",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Ice weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using an Ice\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31380",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Ice weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using an Ice\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31389",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31405",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力大増加",
 		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 35%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31406",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 35%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31409",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31410",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31417",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力劇的強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 115%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31418",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 155%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 175%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31419",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 12% every 3 seconds.\n     (Maximum boost: 70%)\n<color=yellow>SP: </color>Boosts damage by 14% every 3 seconds.\n     (Maximum boost: 80%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31420",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 17% every 3 seconds.\n     (Maximum boost: 100%)\n<color=yellow>SP: </color>Boosts damage by 19% every 3 seconds.\n     (Maximum boost: 110%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31425",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31426",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 90% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31427",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
 		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage against Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31428",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
 		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage against Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31437",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 30% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "31438",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31443",
 		"jp_explainShort": "氷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Ice Element up + damage boosted",
 		"jp_explainLong": "① 氷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases Ice Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Ice Element by 60.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31444",
 		"jp_explainShort": "氷属性劇的強化＋追加特大ダメージ",
 		"tr_explainShort": "Ice Element up + damage boosted",
 		"jp_explainLong": "① 氷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases Ice Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Ice Element by 80.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31453",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31454",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31457",
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n③  Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31458",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n③  Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 80 seconds"
 	},
 	{
 		"assign": "31475",
 		"jp_explainShort": "雷枚数攻撃力絶大増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 30% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of Chip abilities by 5 seconds.\n[Effect Duration] 56 seconds"
 	},
 	{
 		"assign": "31476",
 		"jp_explainShort": "雷枚数攻撃力超絶増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n① チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 35% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 40% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of Chip abilities by 5 seconds.\n[Effect Duration] 56 seconds"
 	},
 	{
 		"assign": "31483",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31484",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 22% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 23% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31485",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage x your Dark\n     Element.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31486",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 33% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage x your Dark\n     Element.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31499",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts PAs and Techs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 25% +\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 30% +\n     2% x this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31500",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 35% +\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 40% +\n     2% x this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31507",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     Fire chips equipped.\n③  Grants knockdown immunity.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31508",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     Fire chips equipped.\n③  Grants knockdown immunity.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31509",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Greatly boosts damage against enemies affected\n    by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 60% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31510",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31517",
 		"jp_explainShort": "攻撃力絶大増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    use a PA or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 13% each time you use\n     a PA or Tech.\n     (Maximum boost: 65%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31518",
 		"jp_explainShort": "攻撃力絶大増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    use a PA or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 13% each time you use\n     a PA or Tech.\n     (Maximum boost: 65%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31519",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 28% every 3 seconds.\n     (Maximum boost: 165%)\n<color=yellow>SP: </color>Boosts damage by 31% every 3 seconds.\n     (Maximum boost: 185%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 15%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31520",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 33% every 3 seconds.\n     (Maximum boost: 195%)\n<color=yellow>SP: </color>Boosts damage by 36% every 3 seconds.\n     (Maximum boost: 215%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 15%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31523",
 		"jp_explainShort": "ＨＰ・ＣＰ特大回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを劇的に回復する。\n③ ＣＰを劇的に回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Dramatically recovers HP.\n③ Dramatically recovers CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 97%.\n<color=yellow>SP: </color>Recovers HP by 98%.\n③  Recovers CP by 97.\n<color=yellow>SP: </color>Recovers CP by 98.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31524",
 		"jp_explainShort": "ＨＰ・ＣＰ特大回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを劇的に回復する。\n③ ＣＰを劇的に回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Dramatically recovers HP.\n③ Dramatically recovers CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 99%.\n<color=yellow>SP: </color>Recovers HP by 100%.\n③  Recovers CP by 99.\n<color=yellow>SP: </color>Recovers CP by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31533",
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31534",
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31539",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種とダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 85% against Mechs and\n     Darkers.\n<color=yellow>SP: </color>Boosts damage by 90% against Mechs and\n     Darkers.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31540",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種とダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 95% against Mechs and\n     Darkers.\n<color=yellow>SP: </color>Boosts damage by 100% against Mechs and\n     Darkers.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31543",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ減＋指定技威力強化",
 		"tr_explainShort": "Damage boost + damage res. + PA boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 「オーバーエンド」の威力を絶大に強化する。\n③ 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts the power of \"Over End\".\n    <color=yellow>[A-Frame]</color>\n③ Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of \"Over End\" by 175%.\n     <color=yellow>[A-Frame]</color>\n③  Reduces damage taken from enemies by 40%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31544",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ減＋指定技威力強化",
 		"tr_explainShort": "Damage boost + damage res. + PA boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 「オーバーエンド」の威力を絶大に強化する。\n③ 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts the power of \"Over End\".\n    <color=yellow>[A-Frame]</color>\n③ Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 230%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of \"Over End\" by 175%.\n     <color=yellow>[A-Frame]</color>\n③  Reduces damage taken from enemies by 40%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31555",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 60%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 70%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31556",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 80%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 90%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31566",
 		"jp_explainShort": "炎属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Fire weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31567",
 		"jp_explainShort": "炎属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Fire weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 130% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31570",
 		"jp_explainShort": "ダメージ極度増加＋効果終了時に被ダメージ",
 		"tr_explainShort": "Damage boost + take damage at the end",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 効果時間終了時に最大ＨＰの９０％の\n　　 ダメージを受ける。（ＨＰは最低でも１残る）\n　　 ただし、ＨＰが９０％未満の場合\n　　 このチップを発動できない。\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② When this effect ends, you take damage equal to\n    90% of your maximum HP.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 90% HP.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 370%.\n<color=yellow>SP: </color>Boosts damage by 380%.\n     <color=yellow>[E-Frame]</color>\n②  When this effect ends, you take damage equal to\n     90% of your maximum HP.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 90% HP.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31571",
 		"jp_explainShort": "ダメージ極度増加＋効果終了時に被ダメージ",
 		"tr_explainShort": "Damage boost + take damage at the end",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 効果時間終了時に最大ＨＰの９０％の\n　　 ダメージを受ける。（ＨＰは最低でも１残る）\n　　 ただし、ＨＰが９０％未満の場合\n　　 このチップを発動できない。\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② When this effect ends, you take damage equal to\n    90% of your maximum HP.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 90% HP.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  When this effect ends, you take damage equal to\n     90% of your maximum HP.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 90% HP.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31576",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は氷属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Ice PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 235%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Ice PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31577",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は氷属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Ice PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Ice PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31578",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31581",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31582",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 850 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8500)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31589",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力超絶強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 210%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 215%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 40%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31590",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力超絶強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 220%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 225%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 40%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31599",
 		"jp_explainShort": "攻撃力増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31600",
 		"jp_explainShort": "攻撃力大増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31605",
 		"jp_explainShort": "氷属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Ice weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120% if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31606",
 		"jp_explainShort": "氷属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Ice weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 130% if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31609",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。（最大時：超絶）\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum increase: Overwhelming)\n③ Increases your maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 1000.\n<color=yellow>SP: </color>Increases your ATK by 1500.\n②  Increases your ATK by 15 x this chip's ability\n     level each time you successfully perform a Just\n     Attack.\n③  Increases your maximum CP by 30.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31610",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。（最大時：超絶）\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum increase: Overwhelming)\n③ Increases your maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 2000.\n<color=yellow>SP: </color>Increases your ATK by 2500.\n②  Increases your ATK by 15 x this chip's ability\n     level each time you successfully perform a Just\n     Attack.\n③  Increases your maximum CP by 30.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31624",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 32% each time you use a PA\n     or Tech.\n     (Maximum boost: 160%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31625",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 34% each time you use a PA\n     or Tech.\n     (Maximum boost: 170%)\n<color=yellow>SP: </color>Boosts damage by 36% each time you use a PA\n     or Tech.\n     (Maximum boost: 180%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31633",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31634",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31635",
 		"jp_explainShort": "攻撃力極度増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 320%.\n<color=yellow>SP: </color>Boosts damage by 325%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31644",
 		"jp_explainShort": "アビリティＬｖ攻撃劇的増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 10% + 10% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 20% + 10% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31645",
 		"jp_explainShort": "アビリティＬｖ攻撃絶大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% + 10% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 40% + 10% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31646",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31647",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31652",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９０％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Cuts your current HP by 90%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Cuts your current HP by 90%.\n②  Increases your ATK by 12500.\n<color=yellow>SP: </color>Increases your ATK by 14000.\n③  Recovers HP by 5% every 1.8 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31653",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９０％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Cuts your current HP by 90%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Cuts your current HP by 90%.\n②  Increases your ATK by 15500.\n<color=yellow>SP: </color>Increases your ATK by 17000.\n③  Recovers HP by 5% every 1.8 seconds.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31662",
 		"jp_explainShort": "闇属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Dark weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31663",
 		"jp_explainShort": "闇属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Dark weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 130% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31664",
 		"jp_explainShort": "消費ＣＰ減＋原生・龍族にダメージ劇的増",
 		"tr_explainShort": "CP use down + boost vs Native&Dragon",
 		"jp_explainLong": "① 原生種と龍族に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Natives\n    and Dragonkin.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 85% against Natives and\n     Dragonkin.\n<color=yellow>SP: </color>Boosts damage by 90% against Natives and\n     Dragonkin.\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31665",
 		"jp_explainShort": "消費ＣＰ減＋原生・龍族にダメージ劇的増",
 		"tr_explainShort": "CP use down + boost vs Native&Dragon",
 		"jp_explainLong": "① 原生種と龍族に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Natives\n    and Dragonkin.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 95% against Natives and\n     Dragonkin.\n<color=yellow>SP: </color>Boosts damage by 100% against Natives and\n     Dragonkin.\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31666",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 255%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31667",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 270%.\n<color=yellow>SP: </color>Boosts damage by 275%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31668",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 295%.\n<color=yellow>SP: </color>Boosts damage by 300%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31673",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Boosts damage against enemies affected by\n    [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 35% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 40% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31674",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ大増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Greatly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 45% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 50% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31677",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 150%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 9 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 170%.\n<color=yellow>SP: </color>Boosts power by 190%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 9 seconds.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31700",
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を劇的に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 15% for\n     each different chip element equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 20% for\n     each different chip element equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n     (Maximum increase: 4500)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31701",
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 25% for\n     each different chip element equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 30% for\n     each different chip element equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n     (Maximum increase: 4500)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31702",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31703",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31704",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31711",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + barrier + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental damage by 135% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 145% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31712",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + barrier + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental damage by 155% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 165% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31713",
 		"jp_explainShort": "攻撃力を劇的強化＋防御力減少",
 		"tr_explainShort": "ATK increased + DEF decreased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 防御力を減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Reduces your DEF.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 4500.\n<color=yellow>SP: </color>Increases your ATK by 5000.\n②  Reduces your DEF by 350.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31714",
 		"jp_explainShort": "攻撃力を絶大強化＋防御力減少",
 		"tr_explainShort": "ATK increased + DEF decreased",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② 防御力を減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely increases ATK.\n② Reduces your DEF.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 5500.\n<color=yellow>SP: </color>Increases your ATK by 6000.\n②  Reduces your DEF by 350.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31733",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31734",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31735",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31742",
 		"jp_explainShort": "威力絶大増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Power boosted + CP recovery over time",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 180%.\n<color=yellow>SP: </color>Boosts power by 190%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers CP by 5 every 10 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31743",
 		"jp_explainShort": "威力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Power boosted + CP recovery over time",
 		"jp_explainLong": "① 威力を超絶に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 200%.\n<color=yellow>SP: </color>Boosts power by 210%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers CP by 5 every 10 seconds.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31748",
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 3500.\n<color=yellow>SP: </color>Increases your ATK by 4000.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     10% x the number of Lightning chips equipped.\n     <color=yellow>[Chase Boost]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31749",
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 4500.\n<color=yellow>SP: </color>Increases your ATK by 5000.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     10% x the number of Lightning chips equipped.\n     <color=yellow>[Chase Boost]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31750",
 		"jp_explainShort": "代償攻撃力絶大増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を絶大に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 170% in exchange for taking\n     more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 180% in exchange for taking\n     more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants a 25% chance to resist knockback and\n     flinching.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31751",
 		"jp_explainShort": "代償攻撃力絶大増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を絶大に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 190% in exchange for taking\n     more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 200% in exchange for taking\n     more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants a 25% chance to resist knockback and\n     flinching.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31752",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31753",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31754",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 310%.\n<color=yellow>SP: </color>Boosts damage by 315%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31757",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 21% every 3 seconds.\n     (Maximum boost: 125%)\n<color=yellow>SP: </color>Boosts damage by 23% every 3 seconds.\n     (Maximum boost: 135%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31758",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 24% every 3 seconds.\n     (Maximum boost: 145%)\n<color=yellow>SP: </color>Boosts damage by 26% every 3 seconds.\n     (Maximum boost: 155%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31759",
 		"jp_explainShort": "絶大追撃＋ダーカー大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost. vs Darkers + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ダーカーに与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 170% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31760",
 		"jp_explainShort": "絶大追撃＋ダーカー大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost. vs Darkers + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ダーカーに与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals an additional 175% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 180% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31772",
 		"jp_explainShort": "攻撃力絶大増加＋一定確率で自身がフリーズ",
 		"tr_explainShort": "Damage boost but chance to [Freeze] self",
 		"jp_explainLong": "① 定期的に一定確率でフリーズになる代わりに\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in exchange for having\n    a chance to [Freeze] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 150% in exchange for having\n     a chance to [Freeze] you every 5 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31773",
 		"jp_explainShort": "攻撃力絶大増加＋一定確率で自身がフリーズ",
 		"tr_explainShort": "Damage boost but chance to [Freeze] self",
 		"jp_explainLong": "① 定期的に一定確率でフリーズになる代わりに\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage in exchange for having\n    a chance to [Freeze] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160% in exchange for having\n     a chance to [Freeze] you every 5 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31778",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Elem. dam. boost + barrier + rand. evasion",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental damage by 70% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 75% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31779",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Elem. dam. boost + barrier + rand. evasion",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental damage by 75% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 80% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31780",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the activation rate of all Support Chips\n     by 30%.\n③  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31781",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the activation rate of all Support Chips\n     by 30%.\n③  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31788",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "PA/T boost x lv. + barr. + counter-Freeze",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts all PAs and Techs by 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 6% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% of your HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31789",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "PA/T boost x lv. + barr. + counter-Freeze",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts all PAs and Techs by 6% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 7% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% of your HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31790",
 		"jp_explainShort": "被バーン状態時に攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted while burned",
 		"jp_explainLong": "① 自身が「バーン」状態にある場合に\r\n　　 攻撃力を劇的に増加する。\r\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage while you are\n    affected by [Burn].\n    <color=yellow>[O-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110% while you are affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 115% while you are affected\n     by [Burn].\n     <color=yellow>[O-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31791",
 		"jp_explainShort": "被バーン状態時に攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted while burned",
 		"jp_explainLong": "① 自身が「バーン」状態にある場合に\r\n　　 攻撃力を劇的に増加する。\r\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage while you are\n    affected by [Burn].\n    <color=yellow>[O-Frame]</color>\r\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 115% while you are affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 120% while you are affected\n     by [Burn].\n     <color=yellow>[O-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31794",
 		"jp_explainShort": "消費ＣＰ減＋機甲・機改種にダメージ劇的増",
 		"tr_explainShort": "CP usage down + dam. boost vs all Mechs",
 		"jp_explainLong": "① 機甲種と機改種に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs and\n    Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Mechs and Reconfigured\n     Mechs by 85%.\n<color=yellow>SP: </color>Boosts damage against Mechs and Reconfigured\n     Mechs by 90%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31795",
 		"jp_explainShort": "消費ＣＰ減＋機甲・機改種にダメージ劇的増",
 		"tr_explainShort": "CP usage down + dam. boost vs all Mechs",
 		"jp_explainLong": "① 機甲種と機改種に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs and\n    Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Mechs and Reconfigured\n     Mechs by 95%.\n<color=yellow>SP: </color>Boosts damage against Mechs and Reconfigured\n     Mechs by 100%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31823",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Weaknesses boosted + CP increased",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 20.\n③  Recovers CP by 20.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31824",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Weaknesses boosted + CP increased",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 100% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 20.\n③  Recovers CP by 20.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31830",
 		"jp_explainShort": "状態異常を取り払いＨＰを中回復",
 		"tr_explainShort": "Status cured + HP recovered",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰを回復する。",
-		"tr_explainLong": "① Cures status effects on yourself.\n② Recovers HP."
+		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 45%.\n<color=yellow>SP: </color>Recovers HP by 50%."
 	},
 	{
 		"assign": "31831",
 		"jp_explainShort": "状態異常を取り払いＨＰを大回復",
 		"tr_explainShort": "Status cured + HP recovered",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰを大きく回復する。",
-		"tr_explainLong": "① Cures status effects on yourself.\n② Greatly recovers HP."
+		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 55%.\n<color=yellow>SP: </color>Recovers HP by 60%."
 	},
 	{
 		"assign": "31834",
 		"jp_explainShort": "氷属性ダメージ＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "Ice weak boost + barrier + counter [Freeze]",
 		"jp_explainLong": "① 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Ice elemental damage against\n    enemies weak to Ice.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Ice elemental damage by 150% against\n     enemies weak to Ice.\n<color=yellow>SP: </color>Boosts Ice elemental damage by 155% against\n     enemies weak to Ice.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31835",
 		"jp_explainShort": "氷属性ダメージ＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "Ice weak boost + barrier + counter [Freeze]",
 		"jp_explainLong": "① 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Ice elemental damage against\n    enemies weak to Ice.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Ice elemental damage by 160% against\n     enemies weak to Ice.\n<color=yellow>SP: </color>Boosts Ice elemental damage by 165% against\n     enemies weak to Ice.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31840",
 		"jp_explainShort": "光枚数ＪＡ威力劇的増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted x # Light + JA = ATK up",
 		"jp_explainLong": "① 装備中チップの光属性チップの枚数に応じて\n　　 ジャストアタックの威力を劇的に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of Light chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully perform\n  a Just Attack.\n  (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 15% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 20% x\n     the number of Light chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n  (Maximum Increase: 4500)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31841",
 		"jp_explainShort": "光枚数ＪＡ威力絶大増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted x # Light + JA = ATK up",
 		"jp_explainLong": "① 装備中チップの光属性チップの枚数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Just Attacks based on the\n    number of Light chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully perform\n  a Just Attack.\n  (Maximum Increase: Dramatic)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 25% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 30% x\n     the number of Light chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n  (Maximum Increase: 4500)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31842",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31843",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31844",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31845",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：大きく）\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Great)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 11% each time you use a PA\n     or Tech.\n     (Maximum boost: 55%)\n<color=yellow>SP: </color>Boosts damage by 12% each time you use a PA\n     or Tech.\n     (Maximum boost: 60%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31846",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 13% each time you use a PA\n     or Tech.\n     (Maximum boost: 65%)\n<color=yellow>SP: </color>Boosts damage by 14% each time you use a PA\n     or Tech.\n     (Maximum boost: 70%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31847",
 		"jp_explainShort": "ＣＰ全回復＋攻撃力極度強化＋定期的ＣＰ減少",
 		"tr_explainShort": "CP full recov. + dam. boost but leaking CP",
 		"jp_explainLong": "① ＣＰを全回復する。\n② 定期的にＣＰが減少する代わりに\n　　 攻撃力を極度に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Fully recovers your CP.\n② Maximally boosts damage in exchange for losing\n    CP at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Fully recovers your CP.\n②  Boosts damage by 630% in exchange for losing\n     10 CP every 0.1 seconds.\n<color=yellow>SP: </color>Boosts damage by 640% in exchange for losing\n     10 CP every 0.1 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31848",
 		"jp_explainShort": "ＣＰ全回復＋攻撃力極度強化＋定期的ＣＰ減少",
 		"tr_explainShort": "CP full recov. + dam. boost but leaking CP",
 		"jp_explainLong": "① ＣＰを全回復する。\n② 定期的にＣＰが減少する代わりに\n　　 攻撃力を極度に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Fully recovers your CP.\n② Maximally boosts damage in exchange for losing\n    CP at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Fully recovers your CP.\n②  Boosts damage by 650% in exchange for losing\n     10 CP every 0.1 seconds.\n<color=yellow>SP: </color>Boosts damage by 660% in exchange for losing\n     10 CP every 0.1 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31849",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31850",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31851",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31852",
 		"jp_explainShort": "炎枚数属性ダメージ＋炎枚数属性上限上昇",
 		"tr_explainShort": "Fire elem. boosted + max Fire value up",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じ\n　　 炎属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Fire elemental damage\n    against enemies weak to Fire based on the\n    number of Fire chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Fire value based\n    on the number of Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Fire elemental damage against\n     enemies weak to Fire by 120% + 10% x\n     the number of Fire chips equipped.\n<color=yellow>SP: </color>Boosts Fire elemental damage against\n     enemies weak to Fire by 130% + 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Fire value by 10 x the\n     number of Fire chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31853",
 		"jp_explainShort": "炎枚数属性ダメージ＋炎枚数属性上限上昇",
 		"tr_explainShort": "Fire elem. boosted + max Fire value up",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じ\n　　 炎属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Fire elemental damage\n    against enemies weak to Fire based on the\n    number of Fire chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Fire value based\n    on the number of Fire chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Fire elemental damage against\n     enemies weak to Fire by 140% + 10% x\n     the number of Fire chips equipped.\n<color=yellow>SP: </color>Boosts Fire elemental damage against\n     enemies weak to Fire by 150% + 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Fire value by 10 x the\n     number of Fire chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31858",
 		"jp_explainShort": "闇枚数属性ダメージ＋闇枚数属性上限上昇",
 		"tr_explainShort": "Dark elem. boosted + max Dark value up",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じ\n　　 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Dark elemental damage against\n    enemies weak to Dark based on the number of\n    Dark chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Dark value\n    based on the number of Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Dark elemental damage against\n     enemies weak to Dark by 120% + 10% x\n     the number of Dark chips equipped.\n<color=yellow>SP: </color>Boosts Dark elemental damage against\n     enemies weak to Dark by 130% + 10% x\n     the number of Dark chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Dark value by 10 x the\n     number of Dark chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31859",
 		"jp_explainShort": "闇枚数属性ダメージ＋闇枚数属性上限上昇",
 		"tr_explainShort": "Dark elem. boosted + max Dark value up",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じ\n　　 闇属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Dark elemental damage\n    against enemies weak to Dark based on the\n    number of Dark chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Dark value\n    based on the number of Dark chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Dark elemental damage against\n     enemies weak to Dark by 140% + 10% x\n     the number of Dark chips equipped.\n<color=yellow>SP: </color>Boosts Dark elemental damage against\n     enemies weak to Dark by 150% + 10% x\n     the number of Dark chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Dark value by 10 x the\n     number of Dark chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31864",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 9000.\n<color=yellow>SP: </color>Increases your ATK by 10000.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31865",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 11000.\n<color=yellow>SP: </color>Increases your ATK by 12000.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31881",
 		"jp_explainShort": "定期的にダメージ",
 		"tr_explainShort": "Damage over time",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じたダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals damage based on attack power to the\n    targeted enemy at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals 400% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 500% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 100,000)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31882",
 		"jp_explainShort": "定期的に大ダメージ",
 		"tr_explainShort": "Damage over time",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "① Deals heavy damage based on attack power to\n    the targeted enemy at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Deals 600% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 700% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 100,000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31885",
 		"jp_explainShort": "風枚数属性ダメージ＋風枚数属性上限上昇",
 		"tr_explainShort": "Wind elem. boosted + max Wind value up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じ\n　　 風属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Wind elemental damage\n    against enemies weak to Wind based on the\n    number of Wind chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Wind value\n    based on the number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Wind elemental damage against\n     enemies weak to Wind by 120% + 10% x\n     the number of Wind chips equipped.\n<color=yellow>SP: </color>Boosts Wind elemental damage against\n     enemies weak to Wind by 130% + 10% x\n     the number of Wind chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Wind value by 10 x the\n     number of Wind chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31886",
 		"jp_explainShort": "風枚数属性ダメージ＋風枚数属性上限上昇",
 		"tr_explainShort": "Wind elem. boosted + max Wind value up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じ\n　　 風属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Wind elemental damage\n    against enemies weak to Wind based on the\n    number of Wind chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Wind value\n    based on the number of Wind chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Wind elemental damage against\n     enemies weak to Wind by 140% + 10% x\n     the number of Wind chips equipped.\n<color=yellow>SP: </color>Boosts Wind elemental damage against\n     enemies weak to Wind by 150% + 10% x\n     the number of Wind chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Wind value by 10 x the\n     number of Wind chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31887",
 		"jp_explainShort": "定期ＨＰ減少＋与ダメージ増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost but leaking HP + CP regen up",
 		"jp_explainLong": "① 定期的にＨＰが最大ＨＰの５％減少する代わりに\n　　 与えるダメージを超絶に増加する。\n　　 （ＨＰは最低でも１残る）\n　　 ただし、ＨＰが５％未満の場合\n　　 このチップを発動できない。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in exchange for\n    losing 5% of your HP at regular intervals.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 5% HP.\n    <color=yellow>[Y-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 250% in exchange for losing\n     5% of your HP every second.\n<color=yellow>SP: </color>Boosts damage by 260% in exchange for losing\n     5% of your HP every second.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 5% HP.\n     <color=yellow>[Y-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31888",
 		"jp_explainShort": "定期ＨＰ減少＋与ダメージ増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost but leaking HP + CP regen up",
 		"jp_explainLong": "① 定期的にＨＰが最大ＨＰの５％減少する代わりに\n　　 与えるダメージを超絶に増加する。\n　　 （ＨＰは最低でも１残る）\n　　 ただし、ＨＰが５％未満の場合\n　　 このチップを発動できない。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage in exchange for\n    losing 5% of your HP at regular intervals.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 5% HP.\n    <color=yellow>[Y-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 270% in exchange for losing\n     5% of your HP every second.\n<color=yellow>SP: </color>Boosts damage by 280% in exchange for losing\n     5% of your HP every second.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 5% HP.\n     <color=yellow>[Y-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31899",
 		"jp_explainShort": "雷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＣＰ回復",
 		"tr_explainShort": "JA boost x # Lightning + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of Lightning chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 35% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 40% x\n     the number of Lightning chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31900",
 		"jp_explainShort": "雷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＣＰ回復",
 		"tr_explainShort": "JA boost x # Lightning + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts Just Attacks based on the\n    number of Lightning chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the damage of Just Attacks by 45% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 50% x\n     the number of Lightning chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31901",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増加＋ＣＰ最大値増",
 		"tr_explainShort": "Dam. boost per PA/Tech use + max CP up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 54% each time you use a PA or\n     Tech.\n     (Maximum boost: 270%)\n<color=yellow>SP: </color>Boosts damage by 56% each time you use a PA or\n     Tech.\n     (Maximum boost: 280%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum CP by 30.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31902",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増加＋ＣＰ最大値増",
 		"tr_explainShort": "Dam. boost per PA/Tech use + max CP up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum CP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 58% each time you use a PA or\n     Tech.\n     (Maximum boost: 290%)\n<color=yellow>SP: </color>Boosts damage by 60% each time you use a PA or\n     Tech.\n     (Maximum boost: 300%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum CP by 30.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31903",
 		"jp_explainShort": "氷枚数属性ダメージ＋氷枚数属性上限上昇",
 		"tr_explainShort": "Ice elem. boosted + max Ice value up",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じ\n　　 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Ice elemental damage\n    against enemies weak to Ice based on the\n    number of Ice chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Ice value\n    based on the number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Ice elemental damage against\n     enemies weak to Ice by 120% + 10% x\n     the number of Ice chips equipped.\n<color=yellow>SP: </color>Boosts Ice elemental damage against\n     enemies weak to Ice by 130% + 10% x\n     the number of Ice chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Ice value by 10 x the\n     number of Ice chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31904",
 		"jp_explainShort": "氷枚数属性ダメージ＋氷枚数属性上限上昇",
 		"tr_explainShort": "Ice elem. boosted + max Ice value up",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じ\n　　 氷属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Ice elemental damage\n    against enemies weak to Ice based on the\n    number of Ice chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Ice value\n    based on the number of Ice chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Ice elemental damage against\n     enemies weak to Ice by 140% + 10% x\n     the number of Ice chips equipped.\n<color=yellow>SP: </color>Boosts Ice elemental damage against\n     enemies weak to Ice by 150% + 10% x\n     the number of Ice chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Ice value by 10 x the\n     number of Ice chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31907",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 245%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31908",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31909",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31922",
 		"jp_explainShort": "光枚数属性ダメージ＋光枚数属性上限上昇",
 		"tr_explainShort": "Light elem. boosted + max Light value up",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じ\n　　 光属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Light elemental damage\n    against enemies weak to Light based on the\n    number of Light chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Light value\n    based on the number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Light elemental damage against\n     enemies weak to Light by 120% + 10% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts Light elemental damage against\n     enemies weak to Light by 130% + 10% x\n     the number of Light chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Light value by 10 x the\n     number of Light chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31923",
 		"jp_explainShort": "光枚数属性ダメージ＋光枚数属性上限上昇",
 		"tr_explainShort": "Light elem. boosted + max Light value up",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じ\n　　 光属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Light elemental damage\n    against enemies weak to Light based on the\n    number of Light chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Light value\n    based on the number of Light chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Light elemental damage against\n     enemies weak to Light by 140% + 10% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts Light elemental damage against\n     enemies weak to Light by 150% + 10% x\n     the number of Light chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Light value by 10 x the\n     number of Light chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31938",
 		"jp_explainShort": "必殺技・法術威力絶大強化＋ダメージ軽減",
 		"tr_explainShort": "PAs/Techs boosted + dam. taken reduced",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power of PAs and Techs by 125%.\n<color=yellow>SP: </color>Boosts power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31939",
 		"jp_explainShort": "必殺技・法術威力絶大強化＋ダメージ大軽減",
 		"tr_explainShort": "PAs/Techs boosted + dam. taken reduced",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts power of PAs and Techs by 155%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 45%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31949",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＣＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Fi/Th/Da + CP regen",
 		"jp_explainLong": "① アビリティレベルと炎・雷・闇属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts elemental power based on\n    this chip's ability level and the total value of your\n    Fire, Lightning and Dark elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental power by 5% + 8% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 9% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31950",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＣＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Fi/Th/Da + CP regen",
 		"jp_explainLong": "① アビリティレベルと炎・雷・闇属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts elemental power based on\n    this chip's ability level and the total value of your\n    Fire, Lightning and Dark elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts elemental power by 5% + 10% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 11% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31951",
 		"jp_explainShort": "雷枚数属性ダメージ＋雷枚数属性上限上昇",
 		"tr_explainShort": "Lightning elem. damage boost x # Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts Lightning elemental\n    damage against enemies weak to Lightning based\n    on the number of Lightning chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 120% + 10% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts Lightning elemental damage against\n     enemies weak to Lightning by 130% + 10% x\n     the number of Lightning chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Lightning value by 10 x\n     the number of Lightning chips equipped.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31952",
 		"jp_explainShort": "雷枚数属性ダメージ＋雷枚数属性上限上昇",
 		"tr_explainShort": "Lightning elem. damage boost x # Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts Lightning elemental\n    damage against enemies weak to Lightning based\n    on the number of Lightning chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 140% + 10% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts Lightning elemental damage against\n     enemies weak to Lightning by 150% + 10% x\n     the number of Lightning chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Lightning value by 10 x\n     the number of Lightning chips equipped.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31953",
 		"jp_explainShort": "威力絶大増＋闇武器攻撃力大増＋闇属性上限上昇",
 		"tr_explainShort": "Power boost + Dark wep. boost + max Dark up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が闇属性の場合\n　　 攻撃力を大きく増加する。\n③ 闇属性の上限値が上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Dark element value.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 140%.\n<color=yellow>SP: </color>Boosts power by 150%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Dark value by 30.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31954",
 		"jp_explainShort": "威力絶大増＋闇武器攻撃力大増＋闇属性上限上昇",
 		"tr_explainShort": "Power boost + Dark wep. boost + max Dark up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が闇属性の場合\n　　 攻撃力を大きく増加する。\n③ 闇属性の上限値が上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Dark element value.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 170%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Dark value by 30.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31963",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
-		"tr_explainShort": "Cuts HP to damage all enemies",
+		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に光属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive Light striking damage to yourself\n    and all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 12500% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP.\n<color=yellow>SP: </color>Deals 13000% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP."
 	},
 	{
 		"assign": "31964",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
-		"tr_explainShort": "Cuts HP to damage all enemies",
+		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に光属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive Light striking damage to yourself\n    and all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 13500% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP.\n<color=yellow>SP: </color>Deals 14000% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP."
 	},
 	{
 		"assign": "31965",
 		"jp_explainShort": "アビＬｖ攻撃力劇的増加＋一定確率で自身がバーン",
 		"tr_explainShort": "Dam. boost x ab. lv. but chance to [Burn] self",
 		"jp_explainLong": "① 定期的に一定確率でバーンになる代わりに\n　　 アビリティレベルに応じて攻撃力を劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level in exchange for having a chance to\n    [Burn] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n<color=yellow>SP: </color>Boosts damage by 80% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31966",
 		"jp_explainShort": "アビＬｖ攻撃力劇的増加＋一定確率で自身がバーン",
 		"tr_explainShort": "Dam. boost x ab. lv. but chance to [Burn] self",
 		"jp_explainLong": "① 定期的に一定確率でバーンになる代わりに\n　　 アビリティレベルに応じて攻撃力を劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level in exchange for having a chance to\n    [Burn] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n<color=yellow>SP: </color>Boosts damage by 100% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31967",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts attack power by 105% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 110% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31968",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts attack power by 115% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 120% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31973",
 		"jp_explainShort": "原生種・ダーカーにダメージ絶大増加＋軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Natives/Darkers",
 		"jp_explainLong": "① 原生種とダーカーに与えるダメージを絶大に増加する。\n② 原生種とダーカーから受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage against Natives and\n    Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives and Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Natives and Darkers by\n     135%.\n<color=yellow>SP: </color>Boosts damage against Natives and Darkers by\n     140%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives and Darkers\n     by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Natives and Darkers\n     by 35%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31974",
 		"jp_explainShort": "原生種・ダーカーにダメージ絶大増加＋大軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Natives/Darkers",
 		"jp_explainLong": "① 原生種とダーカーに与えるダメージを絶大に増加する。\n② 原生種とダーカーから受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage against Natives and\n    Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives and Darkers.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Natives and Darkers by\n     145%.\n<color=yellow>SP: </color>Boosts damage against Natives and Darkers by\n     150%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives and Darkers\n     by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Natives and Darkers\n     by 50%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31977",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31978",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts power by 150%.\n<color=yellow>SP: </color>Boosts power by 160%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31979",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "① Boosts power by 170%.\n<color=yellow>SP: </color>Boosts power by 180%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31980",
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31981",
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31992",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 365% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 375% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31993",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 385% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 395% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31994",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 410% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 420% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "2110",
 		"jp_explainShort": "防御力を大強化",
 		"tr_explainShort": "DEF increased",
 		"jp_explainLong": "① 防御力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases DEF.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your DEF by 650.\n<color=yellow>SP: </color>Increases your DEF by 700.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "2120",
 		"jp_explainShort": "防御力を劇的強化",
 		"tr_explainShort": "DEF increased",
 		"jp_explainLong": "① 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases DEF.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your DEF by 750.\n<color=yellow>SP: </color>Increases your DEF by 800.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "2410",
 		"jp_explainShort": "攻撃力を強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 350.\n<color=yellow>SP: </color>Increases your ATK by 370.\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "2420",
 		"jp_explainShort": "攻撃力を強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 380.\n<color=yellow>SP: </color>Increases your ATK by 400.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "80210",
 		"jp_explainShort": "攻撃力大増加＋ダメージ大軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 50%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "80220",
 		"jp_explainShort": "攻撃力大増加＋ダメージ大軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 60%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "80410",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 8% of damage dealt as HP.\n     (Maximum recovery per hit: 8% of max HP)\n<color=yellow>SP: </color>Recovers 10% of damage dealt as HP.\n     (Maximum recovery per hit: 10% of max HP)\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "80420",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 12% of damage dealt as HP.\n     (Maximum recovery per hit: 12% of max HP)\n<color=yellow>SP: </color>Recovers 15% of damage dealt as HP.\n     (Maximum recovery per hit: 15% of max HP)\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "80510",
 		"jp_explainShort": "攻撃力増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status cured",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "80520",
 		"jp_explainShort": "攻撃力大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status cured",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "80710",
 		"jp_explainShort": "攻撃力と防御力を強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 防御力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Increases DEF.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 270.\n<color=yellow>SP: </color>Increases your ATK by 290.\n②  Increases your DEF by 270.\n<color=yellow>SP: </color>Increases your DEF by 290.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "80720",
 		"jp_explainShort": "攻撃力と防御力を強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 防御力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK.\n② Increases DEF.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 290.\n<color=yellow>SP: </color>Increases your ATK by 320.\n②  Increases your DEF by 290.\n<color=yellow>SP: </color>Increases your DEF by 320.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "80810",
 		"jp_explainShort": "武器に「バーン」効果＋攻撃力を強化",
 		"tr_explainShort": "[Burn] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 420.\n<color=yellow>SP: </color>Increases your ATK by 440.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "80820",
 		"jp_explainShort": "武器に「バーン」効果＋攻撃力を大強化",
 		"tr_explainShort": "[Burn] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "80910",
 		"jp_explainShort": "ダメージを武器の上限値に収束させる",
-		"tr_explainShort": "Damage variance tightened",
+		"tr_explainShort": "Critical hit rate increased",
 		"jp_explainLong": "① 敵に与えるダメージを\n　　 装備中の武器における上限値に収束する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Tightens random damage variance to bring\n    minimum damage closer to maximum.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases critical hit rate by 70%.\n<color=yellow>SP: </color>Increases critical hit rate by 80%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "80920",
 		"jp_explainShort": "ダメージを武器の上限値に収束させる",
-		"tr_explainShort": "Damage variance tightened",
+		"tr_explainShort": "Critical hit rate increased",
 		"jp_explainLong": "① 敵に与えるダメージを\n　　 装備中の武器における上限値に収束する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Tightens random damage variance to bring\n    minimum damage closer to maximum.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases critical hit rate by 85%.\n<color=yellow>SP: </color>Increases critical hit rate by 95%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "81010",
 		"jp_explainShort": "氷属性の打撃による大ダメージ",
-		"tr_explainShort": "Ice striking damage to all enemies",
+		"tr_explainShort": "Ice striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 氷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1500% 200 Ice striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 2000% 200 Ice striking damage to the\n     target."
 	},
 	{
 		"assign": "81020",
 		"jp_explainShort": "氷属性の打撃による特大ダメージ",
-		"tr_explainShort": "Ice striking damage to all enemies",
+		"tr_explainShort": "Ice striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 氷属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals massive Ice striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 2500% 200 Ice striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 3000% 200 Ice striking damage to the\n     target."
 	},
 	{
 		"assign": "81110",
 		"jp_explainShort": "全体に中ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to all enemies.\n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 675% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 810% shooting damage to all enemies.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "81120",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy damage to all enemies.\n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 900% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1080% shooting damage to all enemies.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "81210",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "DEF decreased + ATK increased",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces your DEF by 50.\n<color=yellow>SP: </color>Reduces your DEF by 100.\n②  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "81220",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "DEF decreased + ATK increased",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces your DEF by 150\n<color=yellow>SP: </color>Reduces your DEF by 200.\n②  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "81610",
 		"jp_explainShort": "武器に「ミラージュ」＋攻撃力を強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 430.\n<color=yellow>SP: </color>Increases your ATK by 450.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "81620",
 		"jp_explainShort": "武器に「ミラージュ」＋攻撃力を大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 480.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "81710",
 		"jp_explainShort": "雷属性を強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "81720",
 		"jp_explainShort": "雷属性を大強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases Lightning Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 90.\n<color=yellow>SP: </color>Increases your Lightning Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "81810",
 		"jp_explainShort": "炎属性を強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 84.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "81820",
 		"jp_explainShort": "炎属性を大強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases Fire Element.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Fire Element by 90.\n<color=yellow>SP: </color>Increases your Fire Element by 100.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "50110",
@@ -5254,7 +5254,7 @@
 		"jp_explainShort": "無数の矢を同時に発射する強弓用の必殺技",
 		"tr_explainShort": "[Bullet Bow PA] - Million Storm",
 		"jp_explainLong": "「強弓用の必殺技」\n 敵を貫く無数の矢を同時に発射する。",
-		"tr_explainLong": "Bullet Bow PA]\nFire countless arrows that pierce the enemy."
+		"tr_explainLong": "[Bullet Bow PA]\nFire countless arrows that pierce the enemy."
 	},
 	{
 		"assign": "60141",
@@ -7207,224 +7207,224 @@
 		"jp_explainShort": "ＨＰを小回復",
 		"tr_explainShort": "Small HP recovery",
 		"jp_explainLong": "① ＨＰをわずかに回復する。",
-		"tr_explainLong": "① Slightly recovers HP."
+		"tr_explainLong": "①  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%."
 	},
 	{
 		"assign": "1810",
 		"jp_explainShort": "ＨＰを回復",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。",
-		"tr_explainLong": "① Recovers HP."
+		"tr_explainLong": "①  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 18%."
 	},
 	{
 		"assign": "1910",
 		"jp_explainShort": "ＨＰを回復",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。",
-		"tr_explainLong": "① Recovers HP."
+		"tr_explainLong": "①  Recovers HP by 20%.\n<color=yellow>SP: </color>Recovers HP by 24%."
 	},
 	{
 		"assign": "2010",
 		"jp_explainShort": "状態異常を取り払いＨＰを小回復",
 		"tr_explainShort": "Status effects cured + HP recovery",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰをわずかに回復する。",
-		"tr_explainLong": "① Cures all status effects on yourself.\n② Slightly recovers HP."
+		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%."
 	},
 	{
 		"assign": "20110",
 		"jp_explainShort": "炎属性を小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 10.\n<color=yellow>SP: </color>Increases your Fire Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "20210",
 		"jp_explainShort": "炎属性を強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Fire Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "20310",
 		"jp_explainShort": "氷属性を小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 10.\n<color=yellow>SP: </color>Increases your Ice Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "20410",
 		"jp_explainShort": "氷属性を強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Ice Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 20.\n<color=yellow>SP: </color>Increases your Ice Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "20510",
 		"jp_explainShort": "雷属性を小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 10.\n<color=yellow>SP: </color>Increases your Lightning Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "20610",
 		"jp_explainShort": "雷属性を強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Lightning Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 20.\n<color=yellow>SP: </color>Increases your Lightning Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "20710",
 		"jp_explainShort": "風属性を小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 10.\n<color=yellow>SP: </color>Increases your Wind Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "20810",
 		"jp_explainShort": "風属性を強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Wind Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 20.\n<color=yellow>SP: </color>Increases your Wind Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "20910",
 		"jp_explainShort": "光属性を小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 10.\n<color=yellow>SP: </color>Increases your Light Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "21010",
 		"jp_explainShort": "光属性を強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Light Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 20.\n<color=yellow>SP: </color>Increases your Light Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "21110",
 		"jp_explainShort": "闇属性を小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 10.\n<color=yellow>SP: </color>Increases your Dark Element by 12.\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "21210",
 		"jp_explainShort": "闇属性を強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Dark Element.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 20.\n<color=yellow>SP: </color>Increases your Dark Element by 24.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "3810",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Dark Tech damage",
+		"tr_explainShort": "Dark tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% 30 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 450% 30 Dark tech damage to the target."
 	},
 	{
 		"assign": "3820",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Dark Tech damage",
+		"tr_explainShort": "Dark tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% 30 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 675% 30 Dark tech damage to the target."
 	},
 	{
 		"assign": "3910",
 		"jp_explainShort": "中ダメージ＋一定確率で「ポイズン」",
 		"tr_explainShort": "Medium damage + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target. \n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "3920",
 		"jp_explainShort": "中ダメージ＋一定確率で「ポイズン」",
 		"tr_explainShort": "Medium damage + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target. \n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "4010",
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your Dark Element by 80% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Dark Element by 100% of its\n     value on activation.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "4020",
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your Dark Element by 110% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Dark Element by 130% of its\n     value on activation.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "4110",
 		"jp_explainShort": "全体に闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Dark Tech damage to all enemies",
+		"tr_explainShort": "Medium Dark tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 800% 80 Dark tech damage to all enemies."
 	},
 	{
 		"assign": "4120",
 		"jp_explainShort": "全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Heavy Dark Tech damage to all enemies",
+		"tr_explainShort": "Heavy Dark tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to all enemies."
 	},
 	{
 		"assign": "4310",
 		"jp_explainShort": "攻撃時に追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "4320",
 		"jp_explainShort": "攻撃時に追加で小ダメージ",
 		"tr_explainShort": "Additional  damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 20%  damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25%  damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "4510",
 		"jp_explainShort": "敵から受けるダメージを軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "4520",
 		"jp_explainShort": "敵から受けるダメージを大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[効果時間]短い時間",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Effect Duration] Short"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 45%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "4810",
 		"jp_explainShort": "攻撃時に追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 6 seconds"
 	},
 	{
 		"assign": "4820",
 		"jp_explainShort": "攻撃時に追加で大ダメージ",
-		"tr_explainShort": "Heavy additional damage to enemies",
+		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "4910",
 		"jp_explainShort": "闇属性の打撃による中ダメージ",
 		"tr_explainShort": "Heavy Dark damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 750% 100 Dark striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 1000% 100 Dark striking damage to the\n     target."
 	},
 	{
 		"assign": "4920",
 		"jp_explainShort": "闇属性の打撃による大ダメージ",
 		"tr_explainShort": "Heavy Dark damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1250% 100 Dark striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 1500% 100 Dark striking damage to the\n     target."
 	},
 	{
 		"assign": "5110",
@@ -7445,140 +7445,140 @@
 		"jp_explainShort": "全体に闇属性の射撃による中ダメージ",
 		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Dark shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "5320",
 		"jp_explainShort": "全体に闇属性の射撃による大ダメージ",
 		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "20005",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Dark Tech damage",
+		"tr_explainShort": "Medium Dark tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 800% 80 Dark tech damage to the target."
 	},
 	{
 		"assign": "20006",
 		"jp_explainShort": "闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Heavy Dark Tech damage",
+		"tr_explainShort": "Heavy Dark tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to the target."
 	},
 	{
 		"assign": "20007",
 		"jp_explainShort": "敵全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Dark Tech damage to all enemies",
+		"tr_explainShort": "Dark tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to all enemies."
 	},
 	{
 		"assign": "20008",
 		"jp_explainShort": "敵全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Dark Tech damage to all enemies",
+		"tr_explainShort": "Dark tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Dark tech damage to all enemies."
 	},
 	{
 		"assign": "20017",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + damage boosted vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 15% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 18% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "20018",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + damage boosted vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 20% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 25% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "20043",
 		"jp_explainShort": "法術小強化＋加速",
 		"tr_explainShort": "Techs boosted + actions quickened",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Techs by 15%.\n<color=yellow>SP: </color>Boosts the power of Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20044",
 		"jp_explainShort": "法術小強化＋加速",
 		"tr_explainShort": "Techs boosted + actions quickened",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "5410",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 100% striking damage to the target.\n<color=yellow>SP: </color>Deals 120% striking damage to the target."
 	},
 	{
 		"assign": "5420",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 140% striking damage to the target.\n<color=yellow>SP: </color>Deals 160% striking damage to the target."
 	},
 	{
 		"assign": "5510",
 		"jp_explainShort": "射撃による小ダメージ",
 		"tr_explainShort": "Minor shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 190% shooting damage to the target.\n<color=yellow>SP: </color>Deals 230% shooting damage to the target."
 	},
 	{
 		"assign": "5520",
 		"jp_explainShort": "射撃による中ダメージ",
 		"tr_explainShort": "Medium shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 270% shooting damage to the target.\n<color=yellow>SP: </color>Deals 320% shooting damage to the target."
 	},
 	{
 		"assign": "6010",
 		"jp_explainShort": "射撃による小ダメージ",
 		"tr_explainShort": "Minor shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 190% shooting damage to the target.\n<color=yellow>SP: </color>Deals 230% shooting damage to the target."
 	},
 	{
 		"assign": "6020",
 		"jp_explainShort": "射撃による中ダメージ",
 		"tr_explainShort": "Medium shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 270% shooting damage to the target.\n<color=yellow>SP: </color>Deals 320% shooting damage to the target."
 	},
 	{
 		"assign": "6110",
 		"jp_explainShort": "中ダメージ＋一定確率で「フリーズ」",
 		"tr_explainShort": "Medium damage + chance to [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target.\n② Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "6120",
 		"jp_explainShort": "中ダメージ＋一定確率で「フリーズ」",
 		"tr_explainShort": "Medium damage + chance to [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target.\n② Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "6410",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 210% striking damage to the target.\n<color=yellow>SP: </color>Deals 250% striking damage to the target."
 	},
 	{
 		"assign": "6420",
 		"jp_explainShort": "打撃による中ダメージ",
 		"tr_explainShort": "Medium striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% striking damage to the target.\n<color=yellow>SP: </color>Deals 350% striking damage to the target."
 	},
 	{
 		"assign": "6610",
@@ -7625,58 +7625,58 @@
 	{
 		"assign": "7010",
 		"jp_explainShort": "風属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Wind Tech damage",
+		"tr_explainShort": "Medium Wind tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 風属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Wind Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Wind tech damage to the target.\n<color=yellow>SP: </color>Deals 800% 80 Wind tech damage to the target."
 	},
 	{
 		"assign": "7020",
 		"jp_explainShort": "風属性の法撃による大ダメージ",
-		"tr_explainShort": "Medium Wind Tech damage",
+		"tr_explainShort": "Medium Wind tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 風属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Wind Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Wind tech damage to the target.\n<color=yellow>SP: </color>Deals 1200% 80 Wind tech damage to the target."
 	},
 	{
 		"assign": "7110",
 		"jp_explainShort": "全体に風属性の打撃による中ダメージ",
 		"tr_explainShort": "Wind striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に風属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Wind striking damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Wind striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Wind striking damage to all\n     enemies."
 	},
 	{
 		"assign": "7120",
 		"jp_explainShort": "全体に風属性の打撃による大ダメージ",
 		"tr_explainShort": "Wind striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に風属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Wind striking damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Wind striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Wind striking damage to all\n     enemies."
 	},
 	{
 		"assign": "7210",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Damage to all + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による大ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy shooting damage to all enemies.\n② Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% shooting damage to all enemies.\n②  Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "7220",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Damage to all + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による大ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy shooting damage to all enemies.\n② Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% shooting damage to all enemies.\n②  Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "7310",
 		"jp_explainShort": "全体に中ダメージ＋確率で「フリーズ」",
 		"tr_explainShort": "All Attack + Chance of [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to all enemies.\n② Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 450% shooting damage to all enemies.\n②  Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "7320",
 		"jp_explainShort": "全体に中ダメージ＋確率で「フリーズ」",
 		"tr_explainShort": "All Attack + Chance of [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to all enemies.\n② Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 675% shooting damage to all enemies.\n②  Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "7410",
@@ -7695,58 +7695,58 @@
 	{
 		"assign": "7510",
 		"jp_explainShort": "全体に氷属性の法撃による中ダメージ",
-		"tr_explainShort": "Ice Tech damage to all enemies",
+		"tr_explainShort": "Ice tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Ice Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 800% 80 Ice tech damage to all enemies."
 	},
 	{
 		"assign": "7520",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice Tech damage to all enemies",
+		"tr_explainShort": "Ice tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice tech damage to all enemies."
 	},
 	{
 		"assign": "8710",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light Tech damage",
+		"tr_explainShort": "Light tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% 20 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 375% 20 Light tech damage to the target."
 	},
 	{
 		"assign": "8720",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light Tech damage",
+		"tr_explainShort": "Light tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 450% 20 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 525% 20 Light tech damage to the target."
 	},
 	{
 		"assign": "8910",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light Tech damage",
+		"tr_explainShort": "Light tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 750% 100 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 1000% 100 Light tech damage to the target."
 	},
 	{
 		"assign": "8920",
 		"jp_explainShort": "光属性の法撃による大ダメージ",
-		"tr_explainShort": "Light Tech damage",
+		"tr_explainShort": "Light tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light Tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1250% 100 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 1500% 100 Light tech damage to the target."
 	},
 	{
 		"assign": "9110",
 		"jp_explainShort": "全体に炎属性の打撃による中ダメージ",
 		"tr_explainShort": "Fire striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に炎属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Fire striking damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Fire striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Fire striking damage to all\n     enemies."
 	},
 	{
 		"assign": "9120",
 		"jp_explainShort": "全体に炎属性の打撃による大ダメージ",
 		"tr_explainShort": "Fire striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に炎属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Fire striking damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Fire striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Fire striking damage to all\n     enemies."
 	},
 	{
 		"assign": "9210",
@@ -7767,112 +7767,112 @@
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your Light Element by 80% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Light Element by 100% of its\n     value on activation.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "9320",
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your Light Element by 110% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Light Element by 130% of its\n     value on activation.\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "9410",
 		"jp_explainShort": "全体に光属性の射撃による中ダメージ",
 		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Light shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Light shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "9420",
 		"jp_explainShort": "全体に光属性の射撃による大ダメージ",
 		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Light shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Light shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "9423",
 		"jp_explainShort": "ダメージ小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boost + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 1% of max HP)\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "9424",
 		"jp_explainShort": "ダメージ小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boost + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 1% of max HP)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "9421",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 法撃による大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Tech damage to all enemies.\n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% tech damage to all enemies.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "9422",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 法撃による大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Tech damage to all enemies.\n② Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% tech damage to all enemies.\n②  Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "20025",
 		"jp_explainShort": "敵全体に光属性の打撃による大ダメージ",
 		"tr_explainShort": "Light striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light striking damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Light striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Light striking damage to all\n     enemies."
 	},
 	{
 		"assign": "20026",
 		"jp_explainShort": "敵全体に光属性の打撃による大ダメージ",
 		"tr_explainShort": "Light striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light striking damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Light striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Light striking damage to all\n     enemies."
 	},
 	{
 		"assign": "20027",
 		"jp_explainShort": "射撃小ダメージ＋一定確率で「パニック」",
-		"tr_explainShort": "Shooting damage + chance to [Panic]",
+		"tr_explainShort": "Shooting damage to all + chance to [Panic]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。\n② 一定確率で「パニック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target.\n② Has a chance to inflict [Panic]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 200% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 250% shooting damage to all enemies.\n②  Has a chance to inflict [Panic]."
 	},
 	{
 		"assign": "20028",
 		"jp_explainShort": "射撃中ダメージ＋一定確率で「パニック」",
-		"tr_explainShort": "Shooting damage + chance to [Panic]",
+		"tr_explainShort": "Shooting damage to all + chance to [Panic]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「パニック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Panic]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 350% shooting damage to all enemies.\n②  Has a chance to inflict [Panic]."
 	},
 	{
 		"assign": "9810",
 		"jp_explainShort": "射撃の中ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Shooting damage + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "9820",
 		"jp_explainShort": "射撃の中ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Shooting damage + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "9910",
 		"jp_explainShort": "全体に雷属性の射撃による中ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals medium Lightning shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Lightning shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "9920",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "10010",
@@ -7893,84 +7893,84 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage based on how far you are from\n    the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by up to 35% based on how far\n     you are from the target.\n<color=yellow>SP: </color>Boosts damage by up to 40% based on how far\n     you are from the target.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20036",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が大増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on how far you are\n    from the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by up to 45% based on how far\n     you are from the target.\n<color=yellow>SP: </color>Boosts damage by up to 50% based on how far\n     you are from the target.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "20037",
 		"jp_explainShort": "敵全体に雷属性の打撃による大ダメージ",
 		"tr_explainShort": "Lightning striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning striking damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning striking damage to all\n     enemies."
 	},
 	{
 		"assign": "20038",
 		"jp_explainShort": "敵全体に雷属性の打撃による大ダメージ",
 		"tr_explainShort": "Lightning striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning striking damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Lightning striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Lightning striking damage to all\n     enemies."
 	},
 	{
 		"assign": "30110",
 		"jp_explainShort": "原生種に対してダメージを増加",
 		"tr_explainShort": "Damage to Natives boosted",
 		"jp_explainLong": "① 原生種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Natives by 30%.\n<color=yellow>SP: </color>Boosts damage against Natives by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30120",
 		"jp_explainShort": "原生種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Natives boosted",
 		"jp_explainLong": "① 原生種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Natives by 40%.\n<color=yellow>SP: </color>Boosts damage against Natives by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30210",
 		"jp_explainShort": "機甲種に対してダメージを増加",
 		"tr_explainShort": "Damage to Mechs boosted",
 		"jp_explainLong": "① 機甲種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Mechs by 30%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30220",
 		"jp_explainShort": "機甲種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Mechs boosted",
 		"jp_explainLong": "① 機甲種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Mechs by 40%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30310",
 		"jp_explainShort": "龍族に対してダメージを増加",
 		"tr_explainShort": "Damage to Dragonkin boosted",
 		"jp_explainLong": "① 龍族に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 30%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30320",
 		"jp_explainShort": "龍族に対してダメージを大増加",
 		"tr_explainShort": "Damage to Dragonkin boosted",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 40%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30410",
 		"jp_explainShort": "ダーカーに対してダメージを増加",
 		"tr_explainShort": "Damage to Darkers boosted",
 		"jp_explainLong": "① ダーカーに与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Darkers by 30%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30420",
 		"jp_explainShort": "ダーカーに対してダメージを大増加",
 		"tr_explainShort": "Damage to Darkers boosted",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Darkers by 40%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "25010",
@@ -8117,97 +8117,97 @@
 		"jp_explainShort": "海王種に対してダメージを増加",
 		"tr_explainShort": "Damage to Oceanids boosted",
 		"jp_explainLong": "① 海王種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Oceanids by 30%.\n<color=yellow>SP: </color>Boosts damage against Oceanids by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20010",
 		"jp_explainShort": "海王種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Oceanids boosted",
 		"jp_explainLong": "① 海王種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Oceanids by 40%.\n<color=yellow>SP: </color>Boosts damage against Oceanids by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20011",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
 		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice shooting damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "20012",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
 		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice shooting damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Ice shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Ice shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "20019",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by up to 100 based on how\n     far you are from the target.\n<color=yellow>SP: </color>Increases your ATK by up to 120 based on how\n     far you are from the target.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20020",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by up to 150 based on how\n     far you are from the target.\n<color=yellow>SP: </color>Increases your ATK by up to 200 based on how\n     far you are from the target.\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20049",
 		"jp_explainShort": "消費ＣＰ減＋機改種に対してダメージを増加",
 		"tr_explainShort": "CP usage down + dam. boost vs Recon.",
 		"jp_explainLong": "① 機改種に対して与えるダメージを増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage against Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Reconfigured Mechs by\n     30%.\n<color=yellow>SP: </color>Boosts damage against Reconfigured Mechs by\n     40%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "20050",
 		"jp_explainShort": "消費ＣＰ減＋機改種に対してダメージを大増加",
 		"tr_explainShort": "CP usage down + dam. boost vs Recon.",
 		"jp_explainLong": "① 機改種に対して与えるダメージを大きく増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage against Reconfigured\n    Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Reconfigured Mechs by\n     40%.\n<color=yellow>SP: </color>Boosts damage against Reconfigured Mechs by\n     45%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "20071",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "20072",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Lightning shooting damage to all\n     enemies."
 	},
 	{
 		"assign": "20059",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice Tech damage to all enemies",
+		"tr_explainShort": "Ice tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice tech damage to all enemies."
 	},
 	{
 		"assign": "20060",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice Tech damage to all enemies",
+		"tr_explainShort": "Ice tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Ice tech damage to all enemies."
 	},
 	{
 		"assign": "20065",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + dam. boost vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 8% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 12% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20066",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + dam. boost vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
+		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 16% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 20% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 30 seconds"
 	}
 ]

--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -4,2681 +4,2681 @@
 		"jp_explainShort": "炎属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "120",
 		"jp_explainShort": "炎属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Fire Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 炎属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Fire Element by 90.\n<color=yellow>SP: </color>Increases your Fire Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "210",
 		"jp_explainShort": "氷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Ice Element by 70.\n<color=yellow>SP: </color>Increases your Ice Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "220",
 		"jp_explainShort": "氷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Ice Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 氷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Ice Element by 90.\n<color=yellow>SP: </color>Increases your Ice Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Ice Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "310",
 		"jp_explainShort": "雷属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "320",
 		"jp_explainShort": "雷属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Lightning Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 雷属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Lightning Element by 90.\n<color=yellow>SP: </color>Increases your Lightning Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "410",
 		"jp_explainShort": "風属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "420",
 		"jp_explainShort": "風属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Wind Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 風属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Wind Element by 90.\n<color=yellow>SP: </color>Increases your Wind Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Wind Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "510",
 		"jp_explainShort": "光属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "520",
 		"jp_explainShort": "光属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Light Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 光属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Light Element by 90.\n<color=yellow>SP: </color>Increases your Light Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Light Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "610",
 		"jp_explainShort": "闇属性を大強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 220.\n②  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Greatly increases Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "620",
 		"jp_explainShort": "闇属性を劇的強化＋攻撃力を小強化",
 		"tr_explainShort": "Dark Element up + slight ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 240.\n<color=yellow>SP: </color>Increases your ATK by 260.\n②  Increases your Dark Element by 90.\n<color=yellow>SP: </color>Increases your Dark Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Dramatically increases Dark Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "910",
 		"jp_explainShort": "全体に大ダメージ＋確率で「バーン」",
 		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1200% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1400% shooting damage to all enemies.\n②  Has a chance to inflict [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy damage to all enemies.\n② Has a chance to inflict [Burn]."
 	},
 	{
 		"assign": "920",
 		"jp_explainShort": "全体に特大ダメージ＋確率で「バーン」",
 		"tr_explainShort": "Damage all enemies + chance to [Burn]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に特大ダメージを与える。\n② 一定確率で「バーン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 2000% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 2400% shooting damage to all enemies.\n②  Has a chance to inflict [Burn]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive damage to all enemies.\n② Has a chance to inflict [Burn]."
 	},
 	{
 		"assign": "1110",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces your DEF by 100.\n<color=yellow>SP: </color>Reduces your DEF by 150.\n②  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1120",
 		"jp_explainShort": "防御力を減少させ攻撃力を劇的強化",
 		"tr_explainShort": "ATK up, DEF down",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces your DEF by 200.\n<color=yellow>SP: </color>Reduces your DEF by 250.\n②  Increases your ATK by 720.\n<color=yellow>SP: </color>Increases your ATK by 770.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Reduces DEF.\n② Dramatically increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1310",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your ATK by 35% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 50% against enemy\n     elemental weaknesses.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1320",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量を増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your ATK by 65% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 80% against enemy\n     elemental weaknesses.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1510",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Light damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Light damage to the target.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Light damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1520",
 		"jp_explainShort": "光属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Light damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 光属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Light damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Light damage to the target.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Light damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1530",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Lightning damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Lightning damage to the target.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Lightning damage to the target.\n[Effect Duration] Long."
 	},
 	{
 		"assign": "1540",
 		"jp_explainShort": "雷属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Ice damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 雷属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Lightning damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Lightning damage to the target.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Lightning damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1550",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Wind damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Wind damage to the target.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Wind damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1560",
 		"jp_explainShort": "風属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Wind damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 風属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Wind damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Wind damage to the target.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Wind damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1570",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 3000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n<color=yellow>SP: </color>Deals 3500% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n     You cannot activate this chip when below 30% HP."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive Fire Tech damage to all enemies,\n    while also damaging you by 30% of your maximum\n    HP.\n    You cannot activate this chip when below 30% HP."
 	},
 	{
 		"assign": "1580",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
 		"tr_explainShort": "Damages self and enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に炎属性の法撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 4000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n<color=yellow>SP: </color>Deals 5000% 250 Fire tech damage to all\n     enemies, while also damaging you by 30% of\n     your maximum HP.\n     You cannot activate this chip when below 30% HP."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive Fire Tech damage to all enemies,\n    while also damaging you by 30% of your maximum\n    HP.\n    You cannot activate this chip when below 30% HP."
 	},
 	{
 		"assign": "1590",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Deals 2700% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Fire damage to the target.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1600",
 		"jp_explainShort": "炎属性の特大ダメージ＋攻撃力を大強化",
 		"tr_explainShort": "Massive Fire damage + ATK up",
 		"jp_explainLong": "【ダメージボム】\n① 攻撃力を大きく強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Deals 4500% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Fire damage to the target.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Greatly increases ATK.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11050",
 		"jp_explainShort": "攻撃力増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 5% of damage dealt as HP.\n<color=yellow>SP: </color>Recovers 7% of damage dealt as HP.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "11060",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 8% of damage dealt as HP.\n<color=yellow>SP: </color>Recovers 10% of damage dealt as HP.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1610",
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 5% every second.\n<color=yellow>SP: </color>Recovers HP by 7% every second.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1620",
 		"jp_explainShort": "定期的にＨＰを小回復",
 		"tr_explainShort": "HP recovery over time",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 8% every second.\n<color=yellow>SP: </color>Recovers HP by 10% every second.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30001",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "Actions quickened + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30003",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 85% damage to Mechs.\n<color=yellow>SP: </color>Deals an additional 90% damage to Mechs.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30004",
 		"jp_explainShort": "機甲種攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Mechs",
 		"jp_explainLong": "① 機甲種に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 95% damage to Mechs.\n<color=yellow>SP: </color>Deals an additional 100% damage to Mechs.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Mechs.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30005",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 85% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 90% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30006",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 95% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 100% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30007",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness Elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 120.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 130.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30008",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "Actions quickened + weakness Elem. up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 140.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 150.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30013",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Dragonkin",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 85% damage to Dragonkin.\n<color=yellow>SP: </color>Deals an additional 90% damage to Dragonkin.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Dragonkin.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30014",
 		"jp_explainShort": "龍族攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Dragonkin",
 		"jp_explainLong": "① 龍族に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 95% damage to Dragonkin.\n<color=yellow>SP: </color>Deals an additional 100% damage to Dragonkin.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Dragonkin.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30015",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 85% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 90% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30016",
 		"jp_explainShort": "ダーカー攻撃時に追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to Darkers",
 		"jp_explainLong": "① ダーカーに追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 95% damage to Darkers.\n<color=yellow>SP: </color>Deals an additional 100% damage to Darkers.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals massive additional damage to Darkers.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30017",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up in proportion to remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 10.5 x your current CP.\n<color=yellow>SP: </color>Increases your ATK by 11.5 x your current CP.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically increases ATK, increasing as\n    remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30018",
 		"jp_explainShort": "ＣＰ残量に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up in proportion to remaining CP",
 		"jp_explainLong": "① ＣＰ残量が多いほど攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 13 x your current CP.\n<color=yellow>SP: </color>Increases your ATK by 15 x your current CP.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK, increasing as\n    remaining CP increases.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30027",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Wind chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30028",
 		"jp_explainShort": "風チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Wind chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Wind\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30029",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Ice chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30030",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Ice chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Ice chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30031",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Lightning chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30032",
 		"jp_explainShort": "雷チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Lightning chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Lightning\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30033",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "[Panic] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "[Panic] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1690",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
 		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by up to 1200, inversely\n     proportional to your remaining HP on activation.\n<color=yellow>SP: </color>Increases your ATK by up to 1400, inversely\n     proportional to your remaining HP on activation.\n②  Deals 2700% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 3600% 180 Fire damage to the target.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional to your HP\n    on activation.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "1700",
 		"jp_explainShort": "炎の特大ダメージ＋ＨＰ反比例で攻撃強化",
 		"tr_explainShort": "Fire damage + ATK up inverse to HP",
 		"jp_explainLong": "【ダメージボム】\n① 発動時のＨＰが少ないほど攻撃力を強化する。\n② 炎属性の特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "[Damage Bomb]\n①  Increases your ATK by up to 1600, inversely\n     proportional to your remaining HP on activation.\n<color=yellow>SP: </color>Increases your ATK by up to 1800, inversely\n     proportional to your remaining HP on activation.\n②  Deals 4500% 180 Fire damage to the target.\n<color=yellow>SP: </color>Deals 5400% 180 Fire damage to the target.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "[Damage Bomb]\n① Increases ATK inversely proportional to your HP\n    on activation.\n② Deals massive Fire damage to the target.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30043",
 		"jp_explainShort": "ダメージ軽減＋長槍の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30044",
 		"jp_explainShort": "ダメージ大軽減＋長槍の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30047",
 		"jp_explainShort": "ダメージ軽減＋長銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30048",
 		"jp_explainShort": "ダメージ大軽減＋長銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30053",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Grants knockdown immunity.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30054",
 		"jp_explainShort": "攻撃力を大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Grants knockdown immunity.\n[Effect Duration] 45 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30067",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     different chip elements equipped.\n②  Increases your DEF by 110 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your DEF by 100 x the number of\n     different chip elements equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30068",
 		"jp_explainShort": "チップの属性種数に応じ攻撃・防御を強化",
 		"tr_explainShort": "ATK & DEF up x # Elements equipped",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your ATK by 140 x the number of\n     different chip elements equipped.\n②  Increases your DEF by 120 x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Increases your DEF by 140 x the number of\n     different chip elements equipped.\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of different\n    chip elements equipped.\n② Increases DEF based on the number of different\n    chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30071",
 		"jp_explainShort": "定期的に攻撃力を上昇",
 		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 85 every 3.6 seconds.\n<color=yellow>SP: </color>Increases your ATK by 100 every 3.6 seconds.\n[Effect Duration] 45 seconds"
+		"tr_explainLong": "① Greatly increases ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30072",
 		"jp_explainShort": "定期的に攻撃力を上昇",
 		"tr_explainShort": "ATK up over time",
 		"jp_explainLong": "① 定期的に攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 115 every 3.6 seconds.\n<color=yellow>SP: </color>Increases your ATK by 130 every 3.6 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically increases ATK at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30081",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Light chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30082",
 		"jp_explainShort": "光チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Light chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Light\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30083",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Dark chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30084",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Dark chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Dark\n    chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30085",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 110 x the number of\n     Fire chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30086",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を強化",
 		"tr_explainShort": "ATK up x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 120 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 135 x the number of\n     Fire chips equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on the number of Fire chips\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30089",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Cuts current HP by 90%.\n②  Increases your ATK by 720.\n<color=yellow>SP: </color>Increases your ATK by 840.\n③  Recovers HP by 10% every 1.8 seconds.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30090",
 		"jp_explainShort": "攻撃力を劇的強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９割減少させる。\n② 攻撃力を劇的に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Cuts current HP by 90%.\n②  Increases your ATK by 960.\n<color=yellow>SP: </color>Increases your ATK by 1080.\n③  Recovers HP by 10% every 1.8 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Cuts current HP by 90%.\n② Dramatically increases ATK.\n③ Recovers HP slightly at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31009",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your maximum CP by 30.\n<color=yellow>SP: </color>Increases your maximum CP by 40.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31010",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen up",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your maximum CP by 50.\n<color=yellow>SP: </color>Increases your maximum CP by 60.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31011",
 		"jp_explainShort": "ダーカー以外にダメージ増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 30%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31012",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 45%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 55%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31025",
 		"jp_explainShort": "ダメージ軽減＋飛翔剣の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31026",
 		"jp_explainShort": "ダメージ大軽減＋飛翔剣の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + Dual Blade PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31029",
 		"jp_explainShort": "ダメージ軽減＋双機銃の必殺技を大強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     50%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31030",
 		"jp_explainShort": "ダメージ大軽減＋双機銃の必殺技を劇的強化",
 		"tr_explainShort": "Damage reduced + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     70%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31061",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Wind\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Wind\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31062",
 		"jp_explainShort": "風属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Wind Element",
 		"jp_explainLong": "① 風属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Wind\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Wind\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Wind\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31063",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31064",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31067",
 		"jp_explainShort": "ダメージ増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31068",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31071",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Converts your highest value Element to\n     the targeted enemy's weakness Element.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31072",
 		"jp_explainShort": "自身の高い属性値を弱点属性に変更",
 		"tr_explainShort": "Highest Element converted to weakness",
 		"jp_explainLong": "① 自身の一番高い属性値の属性を\n　　 攻撃対象の敵の弱点属性に変更する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Converts your highest value Element to\n     the targeted enemy's weakness Element.\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Converts your highest value Element to\n    the targeted enemy's weakness Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31085",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Dark\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Dark\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31086",
 		"jp_explainShort": "闇属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Dark Element",
 		"jp_explainLong": "① 闇属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Dark\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Dark\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Dark\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31087",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31088",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31093",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ大増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを大きく増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Inflicts [Burn] on the target.\n②  Boosts damage by 50% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 21 seconds"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Greatly boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31094",
 		"jp_explainShort": "「バーン」付与＋「バーン」ダメージ劇的増加",
 		"tr_explainShort": "[Burn] + damage boosted vs [Burn]",
 		"jp_explainLong": "① 敵に「バーン」を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Inflicts [Burn] on the target.\n②  Boosts damage by 75% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 95% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 21 seconds"
+		"tr_explainLong": "① Inflicts [Burn] on targeted enemy.\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31097",
 		"jp_explainShort": "ダメージ大増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with a Katana.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31098",
 		"jp_explainShort": "ダメージ劇的増加＋抜剣で増加",
 		"tr_explainShort": "Damage boosted + Katana boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 抜剣を装備している場合はさらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n②  Further boosts damage if equipped with a Katana.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31099",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces CP consumption by 40%.\n<color=yellow>SP: </color>Reduces CP consumption by 50%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31100",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces CP consumption by 60%.\n<color=yellow>SP: </color>Reduces CP consumption by 70%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31119",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31120",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage on hit",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31131",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
-		"tr_explainShort": "Damage boosted x chip ability level",
+		"tr_explainShort": "ATK boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 30% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31132",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
-		"tr_explainShort": "Damage boosted x chip ability level",
+		"tr_explainShort": "ATK boosted x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31137",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 0.4 x the number of different chip\n     elements equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers CP by 0.8 x the number of different chip\n     elements equipped every 5 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31138",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost x # Elems + CP over time",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 1 x the number of different chip\n     elements equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers CP by 1.2 x the number of different chip\n     elements equipped every 5 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of different chip elements equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31141",
 		"jp_explainShort": "属性種類数ダメージ大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + barrier",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% of your maximum HP x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% of your maximum HP x the number of\n     different chip elements equipped.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31142",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋ダメージ防御",
 		"tr_explainShort": "Damage boost x # Elems + barrier",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     8% of your maximum HP x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     9% of your maximum HP x the number of\n     different chip elements equipped.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31145",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ大増加",
 		"tr_explainShort": "[Freeze] + damage boost vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Inflicts [Freeze] on the target.\n②  Boosts damage by 120% against enemies\n     affected by [Freeze].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Freeze].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Immensely boosts damage against enemies\n    affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31146",
 		"jp_explainShort": "「フリーズ」付与＋「フリーズ」ダメージ劇的増加",
 		"tr_explainShort": "[Freeze] + damage up vs [Freeze]",
 		"jp_explainLong": "① 敵に「フリーズ」を付与する。\n② 「フリーズ」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Inflicts [Freeze] on the target.\n②  Boosts damage by 160% against enemies\n     affected by [Freeze].\n<color=yellow>SP: </color>Boosts damage by 200% against enemies\n     affected by [Freeze].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Inflicts [Freeze] on targeted enemy.\n② Immensely boosts damage against enemies\n    affected by [Freeze].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31163",
 		"jp_explainShort": "定期的に劇的ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた劇的ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals 1300% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 1600% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 500,000)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Deals regular dramatic damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31164",
 		"jp_explainShort": "定期的に絶大ダメージ",
 		"tr_explainShort": "Regular damage to target",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた絶大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals 1900% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 2200% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 500,000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals regular massive damage to the targeted\n    enemy based on your ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31175",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31176",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "Active chips activate + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31185",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 3 every 3.3 seconds.\n<color=yellow>SP: </color>Recovers CP by 4 every 3.3 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31186",
 		"jp_explainShort": "攻撃力が劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 3.3 seconds.\n<color=yellow>SP: </color>Recovers CP by 6 every 3.3 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31189",
 		"jp_explainShort": "必殺技の威力大強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage from enemies by 30%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31190",
 		"jp_explainShort": "必殺技の威力劇的強化＋ダメージ軽減",
 		"tr_explainShort": "PA damage up + damage reduced",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage from enemies by 50%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts PA damage.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31197",
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% every 3 seconds.\n     (Maximum boost: 120%)\n<color=yellow>SP: </color>Boosts damage by 24% every 3 seconds.\n     (Maximum boost: 140%)\n     <color=yellow>[G-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31198",
 		"jp_explainShort": "定期的に攻撃力が大増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n<color=yellow>SP: </color>Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n     <color=yellow>[G-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31201",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 2% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 5 seconds.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    activate an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31202",
 		"jp_explainShort": "攻撃力大増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力をわずかに増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 2% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 5 seconds.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    activate an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31203",
 		"jp_explainShort": "攻撃力微増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 2 seconds.\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage each time you activate\n    an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31204",
 		"jp_explainShort": "攻撃力増加＋チップ発動時に効果時間延長",
 		"tr_explainShort": "Active chips boost damage & this effect",
 		"jp_explainLong": "① 攻撃力を増加する。\n②  アクティブチップが発動するたびに\n　　 さらに攻撃力を増加する。\n③ アクティブチップが発動するたびに\n　　 効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     activate an active chip.\n     <color=yellow>[E-Frame]</color>\n③  Each time you activate an active chip, this\n     effect's duration is extended by 2 seconds.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage each time you activate\n    an active chip.\n    <color=yellow>[E-Frame]</color>\n③ Each time you activate an active chip, this\n    effect's duration is extended.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31211",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 3% of max HP)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31212",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部をＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 3% of max HP)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31215",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31216",
 		"jp_explainShort": "攻撃力劇的増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31227",
 		"jp_explainShort": "雷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 70.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly increases the Lightning Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31228",
 		"jp_explainShort": "雷属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Lightning boosted + additional damage",
 		"jp_explainLong": "① 雷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 80.\n<color=yellow>SP: </color>Increases your Lightning Element by 90.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases the Lightning Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31241",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31242",
 		"jp_explainShort": "チップのＣＰ消費量が減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP usage reduced + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31243",
 		"jp_explainShort": "攻撃力絶大増加＋法術が小強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力をわずかに強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of Techs by 20%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31244",
 		"jp_explainShort": "攻撃力絶大増加＋法術が大強化",
 		"tr_explainShort": "Damage boosted + Techs boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 法術の威力を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts the power of Techs.\n    <color=yellow>[A-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31245",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>  Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 4 every 10 seconds.\n<color=yellow>SP: </color>Recovers CP by 6 every 10 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31246",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 10 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 10 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31249",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 20% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31255",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 18% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of other Active Chip effects\n     by 10 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31256",
 		"jp_explainShort": "属性数ダメージ劇的増＋アクティブチップ延長",
 		"tr_explainShort": "Damage boost x # Elems + effect time",
 		"jp_explainLong": "① 装備中チップ属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② アクティブチップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 19% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of other Active Chip effects\n     by 10 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different equipped chip elements.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of other Active Chip effects.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31259",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Light Techs by 30% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 40% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 35%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Light Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31260",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベルで光法術劇的強化",
 		"tr_explainShort": "HP recovery + Light Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 光属性の法術の威力を劇的に強化する。\n② ＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Light Techs by 50% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 60% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 35%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts Light Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31269",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements by 50.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Elements.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31270",
 		"jp_explainShort": "全属性値を大強化+攻撃力を劇的増加",
 		"tr_explainShort": "All Elements up + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 全属性の属性値を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements by 50.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases all Elements.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31277",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31278",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PA&Tech CP usage up, damage boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of Techs and PAs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31291",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
 		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 100.\n②  Deals an additional 45% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31292",
 		"jp_explainShort": "弱点属性を劇的強化＋追加大ダメージ",
 		"tr_explainShort": "Weak Element up + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 敵に追加で大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 100.\n②  Deals an additional 55% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases elements that the\n    targeted enemy is weak to.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31311",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31312",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "3 actions = ATK up + actions quickened",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 1000 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 10000)\n<color=yellow>SP: </color>Increases your ATK by 1100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 11000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31315",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31316",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "Boost x # Lightning + 3 actions=ATK up",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31319",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemies that\n     are weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies that\n     are weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31320",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "CP usage down + Wind weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 140% against enemies that\n     are weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 150% against enemies that\n     are weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 25%.\n<color=yellow>SP: </color>Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31327",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 20%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31328",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力劇的強化",
 		"tr_explainShort": "PA&Tech power boosted, CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 95%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 20%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Raises the CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31335",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 1.65% x the number of Light chips\n     equipped every 6.5 seconds.\n<color=yellow>SP: </color>Recovers HP by 2.30% x the number of Light chips\n     equipped every 6.5 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31336",
 		"jp_explainShort": "攻撃力劇的増加＋光チップ数ＨＰ自動回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 定期的にＨＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 2.65% x the number of Light chips\n     equipped every 6.5 seconds.\n<color=yellow>SP: </color>Recovers HP by 3.30% x the number of Light chips\n     equipped every 6.5 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers HP at regular intervals based on the\n    number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31339",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Wind weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 25% if using a Wind\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31340",
 		"jp_explainShort": "攻撃力絶大増加＋風属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Wind weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が風属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 25% if using a Wind\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31345",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 砂漠か地下坑道か採掘場での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% if fighting in the\n     Desert, the Tunnels or the Quarry.\n     <color=yellow>[I-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31346",
 		"jp_explainShort": "攻撃力大増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Damage boost + damage boost on Lillipa",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 砂漠か地下坑道か採掘場での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% if fighting in the\n     Desert, the Tunnels or the Quarry.\n     <color=yellow>[I-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if fighting in\n    the Desert, the Tunnels or the Quarry.\n    <color=yellow>[I-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31355",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 20 CP every 9.8 seconds.\n<color=yellow>SP: </color>Recovers 21 CP every 9.8 seconds.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31356",
 		"jp_explainShort": "攻撃力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 21 CP every 9.8 seconds.\n<color=yellow>SP: </color>Recovers 22 CP every 9.8 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31379",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Ice weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using an Ice\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31380",
 		"jp_explainShort": "攻撃力絶大増加＋氷属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Ice weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 さらに攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using an Ice\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31389",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "Dam. boost + quick + boss dam. x # Ice",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n③ Greatly boosts damage against bosses based on\n    the number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31405",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力大増加",
 		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 35%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31406",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力劇的増加",
 		"tr_explainShort": "CP consumption down + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 35%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31409",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31410",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31417",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力劇的強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 115%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31418",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 155%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 175%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31419",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 12% every 3 seconds.\n     (Maximum boost: 70%)\n<color=yellow>SP: </color>Boosts damage by 14% every 3 seconds.\n     (Maximum boost: 80%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31420",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 17% every 3 seconds.\n     (Maximum boost: 100%)\n<color=yellow>SP: </color>Boosts damage by 19% every 3 seconds.\n     (Maximum boost: 110%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31425",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31426",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 90% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31427",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
 		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage against Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31428",
 		"jp_explainShort": "攻撃力超絶増加＋覇滅種にダメージ増加",
 		"tr_explainShort": "Damage boost + dam. boost to Superior",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 覇滅種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage against Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31437",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 30% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31438",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boosted x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31443",
 		"jp_explainShort": "氷属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Ice Element up + damage boosted",
 		"jp_explainLong": "① 氷属性を大きく強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 60.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly increases Ice Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31444",
 		"jp_explainShort": "氷属性劇的強化＋追加特大ダメージ",
 		"tr_explainShort": "Ice Element up + damage boosted",
 		"jp_explainLong": "① 氷属性を劇的に強化する。\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 80.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases Ice Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31453",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31454",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力絶大強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31457",
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n③  Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31458",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの属性種類数に応じて\n　　 さらに攻撃力を増加する。\n③ 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n③  Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 80 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage based on the number of different\n    chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n③ Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31475",
 		"jp_explainShort": "雷枚数攻撃力絶大増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 30% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of Chip abilities by 5 seconds.\n[Effect Duration] 56 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31476",
 		"jp_explainShort": "雷枚数攻撃力超絶増＋チップ効果時間延長",
 		"tr_explainShort": "Damage boost x # Lightning + Abil. ext.",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n① チップ発動時の効果時間を延長する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 35% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 40% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Extends the duration of Chip abilities by 5 seconds.\n[Effect Duration] 56 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Extends the duration of Active Chip abilities.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31483",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31484",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "Dam. boost x # Wind + 3 acts = ATK up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 22% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 23% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31485",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage x your Dark\n     Element.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31486",
 		"jp_explainShort": "闇チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Dark + Add. dam. x Elem",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 闇属性値に応じて敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage x your Dark\n     Element.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Dark Element value.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31499",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 25% +\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 30% +\n     2% x this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts PAs and Techs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31500",
 		"jp_explainShort": "消費ＣＰ減少＋アビリティレベル技・法大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技・法術の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 35% +\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 40% +\n     2% x this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31507",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     Fire chips equipped.\n③  Grants knockdown immunity.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31508",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockdown",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     Fire chips equipped.\n③  Grants knockdown immunity.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    Fire chips equipped.\n③ Grants knockdown immunity.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31509",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 60% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Greatly boosts damage against enemies affected\n    by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31510",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31517",
 		"jp_explainShort": "攻撃力絶大増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 13% each time you use\n     a PA or Tech.\n     (Maximum boost: 65%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    use a PA or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31518",
 		"jp_explainShort": "攻撃力絶大増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 13% each time you use\n     a PA or Tech.\n     (Maximum boost: 65%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    use a PA or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31519",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を小増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 28% every 3 seconds.\n     (Maximum boost: 165%)\n<color=yellow>SP: </color>Boosts damage by 31% every 3 seconds.\n     (Maximum boost: 185%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 15%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31520",
 		"jp_explainShort": "消費ＣＰ減少＋定期的に攻撃力を増加",
 		"tr_explainShort": "CP usage down + dam. boost over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% every 3 seconds.\n     (Maximum boost: 195%)\n<color=yellow>SP: </color>Boosts damage by 36% every 3 seconds.\n     (Maximum boost: 215%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces CP consumption by 15%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31523",
 		"jp_explainShort": "ＨＰ・ＣＰ特大回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを劇的に回復する。\n③ ＣＰを劇的に回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 97%.\n<color=yellow>SP: </color>Recovers HP by 98%.\n③  Recovers CP by 97.\n<color=yellow>SP: </color>Recovers CP by 98.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Dramatically recovers HP.\n③ Dramatically recovers CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31524",
 		"jp_explainShort": "ＨＰ・ＣＰ特大回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを劇的に回復する。\n③ ＣＰを劇的に回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 99%.\n<color=yellow>SP: </color>Recovers HP by 100%.\n③  Recovers CP by 99.\n<color=yellow>SP: </color>Recovers CP by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Dramatically recovers HP.\n③ Dramatically recovers CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31533",
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31534",
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31539",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種とダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 85% against Mechs and\n     Darkers.\n<color=yellow>SP: </color>Boosts damage by 90% against Mechs and\n     Darkers.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31540",
 		"jp_explainShort": "消費ＣＰ減＋機甲・ダーカーにダメージ劇的増",
 		"tr_explainShort": "CP use down + Mech/Darker damage up",
 		"jp_explainLong": "① 機甲種とダーカーに対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 95% against Mechs and\n     Darkers.\n<color=yellow>SP: </color>Boosts damage by 100% against Mechs and\n     Darkers.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31543",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ減＋指定技威力強化",
 		"tr_explainShort": "Damage boost + damage res. + PA boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 「オーバーエンド」の威力を絶大に強化する。\n③ 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of \"Over End\" by 175%.\n     <color=yellow>[A-Frame]</color>\n③  Reduces damage taken from enemies by 40%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts the power of \"Over End\".\n    <color=yellow>[A-Frame]</color>\n③ Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31544",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ減＋指定技威力強化",
 		"tr_explainShort": "Damage boost + damage res. + PA boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 「オーバーエンド」の威力を絶大に強化する。\n③ 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 230%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of \"Over End\" by 175%.\n     <color=yellow>[A-Frame]</color>\n③  Reduces damage taken from enemies by 40%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts the power of \"Over End\".\n    <color=yellow>[A-Frame]</color>\n③ Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31555",
 		"jp_explainShort": "ダーカー以外にダメージ大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 60%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 70%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31556",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 80%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 90%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Greatly boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31566",
 		"jp_explainShort": "炎属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Fire weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31567",
 		"jp_explainShort": "炎属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Fire weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31570",
 		"jp_explainShort": "ダメージ極度増加＋効果終了時に被ダメージ",
 		"tr_explainShort": "Damage boost + take damage at the end",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 効果時間終了時に最大ＨＰの９０％の\n　　 ダメージを受ける。（ＨＰは最低でも１残る）\n　　 ただし、ＨＰが９０％未満の場合\n　　 このチップを発動できない。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 370%.\n<color=yellow>SP: </color>Boosts damage by 380%.\n     <color=yellow>[E-Frame]</color>\n②  When this effect ends, you take damage equal to\n     90% of your maximum HP.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 90% HP.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② When this effect ends, you take damage equal to\n    90% of your maximum HP.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 90% HP.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31571",
 		"jp_explainShort": "ダメージ極度増加＋効果終了時に被ダメージ",
 		"tr_explainShort": "Damage boost + take damage at the end",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 効果時間終了時に最大ＨＰの９０％の\n　　 ダメージを受ける。（ＨＰは最低でも１残る）\n　　 ただし、ＨＰが９０％未満の場合\n　　 このチップを発動できない。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  When this effect ends, you take damage equal to\n     90% of your maximum HP.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 90% HP.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② When this effect ends, you take damage equal to\n    90% of your maximum HP.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 90% HP.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31576",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は氷属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 235%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Ice PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Ice PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31577",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は氷属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Ice PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Ice PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31578",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ファイターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n     (Even applies to this chip's activation cost)\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot\n     is Fighter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Fighter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31581",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31582",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 850 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8500)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31589",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力超絶強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 210%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 215%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 40%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31590",
 		"jp_explainShort": "技と法術のＣＰ消費を増加し、威力超絶強化",
 		"tr_explainShort": "PAs & Techs boosted + CP usage up",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 必殺技・法術のＣＰ消費量を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 220%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 225%.\n     <color=yellow>[A-Frame]</color>\n②  Increases the CP consumption of PAs and Techs\n     by 40%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases CP consumption of PAs and Techs.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31599",
 		"jp_explainShort": "攻撃力増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31600",
 		"jp_explainShort": "攻撃力大増加＋特定条件で戦闘不能回避",
 		"tr_explainShort": "Damage boosted + conditional Iron Will",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の雷属性チップが２枚以下の時\n　　 効果中一度だけ戦闘不能にならない。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Prevents a single incapacitation if the number\n     of equipped Lightning chips is 2 or less.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Prevents a single incapacitation if the number\n    of equipped Lightning chips is 2 or less.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31605",
 		"jp_explainShort": "氷属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Ice weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120% if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31606",
 		"jp_explainShort": "氷属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Ice weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31609",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。（最大時：超絶）\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 1000.\n<color=yellow>SP: </color>Increases your ATK by 1500.\n②  Increases your ATK by 15 x this chip's ability\n     level each time you successfully perform a Just\n     Attack.\n③  Increases your maximum CP by 30.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum increase: Overwhelming)\n③ Increases your maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31610",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "Just Attack = ATK up + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アビリティレベルに応じてジャストアタックごとに\n　　 攻撃力をわずかに強化する。（最大時：超絶）\n③ ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 2000.\n<color=yellow>SP: </color>Increases your ATK by 2500.\n②  Increases your ATK by 15 x this chip's ability\n     level each time you successfully perform a Just\n     Attack.\n③  Increases your maximum CP by 30.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK based on this chip's ability\n    level each time you successfully perform a Just\n    Attack.\n    (Maximum increase: Overwhelming)\n③ Increases your maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31624",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 32% each time you use a PA\n     or Tech.\n     (Maximum boost: 160%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31625",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 34% each time you use a PA\n     or Tech.\n     (Maximum boost: 170%)\n<color=yellow>SP: </color>Boosts damage by 36% each time you use a PA\n     or Tech.\n     (Maximum boost: 180%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31633",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31634",
 		"jp_explainShort": "攻撃力超絶増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31635",
 		"jp_explainShort": "攻撃力極度増＋ダメージ大軽減＋攻撃威力増",
 		"tr_explainShort": "Dam. boost + dam. res. + boost x D. link",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ 全てのリンクスロットに装備した\n　　 闇属性チップの枚数に応じて攻撃の威力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 320%.\n<color=yellow>SP: </color>Boosts damage by 325%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Boosts damage by 5% x the number of Dark\n     chips equipped in all link slots.\n     <color=yellow>[P-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Boosts damage based on the number of Dark\n    chips equipped in all link slots.\n    <color=yellow>[P-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31644",
 		"jp_explainShort": "アビリティＬｖ攻撃劇的増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 10% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 20% + 10% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31645",
 		"jp_explainShort": "アビリティＬｖ攻撃絶大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Damage boost x ability lv. + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% + 10% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 40% + 10% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31646",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31647",
 		"jp_explainShort": "消費ＣＰ減＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "CP consumption down + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31652",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９０％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Cuts your current HP by 90%.\n②  Increases your ATK by 12500.\n<color=yellow>SP: </color>Increases your ATK by 14000.\n③  Recovers HP by 5% every 1.8 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Cuts your current HP by 90%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31653",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを９０％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Cuts your current HP by 90%.\n②  Increases your ATK by 15500.\n<color=yellow>SP: </color>Increases your ATK by 17000.\n③  Recovers HP by 5% every 1.8 seconds.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Cuts your current HP by 90%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31662",
 		"jp_explainShort": "闇属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Dark weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 125% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31663",
 		"jp_explainShort": "闇属性武器で攻撃力が絶大増加",
 		"tr_explainShort": "Dark weapon damage boost",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31664",
 		"jp_explainShort": "消費ＣＰ減＋原生・龍族にダメージ劇的増",
 		"tr_explainShort": "CP use down + boost vs Native&Dragon",
 		"jp_explainLong": "① 原生種と龍族に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 85% against Natives and\n     Dragonkin.\n<color=yellow>SP: </color>Boosts damage by 90% against Natives and\n     Dragonkin.\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Natives\n    and Dragonkin.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31665",
 		"jp_explainShort": "消費ＣＰ減＋原生・龍族にダメージ劇的増",
 		"tr_explainShort": "CP use down + boost vs Native&Dragon",
 		"jp_explainLong": "① 原生種と龍族に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 95% against Natives and\n     Dragonkin.\n<color=yellow>SP: </color>Boosts damage by 100% against Natives and\n     Dragonkin.\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Natives\n    and Dragonkin.\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31666",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 255%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31667",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 270%.\n<color=yellow>SP: </color>Boosts damage by 275%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31668",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 295%.\n<color=yellow>SP: </color>Boosts damage by 300%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 15 CP every 4.9 seconds.\n③  Boosts damage by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31673",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 35% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 40% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Boosts damage against enemies affected by\n    [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31674",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ大増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 45% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 50% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Greatly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31677",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 150%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 9 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31678",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 170%.\n<color=yellow>SP: </color>Boosts power by 190%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 9 seconds.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31700",
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を劇的に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 15% for\n     each different chip element equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 20% for\n     each different chip element equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n     (Maximum increase: 4500)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31701",
 		"jp_explainShort": "ＪＡ威力増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted + ATK up per JA",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 25% for\n     each different chip element equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 30% for\n     each different chip element equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n     (Maximum increase: 4500)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully\n    perform a Just Attack.\n    (Maximum increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31702",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31703",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31704",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31711",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + barrier + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental damage by 135% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 145% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31712",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + barrier + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental damage by 155% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 165% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31713",
 		"jp_explainShort": "攻撃力を劇的強化＋防御力減少",
 		"tr_explainShort": "ATK increased + DEF decreased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 防御力を減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 4500.\n<color=yellow>SP: </color>Increases your ATK by 5000.\n②  Reduces your DEF by 350.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Reduces your DEF.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31714",
 		"jp_explainShort": "攻撃力を絶大強化＋防御力減少",
 		"tr_explainShort": "ATK increased + DEF decreased",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② 防御力を減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 5500.\n<color=yellow>SP: </color>Increases your ATK by 6000.\n②  Reduces your DEF by 350.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely increases ATK.\n② Reduces your DEF.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31733",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31734",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31735",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が光属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Light chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Light chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31742",
 		"jp_explainShort": "威力絶大増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Power boosted + CP recovery over time",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 180%.\n<color=yellow>SP: </color>Boosts power by 190%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers CP by 5 every 10 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31743",
 		"jp_explainShort": "威力超絶増加＋定期的にＣＰ回復",
 		"tr_explainShort": "Power boosted + CP recovery over time",
 		"jp_explainLong": "① 威力を超絶に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 200%.\n<color=yellow>SP: </color>Boosts power by 210%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers CP by 5 every 10 seconds.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31748",
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 3500.\n<color=yellow>SP: </color>Increases your ATK by 4000.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     10% x the number of Lightning chips equipped.\n     <color=yellow>[Chase Boost]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31749",
 		"jp_explainShort": "攻撃力劇的強化＋追加ダメージ効果大増加",
 		"tr_explainShort": "ATK up + add. dam. boost x # Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの雷属性チップの枚数に応じて\n　　 追加ダメージ威力をそれぞれ大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 4500.\n<color=yellow>SP: </color>Increases your ATK by 5000.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     10% x the number of Lightning chips equipped.\n     <color=yellow>[Chase Boost]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects based on the number of Lightning chips\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31750",
 		"jp_explainShort": "代償攻撃力絶大増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を絶大に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 170% in exchange for taking\n     more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 180% in exchange for taking\n     more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants a 25% chance to resist knockback and\n     flinching.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31751",
 		"jp_explainShort": "代償攻撃力絶大増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を絶大に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 190% in exchange for taking\n     more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 200% in exchange for taking\n     more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants a 25% chance to resist knockback and\n     flinching.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31752",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31753",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31754",
 		"jp_explainShort": "攻撃力増＋ダメージ防御＋風弱点ダメージ増",
 		"tr_explainShort": "Dam. boost + barrier + Wind weak boost",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵が風属性弱点の場合に\n　　 全てのリンクスロットに装備した\n　　 風属性チップの枚数に応じダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 310%.\n<color=yellow>SP: </color>Boosts damage by 315%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Boosts damage by 7% x the number of Wind chips\n     equipped in all link slots against enemies weak to\n     Wind.\n     <color=yellow>[D-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Greatly boosts damage against enemies weak to\n    Wind based on the number of Wind chips in all link\n    slots.\n    <color=yellow>[D-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31757",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 21% every 3 seconds.\n     (Maximum boost: 125%)\n<color=yellow>SP: </color>Boosts damage by 23% every 3 seconds.\n     (Maximum boost: 135%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31758",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 24% every 3 seconds.\n     (Maximum boost: 145%)\n<color=yellow>SP: </color>Boosts damage by 26% every 3 seconds.\n     (Maximum boost: 155%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31759",
 		"jp_explainShort": "絶大追撃＋ダーカー大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost. vs Darkers + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ダーカーに与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 170% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31760",
 		"jp_explainShort": "絶大追撃＋ダーカー大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost. vs Darkers + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ダーカーに与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 175% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 180% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31772",
 		"jp_explainShort": "攻撃力絶大増加＋一定確率で自身がフリーズ",
 		"tr_explainShort": "Damage boost but chance to [Freeze] self",
 		"jp_explainLong": "① 定期的に一定確率でフリーズになる代わりに\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 150% in exchange for having\n     a chance to [Freeze] you every 5 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage in exchange for having\n    a chance to [Freeze] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31773",
 		"jp_explainShort": "攻撃力絶大増加＋一定確率で自身がフリーズ",
 		"tr_explainShort": "Damage boost but chance to [Freeze] self",
 		"jp_explainLong": "① 定期的に一定確率でフリーズになる代わりに\n　　 攻撃力を絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160% in exchange for having\n     a chance to [Freeze] you every 5 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage in exchange for having\n    a chance to [Freeze] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31778",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Elem. dam. boost + barrier + rand. evasion",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental damage by 70% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 75% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31779",
 		"jp_explainShort": "属性ダメージ＋ダメージ防御＋一定確率回避",
 		"tr_explainShort": "Elem. dam. boost + barrier + rand. evasion",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental damage by 75% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 80% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31780",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the activation rate of all Support Chips\n     by 30%.\n③  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31781",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the activation rate of all Support Chips\n     by 30%.\n③  Reduces CP consumption by 30%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31788",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "PA/T boost x lv. + barr. + counter-Freeze",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts all PAs and Techs by 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 6% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% of your HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31789",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "PA/T boost x lv. + barr. + counter-Freeze",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts all PAs and Techs by 6% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 7% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% of your HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31790",
 		"jp_explainShort": "被バーン状態時に攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted while burned",
 		"jp_explainLong": "① 自身が「バーン」状態にある場合に\r\n　　 攻撃力を劇的に増加する。\r\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110% while you are affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 115% while you are affected\n     by [Burn].\n     <color=yellow>[O-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage while you are\n    affected by [Burn].\n    <color=yellow>[O-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31791",
 		"jp_explainShort": "被バーン状態時に攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted while burned",
 		"jp_explainLong": "① 自身が「バーン」状態にある場合に\r\n　　 攻撃力を劇的に増加する。\r\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 115% while you are affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 120% while you are affected\n     by [Burn].\n     <color=yellow>[O-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage while you are\n    affected by [Burn].\n    <color=yellow>[O-Frame]</color>\r\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31794",
 		"jp_explainShort": "消費ＣＰ減＋機甲・機改種にダメージ劇的増",
 		"tr_explainShort": "CP usage down + dam. boost vs all Mechs",
 		"jp_explainLong": "① 機甲種と機改種に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Mechs and Reconfigured\n     Mechs by 85%.\n<color=yellow>SP: </color>Boosts damage against Mechs and Reconfigured\n     Mechs by 90%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs and\n    Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31795",
 		"jp_explainShort": "消費ＣＰ減＋機甲・機改種にダメージ劇的増",
 		"tr_explainShort": "CP usage down + dam. boost vs all Mechs",
 		"jp_explainLong": "① 機甲種と機改種に対して\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Mechs and Reconfigured\n     Mechs by 95%.\n<color=yellow>SP: </color>Boosts damage against Mechs and Reconfigured\n     Mechs by 100%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 20%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs and\n    Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31823",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Weaknesses boosted + CP increased",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 20.\n③  Recovers CP by 20.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31824",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Weaknesses boosted + CP increased",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 100% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 20.\n③  Recovers CP by 20.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31830",
 		"jp_explainShort": "状態異常を取り払いＨＰを中回復",
 		"tr_explainShort": "Status cured + HP recovered",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰを回復する。",
-		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 45%.\n<color=yellow>SP: </color>Recovers HP by 50%."
+		"tr_explainLong": "① Cures status effects on yourself.\n② Recovers HP."
 	},
 	{
 		"assign": "31831",
 		"jp_explainShort": "状態異常を取り払いＨＰを大回復",
 		"tr_explainShort": "Status cured + HP recovered",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰを大きく回復する。",
-		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 55%.\n<color=yellow>SP: </color>Recovers HP by 60%."
+		"tr_explainLong": "① Cures status effects on yourself.\n② Greatly recovers HP."
 	},
 	{
 		"assign": "31834",
 		"jp_explainShort": "氷属性ダメージ＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "Ice weak boost + barrier + counter [Freeze]",
 		"jp_explainLong": "① 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Ice elemental damage by 150% against\n     enemies weak to Ice.\n<color=yellow>SP: </color>Boosts Ice elemental damage by 155% against\n     enemies weak to Ice.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Ice elemental damage against\n    enemies weak to Ice.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31835",
 		"jp_explainShort": "氷属性ダメージ＋ダメージ防御＋フリーズ付与",
 		"tr_explainShort": "Ice weak boost + barrier + counter [Freeze]",
 		"jp_explainLong": "① 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「フリーズ」効果を与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Ice elemental damage by 160% against\n     enemies weak to Ice.\n<color=yellow>SP: </color>Boosts Ice elemental damage by 165% against\n     enemies weak to Ice.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Freeze].\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts Ice elemental damage against\n    enemies weak to Ice.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Freeze].\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31840",
 		"jp_explainShort": "光枚数ＪＡ威力劇的増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted x # Light + JA = ATK up",
 		"jp_explainLong": "① 装備中チップの光属性チップの枚数に応じて\n　　 ジャストアタックの威力を劇的に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 15% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 20% x\n     the number of Light chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n  (Maximum Increase: 4500)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts Just Attacks based on the\n    number of Light chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully perform\n  a Just Attack.\n  (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31841",
 		"jp_explainShort": "光枚数ＪＡ威力絶大増加＋ＪＡ攻撃力強化",
 		"tr_explainShort": "JAs boosted x # Light + JA = ATK up",
 		"jp_explainLong": "① 装備中チップの光属性チップの枚数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックごとに\n　　 攻撃力を強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 25% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 30% x\n     the number of Light chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Increases your ATK by 375 each time you\n     successfully perform a Just Attack.\n  (Maximum Increase: 4500)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts Just Attacks based on the\n    number of Light chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Increases ATK each time you successfully perform\n  a Just Attack.\n  (Maximum Increase: Dramatic)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31842",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31843",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31844",
 		"jp_explainShort": "攻撃力が極度に増加＋炎属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Fire up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 炎属性の場合、炎属性の上限値が上昇する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Fire value by 20 if there\n     is a Fire chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Fire value if there is a\n    Fire chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31845",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：大きく）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 11% each time you use a PA\n     or Tech.\n     (Maximum boost: 55%)\n<color=yellow>SP: </color>Boosts damage by 12% each time you use a PA\n     or Tech.\n     (Maximum boost: 60%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Great)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31846",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 13% each time you use a PA\n     or Tech.\n     (Maximum boost: 65%)\n<color=yellow>SP: </color>Boosts damage by 14% each time you use a PA\n     or Tech.\n     (Maximum boost: 70%)\n     <color=yellow>[L-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31847",
 		"jp_explainShort": "ＣＰ全回復＋攻撃力極度強化＋定期的ＣＰ減少",
 		"tr_explainShort": "CP full recov. + dam. boost but leaking CP",
 		"jp_explainLong": "① ＣＰを全回復する。\n② 定期的にＣＰが減少する代わりに\n　　 攻撃力を極度に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Fully recovers your CP.\n②  Boosts damage by 630% in exchange for losing\n     10 CP every 0.1 seconds.\n<color=yellow>SP: </color>Boosts damage by 640% in exchange for losing\n     10 CP every 0.1 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Fully recovers your CP.\n② Maximally boosts damage in exchange for losing\n    CP at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31848",
 		"jp_explainShort": "ＣＰ全回復＋攻撃力極度強化＋定期的ＣＰ減少",
 		"tr_explainShort": "CP full recov. + dam. boost but leaking CP",
 		"jp_explainLong": "① ＣＰを全回復する。\n② 定期的にＣＰが減少する代わりに\n　　 攻撃力を極度に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Fully recovers your CP.\n②  Boosts damage by 650% in exchange for losing\n     10 CP every 0.1 seconds.\n<color=yellow>SP: </color>Boosts damage by 660% in exchange for losing\n     10 CP every 0.1 seconds.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Fully recovers your CP.\n② Maximally boosts damage in exchange for losing\n    CP at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31849",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31850",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31851",
 		"jp_explainShort": "攻撃力増＋特定クエストダメージ＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost + Quest boost + CP cost down",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② タワークエストで敵に与えるダメージを\n　　 アビリティレベルに応じて極度に増加する。\n③ リンクスロットに装備したチップの属性が\n　　 闇属性の場合、闇属性チップの消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 10% x this chip's ability level\n     in Tower Quests.\n     <color=yellow>[X-Frame]</color>\n③  Reduces the CP consumption of Dark chips by\n     10% if there is a Dark chip in this chip's link slot.\n     (Even applies to this chip's activation cost)\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Maximally boosts damage against enemies in\n    Tower Quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n③ Reduces the CP consumption of Dark chips if there\n    is a Dark chip in this chip's link slot.\n    (Even applies to this chip's activation cost)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31852",
 		"jp_explainShort": "炎枚数属性ダメージ＋炎枚数属性上限上昇",
 		"tr_explainShort": "Fire elem. boosted + max Fire value up",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じ\n　　 炎属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Fire elemental damage against\n     enemies weak to Fire by 120% + 10% x\n     the number of Fire chips equipped.\n<color=yellow>SP: </color>Boosts Fire elemental damage against\n     enemies weak to Fire by 130% + 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Fire value by 10 x the\n     number of Fire chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Fire elemental damage\n    against enemies weak to Fire based on the\n    number of Fire chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Fire value based\n    on the number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31853",
 		"jp_explainShort": "炎枚数属性ダメージ＋炎枚数属性上限上昇",
 		"tr_explainShort": "Fire elem. boosted + max Fire value up",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じ\n　　 炎属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Fire elemental damage against\n     enemies weak to Fire by 140% + 10% x\n     the number of Fire chips equipped.\n<color=yellow>SP: </color>Boosts Fire elemental damage against\n     enemies weak to Fire by 150% + 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Fire value by 10 x the\n     number of Fire chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Fire elemental damage\n    against enemies weak to Fire based on the\n    number of Fire chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Fire value based\n    on the number of Fire chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31858",
 		"jp_explainShort": "闇枚数属性ダメージ＋闇枚数属性上限上昇",
 		"tr_explainShort": "Dark elem. boosted + max Dark value up",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じ\n　　 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Dark elemental damage against\n     enemies weak to Dark by 120% + 10% x\n     the number of Dark chips equipped.\n<color=yellow>SP: </color>Boosts Dark elemental damage against\n     enemies weak to Dark by 130% + 10% x\n     the number of Dark chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Dark value by 10 x the\n     number of Dark chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Dark elemental damage against\n    enemies weak to Dark based on the number of\n    Dark chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Dark value\n    based on the number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31859",
 		"jp_explainShort": "闇枚数属性ダメージ＋闇枚数属性上限上昇",
 		"tr_explainShort": "Dark elem. boosted + max Dark value up",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じ\n　　 闇属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Dark elemental damage against\n     enemies weak to Dark by 140% + 10% x\n     the number of Dark chips equipped.\n<color=yellow>SP: </color>Boosts Dark elemental damage against\n     enemies weak to Dark by 150% + 10% x\n     the number of Dark chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Dark value by 10 x the\n     number of Dark chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Dark elemental damage\n    against enemies weak to Dark based on the\n    number of Dark chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Dark value\n    based on the number of Dark chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31864",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 9000.\n<color=yellow>SP: </color>Increases your ATK by 10000.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31865",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 11000.\n<color=yellow>SP: </color>Increases your ATK by 12000.\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31881",
 		"jp_explainShort": "定期的にダメージ",
 		"tr_explainShort": "Damage over time",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じたダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals 400% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 500% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 100,000)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Deals damage based on attack power to the\n    targeted enemy at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31882",
 		"jp_explainShort": "定期的に大ダメージ",
 		"tr_explainShort": "Damage over time",
 		"jp_explainLong": "① 攻撃対象の敵に対して\n　　 定期的に攻撃力に応じた大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals 600% damage of your current type to\n     the target every 1.7 seconds.\n<color=yellow>SP: </color>Deals 700% damage of your current type to\n     the target every 1.7 seconds.\n     (Maximum damage: 100,000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Deals heavy damage based on attack power to\n    the targeted enemy at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31885",
 		"jp_explainShort": "風枚数属性ダメージ＋風枚数属性上限上昇",
 		"tr_explainShort": "Wind elem. boosted + max Wind value up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じ\n　　 風属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Wind elemental damage against\n     enemies weak to Wind by 120% + 10% x\n     the number of Wind chips equipped.\n<color=yellow>SP: </color>Boosts Wind elemental damage against\n     enemies weak to Wind by 130% + 10% x\n     the number of Wind chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Wind value by 10 x the\n     number of Wind chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Wind elemental damage\n    against enemies weak to Wind based on the\n    number of Wind chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Wind value\n    based on the number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31886",
 		"jp_explainShort": "風枚数属性ダメージ＋風枚数属性上限上昇",
 		"tr_explainShort": "Wind elem. boosted + max Wind value up",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じ\n　　 風属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Wind elemental damage against\n     enemies weak to Wind by 140% + 10% x\n     the number of Wind chips equipped.\n<color=yellow>SP: </color>Boosts Wind elemental damage against\n     enemies weak to Wind by 150% + 10% x\n     the number of Wind chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Wind value by 10 x the\n     number of Wind chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Wind elemental damage\n    against enemies weak to Wind based on the\n    number of Wind chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Wind value\n    based on the number of Wind chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31887",
 		"jp_explainShort": "定期ＨＰ減少＋与ダメージ増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost but leaking HP + CP regen up",
 		"jp_explainLong": "① 定期的にＨＰが最大ＨＰの５％減少する代わりに\n　　 与えるダメージを超絶に増加する。\n　　 （ＨＰは最低でも１残る）\n　　 ただし、ＨＰが５％未満の場合\n　　 このチップを発動できない。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 250% in exchange for losing\n     5% of your HP every second.\n<color=yellow>SP: </color>Boosts damage by 260% in exchange for losing\n     5% of your HP every second.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 5% HP.\n     <color=yellow>[Y-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage in exchange for\n    losing 5% of your HP at regular intervals.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 5% HP.\n    <color=yellow>[Y-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31888",
 		"jp_explainShort": "定期ＨＰ減少＋与ダメージ増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost but leaking HP + CP regen up",
 		"jp_explainLong": "① 定期的にＨＰが最大ＨＰの５％減少する代わりに\n　　 与えるダメージを超絶に増加する。\n　　 （ＨＰは最低でも１残る）\n　　 ただし、ＨＰが５％未満の場合\n　　 このチップを発動できない。\n② ＣＰの回復速度を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 270% in exchange for losing\n     5% of your HP every second.\n<color=yellow>SP: </color>Boosts damage by 280% in exchange for losing\n     5% of your HP every second.\n     (Cannot reduce your HP below 1).\n     You cannot activate this chip when below 5% HP.\n     <color=yellow>[Y-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage in exchange for\n    losing 5% of your HP at regular intervals.\n    (Cannot reduce your HP below 1).\n    You cannot activate this chip when below 5% HP.\n    <color=yellow>[Y-Frame]</color>\n② Dramatically increases CP regeneration.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31899",
 		"jp_explainShort": "雷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＣＰ回復",
 		"tr_explainShort": "JA boost x # Lightning + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 35% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 40% x\n     the number of Lightning chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of Lightning chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31900",
 		"jp_explainShort": "雷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＣＰ回復",
 		"tr_explainShort": "JA boost x # Lightning + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the damage of Just Attacks by 45% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts the damage of Just Attacks by 50% x\n     the number of Lightning chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts Just Attacks based on the\n    number of Lightning chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31901",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増加＋ＣＰ最大値増",
 		"tr_explainShort": "Dam. boost per PA/Tech use + max CP up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 54% each time you use a PA or\n     Tech.\n     (Maximum boost: 270%)\n<color=yellow>SP: </color>Boosts damage by 56% each time you use a PA or\n     Tech.\n     (Maximum boost: 280%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum CP by 30.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31902",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増加＋ＣＰ最大値増",
 		"tr_explainShort": "Dam. boost per PA/Tech use + max CP up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② ＣＰの最大値を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 58% each time you use a PA or\n     Tech.\n     (Maximum boost: 290%)\n<color=yellow>SP: </color>Boosts damage by 60% each time you use a PA or\n     Tech.\n     (Maximum boost: 300%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum CP by 30.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum CP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31903",
 		"jp_explainShort": "氷枚数属性ダメージ＋氷枚数属性上限上昇",
 		"tr_explainShort": "Ice elem. boosted + max Ice value up",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じ\n　　 氷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Ice elemental damage against\n     enemies weak to Ice by 120% + 10% x\n     the number of Ice chips equipped.\n<color=yellow>SP: </color>Boosts Ice elemental damage against\n     enemies weak to Ice by 130% + 10% x\n     the number of Ice chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Ice value by 10 x the\n     number of Ice chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Ice elemental damage\n    against enemies weak to Ice based on the\n    number of Ice chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Ice value\n    based on the number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31904",
 		"jp_explainShort": "氷枚数属性ダメージ＋氷枚数属性上限上昇",
 		"tr_explainShort": "Ice elem. boosted + max Ice value up",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じ\n　　 氷属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Ice elemental damage against\n     enemies weak to Ice by 140% + 10% x\n     the number of Ice chips equipped.\n<color=yellow>SP: </color>Boosts Ice elemental damage against\n     enemies weak to Ice by 150% + 10% x\n     the number of Ice chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Ice value by 10 x the\n     number of Ice chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Ice elemental damage\n    against enemies weak to Ice based on the\n    number of Ice chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Ice value\n    based on the number of Ice chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31907",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 245%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31908",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31909",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 光属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 15%.\n④  If there is a Light chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Light chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31922",
 		"jp_explainShort": "光枚数属性ダメージ＋光枚数属性上限上昇",
 		"tr_explainShort": "Light elem. boosted + max Light value up",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じ\n　　 光属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Light elemental damage against\n     enemies weak to Light by 120% + 10% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts Light elemental damage against\n     enemies weak to Light by 130% + 10% x\n     the number of Light chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Light value by 10 x the\n     number of Light chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Light elemental damage\n    against enemies weak to Light based on the\n    number of Light chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Light value\n    based on the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31923",
 		"jp_explainShort": "光枚数属性ダメージ＋光枚数属性上限上昇",
 		"tr_explainShort": "Light elem. boosted + max Light value up",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じ\n　　 光属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Light elemental damage against\n     enemies weak to Light by 140% + 10% x\n     the number of Light chips equipped.\n<color=yellow>SP: </color>Boosts Light elemental damage against\n     enemies weak to Light by 150% + 10% x\n     the number of Light chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Light value by 10 x the\n     number of Light chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Light elemental damage\n    against enemies weak to Light based on the\n    number of Light chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Light value\n    based on the number of Light chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31938",
 		"jp_explainShort": "必殺技・法術威力絶大強化＋ダメージ軽減",
 		"tr_explainShort": "PAs/Techs boosted + dam. taken reduced",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 敵から受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power of PAs and Techs by 125%.\n<color=yellow>SP: </color>Boosts power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31939",
 		"jp_explainShort": "必殺技・法術威力絶大強化＋ダメージ大軽減",
 		"tr_explainShort": "PAs/Techs boosted + dam. taken reduced",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts power of PAs and Techs by 155%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 45%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts power of PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31949",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＣＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Fi/Th/Da + CP regen",
 		"jp_explainLong": "① アビリティレベルと炎・雷・闇属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental power by 5% + 8% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 9% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts elemental power based on\n    this chip's ability level and the total value of your\n    Fire, Lightning and Dark elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31950",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＣＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Fi/Th/Da + CP regen",
 		"jp_explainLong": "① アビリティレベルと炎・雷・闇属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental power by 5% + 10% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 11% x this chip's\n     ability level x your total Fire, Lightning and Dark\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts elemental power based on\n    this chip's ability level and the total value of your\n    Fire, Lightning and Dark elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31951",
 		"jp_explainShort": "雷枚数属性ダメージ＋雷枚数属性上限上昇",
 		"tr_explainShort": "Lightning elem. damage boost x # Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 120% + 10% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts Lightning elemental damage against\n     enemies weak to Lightning by 130% + 10% x\n     the number of Lightning chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Lightning value by 10 x\n     the number of Lightning chips equipped.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts Lightning elemental\n    damage against enemies weak to Lightning based\n    on the number of Lightning chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31952",
 		"jp_explainShort": "雷枚数属性ダメージ＋雷枚数属性上限上昇",
 		"tr_explainShort": "Lightning elem. damage boost x # Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを超絶に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 140% + 10% x\n     the number of Lightning chips equipped.\n<color=yellow>SP: </color>Boosts Lightning elemental damage against\n     enemies weak to Lightning by 150% + 10% x\n     the number of Lightning chips equipped.\n     <color=yellow>[S-Frame]</color>\n②  Increases your maximum Lightning value by 10 x\n     the number of Lightning chips equipped.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Lightning elemental\n    damage against enemies weak to Lightning based\n    on the number of Lightning chips equipped.\n    <color=yellow>[S-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31953",
 		"jp_explainShort": "威力絶大増＋闇武器攻撃力大増＋闇属性上限上昇",
 		"tr_explainShort": "Power boost + Dark wep. boost + max Dark up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が闇属性の場合\n　　 攻撃力を大きく増加する。\n③ 闇属性の上限値が上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 140%.\n<color=yellow>SP: </color>Boosts power by 150%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Dark value by 30.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Dark element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31954",
 		"jp_explainShort": "威力絶大増＋闇武器攻撃力大増＋闇属性上限上昇",
 		"tr_explainShort": "Power boost + Dark wep. boost + max Dark up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が闇属性の場合\n　　 攻撃力を大きく増加する。\n③ 闇属性の上限値が上昇する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 170%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Dark value by 30.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Dark element value.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31963",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
-		"tr_explainShort": "Damages self and enemies",
+		"tr_explainShort": "Cuts HP to damage all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に光属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 12500% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP.\n<color=yellow>SP: </color>Deals 13000% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive Light striking damage to yourself\n    and all enemies."
 	},
 	{
 		"assign": "31964",
 		"jp_explainShort": "ＨＰを削り敵全体に特大ダメージ",
-		"tr_explainShort": "Damages self and enemies",
+		"tr_explainShort": "Cuts HP to damage all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 自分自身をも巻き込んで\n　　 敵全体に光属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 13500% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP.\n<color=yellow>SP: </color>Deals 14000% 250 Light striking damage to all\n     enemies, while also damaging you by 99% of your\n     maximum HP."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive Light striking damage to yourself\n    and all enemies."
 	},
 	{
 		"assign": "31965",
 		"jp_explainShort": "アビＬｖ攻撃力劇的増加＋一定確率で自身がバーン",
 		"tr_explainShort": "Dam. boost x ab. lv. but chance to [Burn] self",
 		"jp_explainLong": "① 定期的に一定確率でバーンになる代わりに\n　　 アビリティレベルに応じて攻撃力を劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n<color=yellow>SP: </color>Boosts damage by 80% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level in exchange for having a chance to\n    [Burn] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31966",
 		"jp_explainShort": "アビＬｖ攻撃力劇的増加＋一定確率で自身がバーン",
 		"tr_explainShort": "Dam. boost x ab. lv. but chance to [Burn] self",
 		"jp_explainLong": "① 定期的に一定確率でバーンになる代わりに\n　　 アビリティレベルに応じて攻撃力を劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n<color=yellow>SP: </color>Boosts damage by 100% + 2% x this chip's\n     ability level in exchange for having a chance to\n     [Burn] you every second.\n     <color=yellow>[U-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level in exchange for having a chance to\n    [Burn] you at regular intervals.\n    <color=yellow>[U-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31967",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 105% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 110% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31968",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 115% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 120% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31973",
 		"jp_explainShort": "原生種・ダーカーにダメージ絶大増加＋軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Natives/Darkers",
 		"jp_explainLong": "① 原生種とダーカーに与えるダメージを絶大に増加する。\n② 原生種とダーカーから受けるダメージを軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Natives and Darkers by\n     135%.\n<color=yellow>SP: </color>Boosts damage against Natives and Darkers by\n     140%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives and Darkers\n     by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Natives and Darkers\n     by 35%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Immensely boosts damage against Natives and\n    Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives and Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31974",
 		"jp_explainShort": "原生種・ダーカーにダメージ絶大増加＋大軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Natives/Darkers",
 		"jp_explainLong": "① 原生種とダーカーに与えるダメージを絶大に増加する。\n② 原生種とダーカーから受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Natives and Darkers by\n     145%.\n<color=yellow>SP: </color>Boosts damage against Natives and Darkers by\n     150%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives and Darkers\n     by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Natives and Darkers\n     by 50%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Immensely boosts damage against Natives and\n    Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives and Darkers.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31977",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31978",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts power by 150%.\n<color=yellow>SP: </color>Boosts power by 160%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31979",
 		"jp_explainShort": "威力絶大増＋効果時間延長",
 		"tr_explainShort": "Power boost + chip durations extended",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② ボス戦とタワークエストで\n　　 装備中の風属性チップの枚数に応じて\n　　 ①の効果の威力をさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が風属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts power by 170%.\n<color=yellow>SP: </color>Boosts power by 180%.\n     <color=yellow>[F-Frame]</color>\n②  Further boosts the effect of ①  in boss battles\n     and Tower Quests by 40% x the number of\n     Wind chips equipped.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds when they activate, if there is a\n     Wind chip in this chip's Link Slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Wind chips equipped.\n③ Increases the Effect Duration of chips' abilities if\n    there is a Wind chip in this chip's Link Slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31980",
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31981",
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to avoid damage from\n     enemies.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31992",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 365% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 375% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31993",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 385% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 395% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31994",
 		"jp_explainShort": "代償攻撃力極度増加＋ダウン・のけぞり無効",
 		"tr_explainShort": "Costly damage boost + interrupt immune",
 		"jp_explainLong": "① 敵から受けるダメージが増加する代わりに\n　　 攻撃力を極度に増加する。\n② ダウン・のけぞり無効となる効果を付与する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 410% in exchange for taking\n     50% more damage from enemies.\n<color=yellow>SP: </color>Boosts damage by 420% in exchange for taking\n     50% more damage from enemies.\n     <color=yellow>[U-Frame]</color>\n②  Grants immunity to knockback and flinching.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "① Maximally boosts damage in exchange for\n    taking more damage from enemies.\n    <color=yellow>[U-Frame]</color>\n② Grants immunity to knockback and flinching.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "2110",
 		"jp_explainShort": "防御力を大強化",
 		"tr_explainShort": "DEF increased",
 		"jp_explainLong": "① 防御力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your DEF by 650.\n<color=yellow>SP: </color>Increases your DEF by 700.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases DEF.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "2120",
 		"jp_explainShort": "防御力を劇的強化",
 		"tr_explainShort": "DEF increased",
 		"jp_explainLong": "① 防御力を劇的に強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your DEF by 750.\n<color=yellow>SP: </color>Increases your DEF by 800.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically increases DEF.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "2410",
 		"jp_explainShort": "攻撃力を強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 350.\n<color=yellow>SP: </color>Increases your ATK by 370.\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Increases ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "2420",
 		"jp_explainShort": "攻撃力を強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 380.\n<color=yellow>SP: </color>Increases your ATK by 400.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Increases ATK.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80210",
 		"jp_explainShort": "攻撃力大増加＋ダメージ大軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 50%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80220",
 		"jp_explainShort": "攻撃力大増加＋ダメージ大軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵から受けるダメージを大きく軽減する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 60%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80410",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 8% of damage dealt as HP.\n     (Maximum recovery per hit: 8% of max HP)\n<color=yellow>SP: </color>Recovers 10% of damage dealt as HP.\n     (Maximum recovery per hit: 10% of max HP)\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "80420",
 		"jp_explainShort": "攻撃力大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 12% of damage dealt as HP.\n     (Maximum recovery per hit: 12% of max HP)\n<color=yellow>SP: </color>Recovers 15% of damage dealt as HP.\n     (Maximum recovery per hit: 15% of max HP)\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "80510",
 		"jp_explainShort": "攻撃力増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status immunity",
+		"tr_explainShort": "Damage boosted + status cured",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80520",
 		"jp_explainShort": "攻撃力大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status immunity",
+		"tr_explainShort": "Damage boosted + status cured",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80710",
 		"jp_explainShort": "攻撃力と防御力を強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 防御力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 270.\n<color=yellow>SP: </color>Increases your ATK by 290.\n②  Increases your DEF by 270.\n<color=yellow>SP: </color>Increases your DEF by 290.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Increases DEF.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "80720",
 		"jp_explainShort": "攻撃力と防御力を強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 防御力を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 290.\n<color=yellow>SP: </color>Increases your ATK by 320.\n②  Increases your DEF by 290.\n<color=yellow>SP: </color>Increases your DEF by 320.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Increases DEF.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80810",
 		"jp_explainShort": "武器に「バーン」効果＋攻撃力を強化",
 		"tr_explainShort": "[Burn] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 420.\n<color=yellow>SP: </color>Increases your ATK by 440.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "80820",
 		"jp_explainShort": "武器に「バーン」効果＋攻撃力を大強化",
 		"tr_explainShort": "[Burn] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "80910",
 		"jp_explainShort": "ダメージを武器の上限値に収束させる",
-		"tr_explainShort": "Critical hit rate increased",
+		"tr_explainShort": "Damage variance tightened",
 		"jp_explainLong": "① 敵に与えるダメージを\n　　 装備中の武器における上限値に収束する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases critical hit rate by 70%.\n<color=yellow>SP: </color>Increases critical hit rate by 80%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Tightens random damage variance to bring\n    minimum damage closer to maximum.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "80920",
 		"jp_explainShort": "ダメージを武器の上限値に収束させる",
-		"tr_explainShort": "Critical hit rate increased",
+		"tr_explainShort": "Damage variance tightened",
 		"jp_explainLong": "① 敵に与えるダメージを\n　　 装備中の武器における上限値に収束する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases critical hit rate by 85%.\n<color=yellow>SP: </color>Increases critical hit rate by 95%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Tightens random damage variance to bring\n    minimum damage closer to maximum.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "81010",
 		"jp_explainShort": "氷属性の打撃による大ダメージ",
-		"tr_explainShort": "Ice striking damage",
+		"tr_explainShort": "Ice striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 氷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1500% 200 Ice striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 2000% 200 Ice striking damage to the\n     target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice striking damage to the target."
 	},
 	{
 		"assign": "81020",
 		"jp_explainShort": "氷属性の打撃による特大ダメージ",
-		"tr_explainShort": "Ice striking damage",
+		"tr_explainShort": "Ice striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 氷属性の打撃による特大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 2500% 200 Ice striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 3000% 200 Ice striking damage to the\n     target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals massive Ice striking damage to the target."
 	},
 	{
 		"assign": "81110",
 		"jp_explainShort": "全体に中ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 675% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 810% shooting damage to all enemies.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to all enemies.\n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "81120",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 900% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1080% shooting damage to all enemies.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy damage to all enemies.\n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "81210",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "DEF decreased + ATK increased",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces your DEF by 50.\n<color=yellow>SP: </color>Reduces your DEF by 100.\n②  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "81220",
 		"jp_explainShort": "防御力を減少させ攻撃力を大強化",
 		"tr_explainShort": "DEF decreased + ATK increased",
 		"jp_explainLong": "① 防御力を減少する。\n② 攻撃力を大きく強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces your DEF by 150\n<color=yellow>SP: </color>Reduces your DEF by 200.\n②  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Reduces DEF.\n② Greatly increases ATK.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "81610",
 		"jp_explainShort": "武器に「ミラージュ」＋攻撃力を強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 430.\n<color=yellow>SP: </color>Increases your ATK by 450.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "81620",
 		"jp_explainShort": "武器に「ミラージュ」＋攻撃力を大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 480.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "81710",
 		"jp_explainShort": "雷属性を強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "81720",
 		"jp_explainShort": "雷属性を大強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 90.\n<color=yellow>SP: </color>Increases your Lightning Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly increases Lightning Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "81810",
 		"jp_explainShort": "炎属性を強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 84.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "81820",
 		"jp_explainShort": "炎属性を大強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を大きく強化する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 90.\n<color=yellow>SP: </color>Increases your Fire Element by 100.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly increases Fire Element.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "50110",
@@ -5254,7 +5254,7 @@
 		"jp_explainShort": "無数の矢を同時に発射する強弓用の必殺技",
 		"tr_explainShort": "[Bullet Bow PA] - Million Storm",
 		"jp_explainLong": "「強弓用の必殺技」\n 敵を貫く無数の矢を同時に発射する。",
-		"tr_explainLong": "[Bullet Bow PA]\nFire countless arrows that pierce the enemy."
+		"tr_explainLong": "Bullet Bow PA]\nFire countless arrows that pierce the enemy."
 	},
 	{
 		"assign": "60141",
@@ -7207,224 +7207,224 @@
 		"jp_explainShort": "ＨＰを小回復",
 		"tr_explainShort": "Small HP recovery",
 		"jp_explainLong": "① ＨＰをわずかに回復する。",
-		"tr_explainLong": "①  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%."
+		"tr_explainLong": "① Slightly recovers HP."
 	},
 	{
 		"assign": "1810",
 		"jp_explainShort": "ＨＰを回復",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。",
-		"tr_explainLong": "①  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 18%."
+		"tr_explainLong": "① Recovers HP."
 	},
 	{
 		"assign": "1910",
 		"jp_explainShort": "ＨＰを回復",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。",
-		"tr_explainLong": "①  Recovers HP by 20%.\n<color=yellow>SP: </color>Recovers HP by 24%."
+		"tr_explainLong": "① Recovers HP."
 	},
 	{
 		"assign": "2010",
 		"jp_explainShort": "状態異常を取り払いＨＰを小回復",
 		"tr_explainShort": "Status effects cured + HP recovery",
 		"jp_explainLong": "① 自身にかかった状態異常を取り払う。\n② ＨＰをわずかに回復する。",
-		"tr_explainLong": "①  Cures all status effects on yourself.\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%."
+		"tr_explainLong": "① Cures all status effects on yourself.\n② Slightly recovers HP."
 	},
 	{
 		"assign": "20110",
 		"jp_explainShort": "炎属性を小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 10.\n<color=yellow>SP: </color>Increases your Fire Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20210",
 		"jp_explainShort": "炎属性を強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20310",
 		"jp_explainShort": "氷属性を小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 10.\n<color=yellow>SP: </color>Increases your Ice Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20410",
 		"jp_explainShort": "氷属性を強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 20.\n<color=yellow>SP: </color>Increases your Ice Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Ice Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20510",
 		"jp_explainShort": "雷属性を小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 10.\n<color=yellow>SP: </color>Increases your Lightning Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20610",
 		"jp_explainShort": "雷属性を強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 20.\n<color=yellow>SP: </color>Increases your Lightning Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Lightning Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20710",
 		"jp_explainShort": "風属性を小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 10.\n<color=yellow>SP: </color>Increases your Wind Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20810",
 		"jp_explainShort": "風属性を強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 20.\n<color=yellow>SP: </color>Increases your Wind Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Wind Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20910",
 		"jp_explainShort": "光属性を小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 10.\n<color=yellow>SP: </color>Increases your Light Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21010",
 		"jp_explainShort": "光属性を強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 20.\n<color=yellow>SP: </color>Increases your Light Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Light Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21110",
 		"jp_explainShort": "闇属性を小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 10.\n<color=yellow>SP: </color>Increases your Dark Element by 12.\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21210",
 		"jp_explainShort": "闇属性を強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性を強化する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 20.\n<color=yellow>SP: </color>Increases your Dark Element by 24.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Dark Element.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3810",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Dark tech damage",
+		"tr_explainShort": "Dark Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% 30 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 450% 30 Dark tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
 	},
 	{
 		"assign": "3820",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Dark tech damage",
+		"tr_explainShort": "Dark Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% 30 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 675% 30 Dark tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
 	},
 	{
 		"assign": "3910",
 		"jp_explainShort": "中ダメージ＋一定確率で「ポイズン」",
 		"tr_explainShort": "Medium damage + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target. \n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "3920",
 		"jp_explainShort": "中ダメージ＋一定確率で「ポイズン」",
 		"tr_explainShort": "Medium damage + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target. \n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "4010",
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your Dark Element by 80% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Dark Element by 100% of its\n     value on activation.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "4020",
 		"jp_explainShort": "プレイヤーの闇属性を劇的強化",
 		"tr_explainShort": "Dark Element boosted",
 		"jp_explainLong": "① 効果発動時の闇属性値に応じて\n　　 闇属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your Dark Element by 110% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Dark Element by 130% of its\n     value on activation.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases Dark Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "4110",
 		"jp_explainShort": "全体に闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Dark tech damage to all enemies",
+		"tr_explainShort": "Medium Dark Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 800% 80 Dark tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to all enemies."
 	},
 	{
 		"assign": "4120",
 		"jp_explainShort": "全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Heavy Dark tech damage to all enemies",
+		"tr_explainShort": "Heavy Dark Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
 	},
 	{
 		"assign": "4310",
 		"jp_explainShort": "攻撃時に追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4320",
 		"jp_explainShort": "攻撃時に追加で小ダメージ",
 		"tr_explainShort": "Additional  damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 20%  damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25%  damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4510",
 		"jp_explainShort": "敵から受けるダメージを軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4520",
 		"jp_explainShort": "敵から受けるダメージを大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 45%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4810",
 		"jp_explainShort": "攻撃時に追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 6 seconds"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4820",
 		"jp_explainShort": "攻撃時に追加で大ダメージ",
-		"tr_explainShort": "Additional damage to enemies",
+		"tr_explainShort": "Heavy additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Effect Duration] Short"
 	},
 	{
 		"assign": "4910",
 		"jp_explainShort": "闇属性の打撃による中ダメージ",
 		"tr_explainShort": "Heavy Dark damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 750% 100 Dark striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 1000% 100 Dark striking damage to the\n     target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark damage to the target."
 	},
 	{
 		"assign": "4920",
 		"jp_explainShort": "闇属性の打撃による大ダメージ",
 		"tr_explainShort": "Heavy Dark damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1250% 100 Dark striking damage to the\n     target.\n<color=yellow>SP: </color>Deals 1500% 100 Dark striking damage to the\n     target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark damage to the target."
 	},
 	{
 		"assign": "5110",
@@ -7445,140 +7445,140 @@
 		"jp_explainShort": "全体に闇属性の射撃による中ダメージ",
 		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Dark shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "5320",
 		"jp_explainShort": "全体に闇属性の射撃による大ダメージ",
 		"tr_explainShort": "Dark shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "20005",
 		"jp_explainShort": "闇属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Dark tech damage",
+		"tr_explainShort": "Medium Dark Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 800% 80 Dark tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Dark Tech damage to the target."
 	},
 	{
 		"assign": "20006",
 		"jp_explainShort": "闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Heavy Dark tech damage",
+		"tr_explainShort": "Heavy Dark Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to the target.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to the target."
 	},
 	{
 		"assign": "20007",
 		"jp_explainShort": "敵全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Dark tech damage to all enemies",
+		"tr_explainShort": "Dark Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Dark tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
 	},
 	{
 		"assign": "20008",
 		"jp_explainShort": "敵全体に闇属性の法撃による大ダメージ",
-		"tr_explainShort": "Dark tech damage to all enemies",
+		"tr_explainShort": "Dark Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に闇属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Dark tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Dark tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Dark Tech damage to all enemies."
 	},
 	{
 		"assign": "20017",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + damage boosted vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 15% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 18% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20018",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + damage boosted vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 20% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 25% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20043",
 		"jp_explainShort": "法術小強化＋加速",
 		"tr_explainShort": "Techs boosted + actions quickened",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 15%.\n<color=yellow>SP: </color>Boosts the power of Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20044",
 		"jp_explainShort": "法術小強化＋加速",
 		"tr_explainShort": "Techs boosted + actions quickened",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Slightly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "5410",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 100% striking damage to the target.\n<color=yellow>SP: </color>Deals 120% striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
 	},
 	{
 		"assign": "5420",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 140% striking damage to the target.\n<color=yellow>SP: </color>Deals 160% striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
 	},
 	{
 		"assign": "5510",
 		"jp_explainShort": "射撃による小ダメージ",
 		"tr_explainShort": "Minor shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 190% shooting damage to the target.\n<color=yellow>SP: </color>Deals 230% shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target."
 	},
 	{
 		"assign": "5520",
 		"jp_explainShort": "射撃による中ダメージ",
 		"tr_explainShort": "Medium shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 270% shooting damage to the target.\n<color=yellow>SP: </color>Deals 320% shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target."
 	},
 	{
 		"assign": "6010",
 		"jp_explainShort": "射撃による小ダメージ",
 		"tr_explainShort": "Minor shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 190% shooting damage to the target.\n<color=yellow>SP: </color>Deals 230% shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target."
 	},
 	{
 		"assign": "6020",
 		"jp_explainShort": "射撃による中ダメージ",
 		"tr_explainShort": "Medium shooting damage",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 270% shooting damage to the target.\n<color=yellow>SP: </color>Deals 320% shooting damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target."
 	},
 	{
 		"assign": "6110",
 		"jp_explainShort": "中ダメージ＋一定確率で「フリーズ」",
 		"tr_explainShort": "Medium damage + chance to [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target.\n② Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "6120",
 		"jp_explainShort": "中ダメージ＋一定確率で「フリーズ」",
 		"tr_explainShort": "Medium damage + chance to [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium damage to the target.\n② Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "6410",
 		"jp_explainShort": "打撃による小ダメージ",
 		"tr_explainShort": "Minor striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による小ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 210% striking damage to the target.\n<color=yellow>SP: </color>Deals 250% striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor striking damage to the target."
 	},
 	{
 		"assign": "6420",
 		"jp_explainShort": "打撃による中ダメージ",
 		"tr_explainShort": "Medium striking damage",
 		"jp_explainLong": "【ダメージボム】\n① 打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% striking damage to the target.\n<color=yellow>SP: </color>Deals 350% striking damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium striking damage to the target."
 	},
 	{
 		"assign": "6610",
@@ -7625,58 +7625,58 @@
 	{
 		"assign": "7010",
 		"jp_explainShort": "風属性の法撃による中ダメージ",
-		"tr_explainShort": "Medium Wind tech damage",
+		"tr_explainShort": "Medium Wind Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 風属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Wind tech damage to the target.\n<color=yellow>SP: </color>Deals 800% 80 Wind tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Wind Tech damage to the target."
 	},
 	{
 		"assign": "7020",
 		"jp_explainShort": "風属性の法撃による大ダメージ",
-		"tr_explainShort": "Medium Wind tech damage",
+		"tr_explainShort": "Medium Wind Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 風属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Wind tech damage to the target.\n<color=yellow>SP: </color>Deals 1200% 80 Wind tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Wind Tech damage to the target."
 	},
 	{
 		"assign": "7110",
 		"jp_explainShort": "全体に風属性の打撃による中ダメージ",
 		"tr_explainShort": "Wind striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に風属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Wind striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Wind striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Wind striking damage to all\n    enemies."
 	},
 	{
 		"assign": "7120",
 		"jp_explainShort": "全体に風属性の打撃による大ダメージ",
 		"tr_explainShort": "Wind striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に風属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Wind striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Wind striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Wind striking damage to all enemies."
 	},
 	{
 		"assign": "7210",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Damage to all + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による大ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% shooting damage to all enemies.\n②  Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy shooting damage to all enemies.\n② Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "7220",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Damage to all + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による大ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% shooting damage to all enemies.\n②  Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy shooting damage to all enemies.\n② Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "7310",
 		"jp_explainShort": "全体に中ダメージ＋確率で「フリーズ」",
 		"tr_explainShort": "All Attack + Chance of [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 450% shooting damage to all enemies.\n②  Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to all enemies.\n② Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "7320",
 		"jp_explainShort": "全体に中ダメージ＋確率で「フリーズ」",
 		"tr_explainShort": "All Attack + Chance of [Freeze]",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に射撃による中ダメージを与える。\n② 一定確率で「フリーズ」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 675% shooting damage to all enemies.\n②  Has a chance to inflict [Freeze]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to all enemies.\n② Has a chance to inflict [Freeze]."
 	},
 	{
 		"assign": "7410",
@@ -7695,58 +7695,58 @@
 	{
 		"assign": "7510",
 		"jp_explainShort": "全体に氷属性の法撃による中ダメージ",
-		"tr_explainShort": "Ice tech damage to all enemies",
+		"tr_explainShort": "Ice Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 800% 80 Ice tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Ice Tech damage to all enemies."
 	},
 	{
 		"assign": "7520",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice tech damage to all enemies",
+		"tr_explainShort": "Ice Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
 	},
 	{
 		"assign": "8710",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light tech damage",
+		"tr_explainShort": "Light Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% 20 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 375% 20 Light tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light Tech damage to the target."
 	},
 	{
 		"assign": "8720",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light tech damage",
+		"tr_explainShort": "Light Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 450% 20 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 525% 20 Light tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light Tech damage to the target."
 	},
 	{
 		"assign": "8910",
 		"jp_explainShort": "光属性の法撃による中ダメージ",
-		"tr_explainShort": "Light tech damage",
+		"tr_explainShort": "Light Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 750% 100 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 1000% 100 Light tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light Tech damage to the target."
 	},
 	{
 		"assign": "8920",
 		"jp_explainShort": "光属性の法撃による大ダメージ",
-		"tr_explainShort": "Light tech damage",
+		"tr_explainShort": "Light Tech damage",
 		"jp_explainLong": "【ダメージボム】\n① 光属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1250% 100 Light tech damage to the target.\n<color=yellow>SP: </color>Deals 1500% 100 Light tech damage to the target."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light Tech damage to the target."
 	},
 	{
 		"assign": "9110",
 		"jp_explainShort": "全体に炎属性の打撃による中ダメージ",
 		"tr_explainShort": "Fire striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に炎属性の打撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Fire striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Fire striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Fire striking damage to all enemies."
 	},
 	{
 		"assign": "9120",
 		"jp_explainShort": "全体に炎属性の打撃による大ダメージ",
 		"tr_explainShort": "Fire striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に炎属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Fire striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Fire striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Fire striking damage to all enemies."
 	},
 	{
 		"assign": "9210",
@@ -7767,112 +7767,112 @@
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your Light Element by 80% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Light Element by 100% of its\n     value on activation.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "9320",
 		"jp_explainShort": "プレイヤーの光属性を劇的強化",
 		"tr_explainShort": "Light Element boosted",
 		"jp_explainLong": "① 効果発動時の光属性値に応じて\n　　 光属性を劇的に強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your Light Element by 110% of its\n     value on activation.\n<color=yellow>SP: </color>Boosts your Light Element by 130% of its\n     value on activation.\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases Light Element based on its\n    value on activation.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "9410",
 		"jp_explainShort": "全体に光属性の射撃による中ダメージ",
 		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Light shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Light shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Light shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "9420",
 		"jp_explainShort": "全体に光属性の射撃による大ダメージ",
 		"tr_explainShort": "Light shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Light shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Light shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "9423",
 		"jp_explainShort": "ダメージ小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boost + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 1% of max HP)\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "9424",
 		"jp_explainShort": "ダメージ小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boost + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% of damage dealt as HP.\n     (Maximum recovery per hit: 1% of max HP)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Effect Duration] Long"
 	},
 	{
 		"assign": "9421",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 法撃による大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% tech damage to all enemies.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Tech damage to all enemies.\n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "9422",
 		"jp_explainShort": "全体に大ダメージ＋確率で「ポイズン」",
 		"tr_explainShort": "Damage to all + chance to [Poison]",
 		"jp_explainLong": "【ダメージボム】\n① 法撃による大ダメージを与える。\n② 一定確率で「ポイズン」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% tech damage to all enemies.\n②  Has a chance to inflict [Poison]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Tech damage to all enemies.\n② Has a chance to inflict [Poison]."
 	},
 	{
 		"assign": "20025",
 		"jp_explainShort": "敵全体に光属性の打撃による大ダメージ",
 		"tr_explainShort": "Light striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Light striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Light striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light striking damage to all enemies."
 	},
 	{
 		"assign": "20026",
 		"jp_explainShort": "敵全体に光属性の打撃による大ダメージ",
 		"tr_explainShort": "Light striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に光属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Light striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Light striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Light striking damage to all enemies."
 	},
 	{
 		"assign": "20027",
 		"jp_explainShort": "射撃小ダメージ＋一定確率で「パニック」",
-		"tr_explainShort": "Shooting damage to all + chance to [Panic]",
+		"tr_explainShort": "Shooting damage + chance to [Panic]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による小ダメージを与える。\n② 一定確率で「パニック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 200% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 250% shooting damage to all enemies.\n②  Has a chance to inflict [Panic]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals minor shooting damage to the target.\n② Has a chance to inflict [Panic]."
 	},
 	{
 		"assign": "20028",
 		"jp_explainShort": "射撃中ダメージ＋一定確率で「パニック」",
-		"tr_explainShort": "Shooting damage to all + chance to [Panic]",
+		"tr_explainShort": "Shooting damage + chance to [Panic]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「パニック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 300% shooting damage to all enemies.\n<color=yellow>SP: </color>Deals 350% shooting damage to all enemies.\n②  Has a chance to inflict [Panic]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Panic]."
 	},
 	{
 		"assign": "9810",
 		"jp_explainShort": "射撃の中ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Shooting damage + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 375% shooting damage to the target.\n<color=yellow>SP: </color>Deals 450% shooting damage to the target.\n②  Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "9820",
 		"jp_explainShort": "射撃の中ダメージ＋確率で「ショック」",
 		"tr_explainShort": "Shooting damage + chance to [Shock]",
 		"jp_explainLong": "【ダメージボム】\n① 射撃による中ダメージを与える。\n② 一定確率で「ショック」効果を与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 525% shooting damage to the target.\n<color=yellow>SP: </color>Deals 675% shooting damage to the target.\n②  Has a chance to inflict [Shock]."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium shooting damage to the target.\n② Has a chance to inflict [Shock]."
 	},
 	{
 		"assign": "9910",
 		"jp_explainShort": "全体に雷属性の射撃による中ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による中ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 600% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 800% 80 Lightning shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals medium Lightning shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "9920",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "10010",
@@ -7893,84 +7893,84 @@
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by up to 35% based on how far\n     you are from the target.\n<color=yellow>SP: </color>Boosts damage by up to 40% based on how far\n     you are from the target.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage based on how far you are from\n    the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20036",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が大増加",
 		"tr_explainShort": "Damage boosted by distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by up to 45% based on how far\n     you are from the target.\n<color=yellow>SP: </color>Boosts damage by up to 50% based on how far\n     you are from the target.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on how far you are\n    from the target.\n    <color=yellow>[E-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20037",
 		"jp_explainShort": "敵全体に雷属性の打撃による大ダメージ",
 		"tr_explainShort": "Lightning striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning striking damage to all\n    enemies."
 	},
 	{
 		"assign": "20038",
 		"jp_explainShort": "敵全体に雷属性の打撃による大ダメージ",
 		"tr_explainShort": "Lightning striking damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の打撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Lightning striking damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Lightning striking damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning striking damage to all\n    enemies."
 	},
 	{
 		"assign": "30110",
 		"jp_explainShort": "原生種に対してダメージを増加",
 		"tr_explainShort": "Damage to Natives boosted",
 		"jp_explainLong": "① 原生種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Natives by 30%.\n<color=yellow>SP: </color>Boosts damage against Natives by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30120",
 		"jp_explainShort": "原生種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Natives boosted",
 		"jp_explainLong": "① 原生種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Natives by 40%.\n<color=yellow>SP: </color>Boosts damage against Natives by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30210",
 		"jp_explainShort": "機甲種に対してダメージを増加",
 		"tr_explainShort": "Damage to Mechs boosted",
 		"jp_explainLong": "① 機甲種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 30%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30220",
 		"jp_explainShort": "機甲種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Mechs boosted",
 		"jp_explainLong": "① 機甲種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 40%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30310",
 		"jp_explainShort": "龍族に対してダメージを増加",
 		"tr_explainShort": "Damage to Dragonkin boosted",
 		"jp_explainLong": "① 龍族に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 30%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30320",
 		"jp_explainShort": "龍族に対してダメージを大増加",
 		"tr_explainShort": "Damage to Dragonkin boosted",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 40%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30410",
 		"jp_explainShort": "ダーカーに対してダメージを増加",
 		"tr_explainShort": "Damage to Darkers boosted",
 		"jp_explainLong": "① ダーカーに与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 30%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30420",
 		"jp_explainShort": "ダーカーに対してダメージを大増加",
 		"tr_explainShort": "Damage to Darkers boosted",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 40%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "25010",
@@ -8117,97 +8117,97 @@
 		"jp_explainShort": "海王種に対してダメージを増加",
 		"tr_explainShort": "Damage to Oceanids boosted",
 		"jp_explainLong": "① 海王種に与えるダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids by 30%.\n<color=yellow>SP: </color>Boosts damage against Oceanids by 40%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20010",
 		"jp_explainShort": "海王種に対してダメージを大増加",
 		"tr_explainShort": "Damage to Oceanids boosted",
 		"jp_explainLong": "① 海王種に与えるダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids by 40%.\n<color=yellow>SP: </color>Boosts damage against Oceanids by 50%.\n     <color=yellow>[B-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20011",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
 		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice shooting damage to all enemies."
 	},
 	{
 		"assign": "20012",
 		"jp_explainShort": "全体に氷属性の射撃による大ダメージ",
 		"tr_explainShort": "Ice shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Ice shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Ice shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice shooting damage to all enemies."
 	},
 	{
 		"assign": "20019",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by up to 100 based on how\n     far you are from the target.\n<color=yellow>SP: </color>Increases your ATK by up to 120 based on how\n     far you are from the target.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20020",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が強化",
 		"tr_explainShort": "ATK up x distance from target",
 		"jp_explainLong": "① 攻撃対象の敵との距離が遠いほど\n　　 攻撃力を強化する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by up to 150 based on how\n     far you are from the target.\n<color=yellow>SP: </color>Increases your ATK by up to 200 based on how\n     far you are from the target.\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases ATK based on how far you are from\n    the target.\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20049",
 		"jp_explainShort": "消費ＣＰ減＋機改種に対してダメージを増加",
 		"tr_explainShort": "CP usage down + dam. boost vs Recon.",
 		"jp_explainLong": "① 機改種に対して与えるダメージを増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Reconfigured Mechs by\n     30%.\n<color=yellow>SP: </color>Boosts damage against Reconfigured Mechs by\n     40%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "① Boosts damage against Reconfigured Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20050",
 		"jp_explainShort": "消費ＣＰ減＋機改種に対してダメージを大増加",
 		"tr_explainShort": "CP usage down + dam. boost vs Recon.",
 		"jp_explainLong": "① 機改種に対して与えるダメージを大きく増加する。\n② 消費ＣＰを減少する。\n　　 このチップ発動時にも、この効果が適用される。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Reconfigured Mechs by\n     40%.\n<color=yellow>SP: </color>Boosts damage against Reconfigured Mechs by\n     45%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces CP consumption by 10%.\n     (Even applies to this chip's activation cost)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Reconfigured\n    Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces CP consumption.\n    (Even applies to this chip's activation cost)\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20071",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Lightning shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "20072",
 		"jp_explainShort": "全体に雷属性の射撃による大ダメージ",
 		"tr_explainShort": "Lightning shooting damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に雷属性の射撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Lightning shooting damage to all\n     enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Lightning shooting damage to all\n     enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Lightning shooting damage to all\n    enemies."
 	},
 	{
 		"assign": "20059",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice tech damage to all enemies",
+		"tr_explainShort": "Ice Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1000% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1200% 80 Ice tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
 	},
 	{
 		"assign": "20060",
 		"jp_explainShort": "全体に氷属性の法撃による大ダメージ",
-		"tr_explainShort": "Ice tech damage to all enemies",
+		"tr_explainShort": "Ice Tech damage to all enemies",
 		"jp_explainLong": "【ダメージボム】\n① 敵全体に氷属性の法撃による大ダメージを与える。",
-		"tr_explainLong": "[Damage Bomb]\n①  Deals 1400% 80 Ice tech damage to all enemies.\n<color=yellow>SP: </color>Deals 1600% 80 Ice tech damage to all enemies."
+		"tr_explainLong": "[Damage Bomb]\n① Deals heavy Ice Tech damage to all enemies."
 	},
 	{
 		"assign": "20065",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + dam. boost vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 8% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 12% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20066",
 		"jp_explainShort": "「ポイズン」付与＋「ポイズン」ダメージ小増加",
 		"tr_explainShort": "[Poison] + dam. boost vs [Poison]",
 		"jp_explainLong": "① 敵に「ポイズン」を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージをわずかに増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Inflicts [Poison] on the target.\n②  Boosts damage by 16% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 20% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Inflicts [Poison] on targeted enemy.\n② Slightly boosts damage against enemies affected\n    by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Effect Duration] Long"
 	}
 ]

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2,5917 +2,5917 @@
 	{
 		"assign": "710",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "Dramatic HP recovery",
+		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
+		"tr_explainLong": "①  Recovers HP by 80%.\n<color=yellow>SP: </color>Recovers HP by 85%.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "Dramatic HP recovery",
+		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
+		"tr_explainLong": "①  Recovers HP by 95%.\n<color=yellow>SP: </color>Recovers HP by 100%.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 540.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
+		"tr_explainLong": "①  Reduces CP consumption by 50%.\n<color=yellow>SP: </color>Reduces CP consumption by 65%.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
+		"tr_explainLong": "①  Reduces CP consumption by 80%.\n<color=yellow>SP: </color>Reduces CP consumption by 99%.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
+		"tr_explainLong": "①  Allows you to survive with 1 HP.\n[Activation Trigger] Defeated at 30% or more HP\n<color=yellow>SP: </color>[Activation Trigger] Defeated at 25% or more HP\n[Cooldown] 30 seconds"
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
+		"tr_explainLong": "①  Allows you to survive with 1 HP.\n[Activation Trigger] Defeated at 20% or more HP\n<color=yellow>SP: </color>[Activation Trigger] Defeated at 15% or more HP\n[Cooldown] 30 seconds"
 	},
 	{
 		"assign": "1630",
 		"jp_explainShort": "ダーカーに追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Darkers",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]ダーカーに攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
 	},
 	{
 		"assign": "1640",
 		"jp_explainShort": "ダーカーに追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Darkers",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]ダーカーに攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
 	},
 	{
 		"assign": "1650",
 		"jp_explainShort": "機甲種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Mechs",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]機甲種に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
 	},
 	{
 		"assign": "1660",
 		"jp_explainShort": "機甲種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Mechs",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]機甲種に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
 	},
 	{
 		"assign": "1670",
 		"jp_explainShort": "龍族に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Dragonkin",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]龍族に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
 	},
 	{
 		"assign": "1680",
 		"jp_explainShort": "龍族に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Dragonkin",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]龍族に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
 	},
 	{
 		"assign": "11010",
 		"jp_explainShort": "原生種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Natives",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]原生種に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
 	},
 	{
 		"assign": "11020",
 		"jp_explainShort": "原生種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Natives",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]原生種に攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
 	},
 	{
 		"assign": "11030",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 260.\n<color=yellow>SP: </color>Increases your ATK by 280.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "11040",
 		"jp_explainShort": "攻撃力が強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 300.\n<color=yellow>SP: </color>Increases your ATK by 320.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30009",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30010",
 		"jp_explainShort": "追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30011",
 		"jp_explainShort": "チップの効果時間が延長",
 		"tr_explainShort": "Chip Effect Duration extended",
 		"jp_explainLong": "① アクティブチップのアビリティ効果時間を\n　　 延長する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Extends the Effect Duration of Active Chips'\n    abilities.\n[Activation Trigger] Activating an Active Chip"
+		"tr_explainLong": "①  Extends the Effect Duration of an Active Chip's\n     ability by 8 seconds.\n<color=yellow>SP: </color>Extends the Effect Duration of an Active Chip's\n     ability by 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 12 seconds"
 	},
 	{
 		"assign": "30012",
 		"jp_explainShort": "チップの効果時間が延長",
 		"tr_explainShort": "Chip Effect Duration extended",
 		"jp_explainLong": "① アクティブチップのアビリティ効果時間を\n　　 延長する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "① Extends the Effect Duration of Active Chips'\n    abilities.\n[Activation Trigger] Activating an Active Chip"
+		"tr_explainLong": "①  Extends the Effect Duration of an Active Chip's\n     ability by 10 seconds.\n<color=yellow>SP: </color>Extends the Effect Duration of an Active Chip's\n     ability by 12 seconds.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 10 seconds"
 	},
 	{
 		"assign": "30019",
 		"jp_explainShort": "攻撃力が大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30020",
 		"jp_explainShort": "攻撃力が大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30021",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ＨＰが最大で攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30022",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ＨＰが最大で攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30023",
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30024",
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30025",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30026",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30035",
 		"jp_explainShort": "状態異常の敵に対してダメージ量が大増加",
 		"tr_explainShort": "Damage boosted vs status",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30036",
 		"jp_explainShort": "状態異常の敵に対してダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted vs status",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30037",
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 14% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 15% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30038",
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30039",
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "[Freeze] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30040",
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "[Freeze] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30041",
 		"jp_explainShort": "ダメージ軽減＋風の法術が大強化",
 		"tr_explainShort": "Wind Techs boosted + damage reduction",
 		"jp_explainLong": "① 風属性の法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Strongly boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wind Techs by 50%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30042",
 		"jp_explainShort": "ダメージ大軽減＋風の法術が劇的強化",
 		"tr_explainShort": "Wind Techs boosted + damage reduction",
 		"jp_explainLong": "① 風属性の法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wind Techs by 70%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30045",
 		"jp_explainShort": "ダメージ軽減＋大剣の必殺技が大強化",
 		"tr_explainShort": "Sword PAs boosted + damage reduction",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30046",
 		"jp_explainShort": "ダメージ大軽減＋大剣の必殺技が劇的強化",
 		"tr_explainShort": "Sword PAs boosted + damage reduction",
 		"jp_explainLong": "① 大剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30049",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 8%.\n<color=yellow>SP: </color>Recovers HP by 10%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "30050",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 12%.\n<color=yellow>SP: </color>Recovers HP by 15%.\n③  Recovers CP by 10.\n<color=yellow>SP: </color>Recovers CP by 12.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "30051",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Damaged to a certain HP level\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 5% every 4.8 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.8 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Damaged to below 70% HP\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30052",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Damaged to a certain HP level\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 8% every 4.8 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.8 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Damaged to below 70% HP\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30055",
 		"jp_explainShort": "炎属性が大強化＋攻撃力が強化",
 		"tr_explainShort": "Fire Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 炎属性を大きく強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Greatly increases Fire Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases your Fire Element by 60.\n<color=yellow>SP: </color>Increases your Fire Element by 70.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30056",
 		"jp_explainShort": "炎属性が劇的強化＋攻撃力が大強化",
 		"tr_explainShort": "Fire Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 炎属性を劇的に強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Dramatically increases Fire Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases your Fire Element by 85.\n<color=yellow>SP: </color>Increases your Fire Element by 95.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30057",
 		"jp_explainShort": "闇属性が大強化＋攻撃力が強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 闇属性を大きく強化する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Greatly increases Dark Element.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 70.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30058",
 		"jp_explainShort": "闇属性が劇的強化＋攻撃力が大強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 闇属性を劇的に強化する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Dramatically increases Dark Element.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases your Dark Element by 85.\n<color=yellow>SP: </color>Increases your Dark Element by 95.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30059",
 		"jp_explainShort": "弱点属性が強化＋攻撃力が強化",
 		"tr_explainShort": "Weak Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases all Elements that the target is weak\n     to by 40.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30060",
 		"jp_explainShort": "弱点属性が大強化＋攻撃力が大強化",
 		"tr_explainShort": "Weak Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 80.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30061",
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "[Poison] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30062",
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "[Poison] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30063",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30064",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30065",
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
-		"tr_explainShort": "Add. damage x # chips found",
+		"tr_explainShort": "Add. damage x number of chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 0.25% damage to enemies\n     x the number of chips discovered in the Chip Lab.\n     (Maximum additional damage: 65%)\n<color=yellow>SP: </color>(Maximum additional damage: 80%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30066",
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
-		"tr_explainShort": "Add. damage x # chips found",
+		"tr_explainShort": "Add. damage x number of chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 0.25% damage to enemies\n     x the number of chips discovered in the Chip Lab.\n     (Maximum additional damage: 90%)\n<color=yellow>SP: </color>(Maximum additional damage: 100%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30069",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "ATK up + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30070",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "ATK up + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30073",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 2% every 2.4 seconds.\n<color=yellow>SP: </color>Recovers HP by 3% every 2.4 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30074",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Recovers HP by 4% every 2.4 seconds.\n<color=yellow>SP: </color>Recovers HP by 5% every 2.4 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30075",
 		"jp_explainShort": "攻撃力とＣＰの回復速度が劇的強化",
-		"tr_explainShort": "ATK and CP recovery up",
+		"tr_explainShort": "ATK and CP regeneration up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 1500.\n<color=yellow>SP: </color>Increases your ATK by 1800.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "30076",
 		"jp_explainShort": "攻撃力とＣＰの回復速度が劇的強化",
-		"tr_explainShort": "ATK and CP recovery up",
+		"tr_explainShort": "ATK and CP regeneration up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 2000.\n<color=yellow>SP: </color>Increases your ATK by 2400.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "30077",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30078",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30079",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30080",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30087",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 540.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30088",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30091",
 		"jp_explainShort": "状態異常確率上昇＋ＣＰ消費量微減少",
 		"tr_explainShort": "Status rate up + CP usage down",
 		"jp_explainLong": "① 状態異常の発生率を上昇させる。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases status effect infliction rate.\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts status effect infliction rate by 100%.\n②  Reduces CP consumption by 20%.\n<color=yellow>SP: </color>Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30092",
 		"jp_explainShort": "状態異常確率上昇＋ＣＰ消費量減少",
 		"tr_explainShort": "Status rate up + CP usage down",
 		"jp_explainLong": "① 状態異常の発生率を上昇させる。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases status effect infliction rate.\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts status effect infliction rate by 100%.\n②  Reduces CP consumption by 40%.\n<color=yellow>SP: </color>Reduces CP consumption by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30093",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 600.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30094",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 750.\n<color=yellow>SP: </color>Increases your ATK by 900.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30095",
 		"jp_explainShort": "一定ダメージ防御＋大剣・抜剣が超絶強化",
 		"tr_explainShort": "Barrier + Sword & Katana ATK up",
 		"jp_explainLong": "① 大剣か抜剣を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Sword or Katana.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Sword or Katana.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Sword or Katana.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30096",
 		"jp_explainShort": "一定ダメージ防御＋大剣・抜剣が超絶強化",
 		"tr_explainShort": "Barrier + Sword & Katana ATK up",
 		"jp_explainLong": "① 大剣か抜剣を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Sword or Katana.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Sword or Katana.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Sword or Katana.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30097",
 		"jp_explainShort": "一定ダメージ防御＋長槍が超絶強化",
 		"tr_explainShort": "Barrier + Partisan ATK up",
 		"jp_explainLong": "① 長槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Partizan.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Partizan.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30098",
 		"jp_explainShort": "一定ダメージ防御＋長槍が超絶強化",
 		"tr_explainShort": "Barrier + Partisan ATK up",
 		"jp_explainLong": "① 長槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Partizan.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Partizan.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30099",
 		"jp_explainShort": "一定ダメージ防御＋導具が超絶強化",
 		"tr_explainShort": "Barrier + Talis ATK up",
 		"jp_explainLong": "① 導具を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Talis.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Talis.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Talis.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30100",
 		"jp_explainShort": "一定ダメージ防御＋導具が超絶強化",
 		"tr_explainShort": "Barrier + Talis ATK up",
 		"jp_explainLong": "① 導具を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Talis.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Talis.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Talis.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31001",
 		"jp_explainShort": "一定ダメージ防御＋長杖が超絶強化",
 		"tr_explainShort": "Barrier + Rod ATK up",
 		"jp_explainLong": "① 長杖を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Rod.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Rod.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Rod.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31002",
 		"jp_explainShort": "一定ダメージ防御＋長杖が超絶強化",
 		"tr_explainShort": "Barrier + Rod ATK up",
 		"jp_explainLong": "① 長杖を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Rod.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Rod.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Rod.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31003",
 		"jp_explainShort": "一定ダメージ防御＋鋼拳・自在槍が超絶強化",
 		"tr_explainShort": "Barrier + Knuckles & W. Lance ATK up",
 		"jp_explainLong": "① 鋼拳か自在槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with Knuckles or Wired Lances.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     Knuckles or Wired Lances.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     Knuckles or Wired Lances.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31004",
 		"jp_explainShort": "一定ダメージ防御＋鋼拳・自在槍が超絶強化",
 		"tr_explainShort": "Barrier + Knuckles & W. Lance ATK up",
 		"jp_explainLong": "① 鋼拳か自在槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with Knuckles or Wired Lances.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     Knuckles or Wired Lances.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     Knuckles or Wired Lances.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31005",
 		"jp_explainShort": "一定ダメージ防御＋銃剣・長銃が超絶強化",
 		"tr_explainShort": "Barrier + Gunslash & Rifle ATK up",
 		"jp_explainLong": "① 銃剣か長銃を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Gunslash or an Assault Rifle.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Gunslash or an Assault Rifle.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Gunslash or an Assault Rifle.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31006",
 		"jp_explainShort": "一定ダメージ防御＋銃剣・長銃が超絶強化",
 		"tr_explainShort": "Barrier + Gunslash & Rifle ATK up",
 		"jp_explainLong": "① 銃剣か長銃を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Gunslash or an Assault Rifle.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Gunslash or an Assault Rifle.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Gunslash or an Assault Rifle.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31007",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "All chips activated + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31008",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "All chips activated + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 85%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31013",
 		"jp_explainShort": "ダーカーに対してダメージが大増加",
 		"tr_explainShort": "Damage boosted against Darkers",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage against Darkers by 45%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 55%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31014",
 		"jp_explainShort": "ダーカーに対してダメージが劇的増加",
 		"tr_explainShort": "Damage boosted against Darkers",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Darkers by 65%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 75%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31015",
 		"jp_explainShort": "攻撃力大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "ATK up + 3 actions = ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31016",
 		"jp_explainShort": "攻撃力劇的強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "ATK up + 3 actions = ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 800.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31017",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "Lightning up + 3 actions = ATK up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases Lightning Element.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 66.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31018",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "Lightning up + 3 actions = ATK up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases Lightning Element.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31019",
 		"jp_explainShort": "攻撃力が大強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 540.\n②  Recovers HP by 12% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31020",
 		"jp_explainShort": "攻撃力が大強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Recovers HP by 12% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31021",
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が大強化",
 		"tr_explainShort": "Actions quickened + Wind up",
 		"jp_explainLong": "① 風属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases Wind Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 77.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31022",
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が劇的強化",
 		"tr_explainShort": "Actions quickened + Wind up",
 		"jp_explainLong": "① 風属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Wind Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Wind Element by 80.\n<color=yellow>SP: </color>Increases your Wind Element by 96.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31023",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by up to 1500 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 1600 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31024",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by up to 1800 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 2000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31027",
 		"jp_explainShort": "ダメージ軽減＋魔装脚の必殺技が大強化",
 		"tr_explainShort": "Damage reduced + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31028",
 		"jp_explainShort": "ダメージ大軽減＋魔装脚の必殺技が劇的強化",
 		"tr_explainShort": "Damage reduced + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31031",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が大強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 600.\n<color=yellow>SP: </color>Increases your ATK by 720.\n②  Reduces damage taken from enemies by 60%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31032",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力を劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 800.\n<color=yellow>SP: </color>Increases your ATK by 960.\n②  Reduces damage taken from enemies by 60%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31033",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Boosts your ATK by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 110% against enemy\n     elemental weaknesses.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31034",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Boosts your ATK by 120% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 145% against enemy\n     elemental weaknesses.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31035",
 		"jp_explainShort": "ダメージが大増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31036",
 		"jp_explainShort": "ダメージが劇的増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31037",
 		"jp_explainShort": "状態異常ダメージ大増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Damage boost vs status + HP over time",
 		"jp_explainLong": "① 状態異常の敵に対して大きくダメージを増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31038",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Damage boost vs status + HP over time",
 		"jp_explainLong": "① 状態異常の敵に対して劇的にダメージを増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 8% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31039",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & dam. reduced vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージを軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 80%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 35%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31040",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & dam. reduced vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージを大きく軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 90%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 50%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31041",
 		"jp_explainShort": "風チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31042",
 		"jp_explainShort": "風チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31043",
 		"jp_explainShort": "ダメージ軽減＋法術が大強化",
 		"tr_explainShort": "Techs boosted + damage reduced",
 		"jp_explainLong": "① 法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Techs by 50%.\n<color=yellow>SP: </color>Boosts the power of Techs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31044",
 		"jp_explainShort": "ダメージ大軽減＋法術が劇的強化",
 		"tr_explainShort": "Techs boosted + damage reduced",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Techs by 70%.\n<color=yellow>SP: </color>Boosts the power of Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31053",
 		"jp_explainShort": "炎チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31054",
 		"jp_explainShort": "炎チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31055",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31056",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31057",
 		"jp_explainShort": "消費ＣＰ減少＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31058",
 		"jp_explainShort": "消費ＣＰ減少＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31059",
 		"jp_explainShort": "ダメージ絶大増加",
-		"tr_explainShort": "Damage immensely boosted",
+		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 165%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31060",
 		"jp_explainShort": "ダメージ絶大増加",
-		"tr_explainShort": "Damage immensely boosted",
+		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31065",
 		"jp_explainShort": "ダメージ増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31066",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31069",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 800.\n<color=yellow>SP: </color>Increases your ATK by 960.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31070",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 1000.\n<color=yellow>SP: </color>Increases your ATK by 1200.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31073",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen increased",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your maximum CP by 20.\n<color=yellow>SP: </color>Increases your maximum CP by 25.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31074",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen increased",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your maximum CP by 30.\n<color=yellow>SP: </color>Increases your maximum CP by 40.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31075",
 		"jp_explainShort": "雷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31076",
 		"jp_explainShort": "雷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31077",
 		"jp_explainShort": "ダメージ大増加＋鋼拳・自在槍で大増加",
 		"tr_explainShort": "Damage boosted + fist weapons boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 鋼拳か自在槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    Wired Lances or Knuckles.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Wired Lances or Knuckles.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31078",
 		"jp_explainShort": "ダメージ劇的増加＋鋼拳・自在槍で大増加",
 		"tr_explainShort": "Damage boosted + fist weapons boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 鋼拳か自在槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    Wired Lances or Knuckles.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Wired Lances or Knuckles.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31079",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が大増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 80% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31080",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 120% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31081",
 		"jp_explainShort": "ダメージ大増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31082",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31083",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery per hit: 5% of max HP)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31084",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery per hit: 5% of max HP)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31089",
 		"jp_explainShort": "雷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your\n     Lightning Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your\n     Lightning Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31090",
 		"jp_explainShort": "雷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your\n     Lightning Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your\n     Lightning Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31091",
 		"jp_explainShort": "龍族にダメージ大増加＋被ダメージ小軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n② 龍族から受けるダメージをわずかに軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Slightly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 50%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 60%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 10%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 12%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31092",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ小軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージをわずかに軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Slightly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 70%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 80%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 15%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 20%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31095",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31096",
 		"jp_explainShort": "ＨＰ回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Deals an additional 125% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 20%.\n③  Recovers CP by 10.\n<color=yellow>SP: </color>Recovers CP by 12.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31101",
 		"jp_explainShort": "ダメージが大増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31102",
 		"jp_explainShort": "ダメージが劇的増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31103",
 		"jp_explainShort": "ダメージが増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31104",
 		"jp_explainShort": "ダメージが大増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31105",
 		"jp_explainShort": "光属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31106",
 		"jp_explainShort": "光属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31107",
 		"jp_explainShort": "炎属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31108",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31109",
 		"jp_explainShort": "氷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31110",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31111",
 		"jp_explainShort": "消費ＣＰ減少＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dark weakness boost + CP usage down",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31112",
 		"jp_explainShort": "消費ＣＰ減少＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dark weakness boost + CP usage down",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージ劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31113",
 		"jp_explainShort": "海王種・ダーカーにダメージ劇的増加＋軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Darkers",
 		"jp_explainLong": "① 海王種とダーカーに与えるダメージを劇的に増加する。\n② 海王種とダーカーから受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Darkers.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Darkers by 90%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Darkers by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Darkers by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Darkers by 35%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31114",
 		"jp_explainShort": "海王種・ダーカーにダメージ劇的増加＋大軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Darkers",
 		"jp_explainLong": "① 海王種とダーカーに与えるダメージを劇的に増加する。\n② 海王種とダーカーから受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n    and Darkers.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Darkers by 100%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Darkers by 105%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Darkers by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Darkers by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31115",
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 100% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31116",
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 140% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31117",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31118",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31121",
 		"jp_explainShort": "攻撃力が強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 300.\n<color=yellow>SP: </color>Increases your ATK by 330.\n②  Recovers HP by 1% every 2.4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31122",
 		"jp_explainShort": "攻撃力が強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 340.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Recovers HP by 1% every 2.4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31123",
 		"jp_explainShort": "ダメージ増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 3% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31124",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 3% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31125",
 		"jp_explainShort": "ダメージ大増加＋長槍で大増加",
 		"tr_explainShort": "Damage boosted + Partizans boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 長槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    a Partizan.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31126",
 		"jp_explainShort": "ダメージ劇的増加＋長槍で大増加",
 		"tr_explainShort": "Damage boosted + Partizans boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 長槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    a Partizan.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31127",
 		"jp_explainShort": "光チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31128",
 		"jp_explainShort": "光チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31129",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が大増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 80% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31130",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 120% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31133",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 140% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31134",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 180% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 160% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31135",
 		"jp_explainShort": "属性種類数ダメージ大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31136",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋追加ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31139",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.2% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n<color=yellow>SP: </color>Recovers HP by 0.4% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31140",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.6% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n<color=yellow>SP: </color>Recovers HP by 0.8% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31143",
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Fire Element up + 3 actions = ATK up",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases Fire Element.\n② Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 25.\n②  Increases your ATK  by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31144",
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Fire Element up + 3 actions = ATK up",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases Fire Element.\n② Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Fire Element by 30.\n<color=yellow>SP: </color>Increases your Fire Element by 35.\n②  Increases your ATK  by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31147",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31148",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31155",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds or next Slide Action"
 	},
 	{
 		"assign": "31156",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds or next Slide Action"
 	},
 	{
 		"assign": "31157",
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "①  Boosts damage by 20% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 30% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds or next Slide Action"
 	},
 	{
 		"assign": "31158",
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
+		"tr_explainLong": "①  Boosts damage by 40 + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 50 + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds or next Slide Action"
 	},
 	{
 		"assign": "31159",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Dark chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Dark chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31160",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Dark chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Dark chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31161",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31162",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 60% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 70% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31165",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15% x the number  of Fire\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number  of Fire\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.8% x the number of Fire chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers HP by 1.1% x the number of Fire chips\n     equipped every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31166",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 18% x the number  of Fire\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number  of Fire\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 1.65% x the number of Fire chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers HP by 1.3% x the number of Fire chips\n     equipped every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31167",
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 17% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31168",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 23% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 26% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31169",
 		"jp_explainShort": "チップ発見数攻撃力劇的増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chips discovered in the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 0.11% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>Boosts damage by 0.13% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 130%)\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31170",
 		"jp_explainShort": "チップ発見数攻撃力絶大増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chips discovered in the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 0.15% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 0.17% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 170%)\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31173",
 		"jp_explainShort": "消費ＣＰ減少＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Lightning weak boost",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31174",
 		"jp_explainShort": "消費ＣＰ減少＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Lightning weak boost",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31177",
 		"jp_explainShort": "氷チップ数攻撃力大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 12% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage x the number of\n     Ice chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31178",
 		"jp_explainShort": "氷チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 14% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage x the number of\n     Ice chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31179",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31180",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31181",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 10% x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 30% + 10% x the number of\n     Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31182",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40% + 10% x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% + 10% x the number of\n     Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31183",
 		"jp_explainShort": "攻撃力絶大増加＋弱点属性大強化",
-		"tr_explainShort": "Damage boosted + weakness Elem. up",
+		"tr_explainShort": "Damage boosted + weakness Elems up",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31184",
 		"jp_explainShort": "攻撃力絶大増加＋弱点属性劇的強化",
-		"tr_explainShort": "Damage boosted + weakness Elem. up",
+		"tr_explainShort": "Damage boosted + weakness Elems up",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 攻撃対象の敵の弱点属性を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31187",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 50% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31188",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31191",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 6% every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31192",
 		"jp_explainShort": "攻撃力劇的増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 8% every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 9% every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31193",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 45%.\n<color=yellow>SP: </color>Boosts power by 55%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31194",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts power by 65%.\n<color=yellow>SP: </color>Boosts power by 75%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31195",
 		"jp_explainShort": "攻撃力大増加＋大剣・銃剣でさらに増加",
 		"tr_explainShort": "Damage boost + Sword/Gunslash boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 大剣か銃剣を装備している場合は\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with\n　　 a Sword or a Gunslash.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n　　 a Sword or a Gunslash.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31196",
 		"jp_explainShort": "攻撃力劇的増加＋大剣・銃剣でさらに増加",
 		"tr_explainShort": "Damage boost + Sword/Gunslash boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 大剣か銃剣を装備している場合は\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with\n　　 a Sword or a Gunslash.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n　　 a Sword or a Gunslash.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31199",
 		"jp_explainShort": "攻撃力大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 6 every 4 seconds.\n<color=yellow>SP: </color>Recovers CP by 7 every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31200",
 		"jp_explainShort": "攻撃力劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 4 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31205",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ無で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を大きく増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31206",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ無で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31207",
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 14% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 16% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.4% x the number of Ice chips\n     equipped every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 0.6% x the number of Ice chips\n     equipped every 4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31208",
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 18% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 22% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.8% x the number of Ice chips\n     equipped every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 1% x the number of Ice chips\n     equipped every 4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31209",
 		"jp_explainShort": "機甲種にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Mechs",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 機甲種から受けるダメージを軽減する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Mechs.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Mechs by 80%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Mechs by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Mechs by 35%.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31210",
 		"jp_explainShort": "機甲種ダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Mechs",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 機甲種から受けるダメージを大きく軽減する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Mechs.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Mechs by 90%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Mechs by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Mechs by 50%.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31213",
 		"jp_explainShort": "原生種にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Natives",
 		"jp_explainLong": "① 原生種に与えるダメージを劇的に増加する。\n② 原生種から受けるダメージを軽減する。\n[発動条件]原生種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Natives by 80%.\n<color=yellow>SP: </color>Boosts damage against Natives by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Natives by 35%.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31214",
 		"jp_explainShort": "原生種ダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Natives",
 		"jp_explainLong": "① 原生種に与えるダメージを劇的に増加する。\n② 原生種から受けるダメージを大きく軽減する。\n[発動条件]原生種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Natives.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Natives by 90%.\n<color=yellow>SP: </color>Boosts damage against Natives by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Natives by 50%.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31217",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "Actions quickened + damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31218",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "Actions quickened + damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n②  自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n②  Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31219",
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31220",
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 18% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31221",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% x the number of Lightning chips equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     6% x the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31222",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 18% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% x the number of Lightning chips equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% x the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31223",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% x the number of Light\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 12% x the number of Light\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage to enemies x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage to enemies x the\n     number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31224",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 14% x the number of Light\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Light\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies x the\n     number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31225",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by up to 90%, based on how\n     close you are to the target.\n<color=yellow>SP: </color>Boosts damage by up to 100%, based on how\n     close you are to the target.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31226",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by up to 110%, based on how\n     close you are to the target.\n<color=yellow>SP: </color>Boosts damage by up to 120%, based on how\n     close you are to the target.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31229",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockback",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n③  Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31230",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockback",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n③  Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31231",
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.6 CP x the number of Dark chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers 0.9 CP x the number of Dark chips\n     equipped every 5 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31232",
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals based on the\n    number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 18% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1.2 CP x the number of Dark chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers 1.5 CP x the number of Dark chips\n     equipped every 5 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31233",
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31234",
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31235",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n② Boosts damage against enemies affected by\n    [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 70% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31236",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n② Boosts damage against enemies affected by\n    [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31237",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "Damage boost + boost per normal attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    perform a normal attack.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum boost (including ①): 100%)\n<color=yellow>SP: </color>(Maximum boost (including ①): 110%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31238",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "Damage boost + boost per normal attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    perform a normal attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum boost (including ①): 120%)\n<color=yellow>SP: </color>(Maximum boost (including ①): 130%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31239",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＨＰが微回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 7% every 8 seconds.\n<color=yellow>SP: </color>Recovers HP by 8% every 8 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31240",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＨＰが微回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 9% every 8 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 8 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31247",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     55% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31248",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     55% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     60% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31251",
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 13% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 14% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31252",
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31257",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力大増",
 		"tr_explainShort": "Damage boost + boost at low CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage while CP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31258",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力大増",
 		"tr_explainShort": "Damage boost + boost at low CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage while CP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31261",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dark Techs by 30% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 40% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31262",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dark Techs by 50% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 60% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31263",
 		"jp_explainShort": "攻撃力大増加＋飛翔剣で大増加",
 		"tr_explainShort": "Damage boosted + Dual Blades boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 飛翔剣を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with Dual\n    Blades.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31264",
 		"jp_explainShort": "攻撃力劇的増加＋飛翔剣で大増加",
 		"tr_explainShort": "Damage boosted + Dual Blades boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 飛翔剣を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with Dual\n    Blades.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31265",
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies x \n     your Wind Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31266",
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 33% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies x \n     your Wind Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31273",
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     25%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     30%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31274",
 		"jp_explainShort": "攻撃力超絶増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     35%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     40%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31275",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31276",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 19% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31279",
 		"jp_explainShort": "ダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Damage resist + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31280",
 		"jp_explainShort": "ダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Damage resist + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 85%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31281",
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性大強化",
 		"tr_explainShort": "[Poison] imbued + Weak Element up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を大きく強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases the target's weakness\n    Element value.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31282",
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性劇的強化",
 		"tr_explainShort": "[Poison] imbued + Weak Element up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases the target's weakness\n    Element value.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31283",
 		"jp_explainShort": "炎属性強化＋追加で特大ダメージ",
 		"tr_explainShort": "Fire Element up + additional damage",
 		"jp_explainLong": "① 炎属性を強化する。\n② 追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases Fire Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Fire Element by 45.\n<color=yellow>SP: </color>Increases your Fire Element by 50.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31284",
 		"jp_explainShort": "炎属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Fire Element up + additional damage",
 		"jp_explainLong": "① 炎属性を大きく強化する。\n② 追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Fire Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Fire Element by 55.\n<color=yellow>SP: </color>Increases your Fire Element by 60.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31285",
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 20% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31286",
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 20% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31289",
 		"jp_explainShort": "攻撃力大増加＋JA毎に攻撃力小増加",
 		"tr_explainShort": "Damage boosted + damage boost per JA",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ジャストアタックごとに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further slightly boosts damage each time you\n    successfully perform a Just Attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     successfully perform a Just Attack.\n     (Maximum boost (including ①): 140%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31290",
 		"jp_explainShort": "攻撃力劇的増加＋JA毎に攻撃力小増加",
 		"tr_explainShort": "Damage boosted + damage boost per JA",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ジャストアタックごとに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further slightly boosts damage each time you\n    successfully perform a Just Attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     successfully perform a Just Attack.\n     (Maximum boost (including ①): 140%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31293",
 		"jp_explainShort": "攻撃力絶大増＋ダメージ無で攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31294",
 		"jp_explainShort": "攻撃力絶大増＋ダメージ無で攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31295",
 		"jp_explainShort": "攻撃力劇的増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31296",
 		"jp_explainShort": "攻撃力劇的増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 95%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31299",
 		"jp_explainShort": "攻撃力劇的増加＋弱点属性大強化",
 		"tr_explainShort": "Damage boosted + weak Element up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31300",
 		"jp_explainShort": "攻撃力劇的増加＋弱点属性大強化",
 		"tr_explainShort": "Damage boosted + weak Element up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31301",
 		"jp_explainShort": "ＨＰとＣＰが小回復＋追加大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 55% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 4%.\n<color=yellow>SP: </color>Recovers HP by 5%.\n③  Recovers CP by 3.\n<color=yellow>SP: </color>Recovers CP by 4.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31302",
 		"jp_explainShort": "ＨＰとＣＰが小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 65% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 6%.\n<color=yellow>SP: </color>Recovers HP by 7%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 6.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31303",
 		"jp_explainShort": "発見済みエネミーチップ数に応じ特大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of Enemy Chips discovered\n    in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 0.778% damage to enemies x\n     the number of Enemy Chips discovered in the\n     Chip Lab.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>(Maximum boost: 120%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31304",
 		"jp_explainShort": "発見済みエネミーチップ数に応じ絶大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で絶大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies\n    based on the number of Enemy Chips discovered\n    in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 0.778% damage to enemies x\n     the number of Enemy Chips discovered in the\n     Chip Lab.\n     (Maximum boost: 130%)\n<color=yellow>SP: </color>(Maximum boost: 140%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31305",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋光属性大強化",
 		"tr_explainShort": "Dam. boost vs Darkers + Light Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 光属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Light Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Light Element by 50.\n<color=yellow>SP: </color>Increases your Light Element by 60.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31306",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋光属性大強化",
 		"tr_explainShort": "Dam. boost vs Darkers + Light Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 光属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Light Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Darkers by 115%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 80.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31309",
 		"jp_explainShort": "攻撃力劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31310",
 		"jp_explainShort": "攻撃力劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31313",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% + 8% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 35% + 8% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31314",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40% + 8% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 8% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31317",
 		"jp_explainShort": "攻撃力劇的増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "Damage boost + survive 1 incapacitation",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31318",
 		"jp_explainShort": "攻撃力絶大増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "Damage boost + survive 1 incapacitation",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31321",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ一定以上時攻撃力大増加",
 		"tr_explainShort": "Damage boosted + boost at high HP",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＨＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage as long as HP is above\n    a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 40% as long as HP is\n     at 75% or higher.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31322",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ一定以上時攻撃力大増加",
 		"tr_explainShort": "Damage boosted + boost at high HP",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＨＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage as long as HP is above\n    a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 40% as long as HP is\n     at 75% or higher.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31323",
 		"jp_explainShort": "消費ＣＰ減少＋炎弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Fire weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31324",
 		"jp_explainShort": "消費ＣＰ減少＋炎弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Fire weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31325",
 		"jp_explainShort": "攻撃力絶大増加＋光属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Light weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31326",
 		"jp_explainShort": "攻撃力絶大増加＋光属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Light weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31329",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 15% every 3 seconds.\n     (Maximum boost: 90%)\n<color=yellow>SP: </color>Boosts damage by 17% every 3 seconds.\n     (Maximum boost: 100%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31330",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 19% every 3 seconds.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>Boosts damage by 20% every 3 seconds.\n     (Maximum boost: 120%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31331",
 		"jp_explainShort": "ダメージ軽減＋法術が大強化",
 		"tr_explainShort": "Damage taken reduced + Techs boosted",
 		"jp_explainLong": "① 法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31332",
 		"jp_explainShort": "ダメージ大軽減＋法術が劇的強化",
 		"tr_explainShort": "Damage taken reduced + Techs boosted",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31333",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 100%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31334",
 		"jp_explainShort": "ダーカー以外にダメージ絶大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 140%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 160%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31337",
 		"jp_explainShort": "攻撃力超絶増加＋チップ効果時間延長",
 		"tr_explainShort": "Damage boosted + chip effects extended",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップ発動時のアビリティ効果時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Extends the Effect Duration of chips' abilities.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Extends the Effect Duration of chips' abilities by\n     10 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31338",
 		"jp_explainShort": "攻撃力超絶増加＋チップ効果時間延長",
 		"tr_explainShort": "Damage boosted + chip effects extended",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップ発動時のアビリティ効果時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Extends the Effect Duration of chips' abilities.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Extends the Effect Duration of chips' abilities by\n     10 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31341",
 		"jp_explainShort": "攻撃力劇的増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31342",
 		"jp_explainShort": "攻撃力劇的増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31343",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery: 3% of max HP)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31344",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery: 3% of max HP)\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31347",
 		"jp_explainShort": "必殺技大強化＋通常攻撃と移動加速",
 		"tr_explainShort": "PAs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31348",
 		"jp_explainShort": "必殺技劇的強化＋通常攻撃と移動加速",
 		"tr_explainShort": "PAs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31349",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Dam. boost vs status + HP up over time",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31350",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Dam. boost vs status + HP up over time",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 8% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31351",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 70% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 35%.\n<color=yellow>SP: </color>Reduces CP consumption by 36%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31352",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 90% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 36%.\n<color=yellow>SP: </color>Reduces CP consumption by 37%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31353",
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 170% + 5% x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 180% + 5% x the number of\n     Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31354",
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 190% + 5% x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 200% + 5% x the number of\n     Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31357",
 		"jp_explainShort": "攻撃力超絶増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31358",
 		"jp_explainShort": "攻撃力超絶増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31359",
 		"jp_explainShort": "攻撃力増加＋追加絶大ダメージ",
 		"tr_explainShort": "Damage boosted + additional damage",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 敵に追加で絶大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31360",
 		"jp_explainShort": "攻撃力大増加＋追加絶大ダメージ",
 		"tr_explainShort": "Damage boosted + additional damage",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵に追加で絶大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 135% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31361",
 		"jp_explainShort": "攻撃力劇的増＋ＨＰ一定以下時ダメージ大増",
 		"tr_explainShort": "Damage boosted + boost at low HP",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＨＰが一定以下の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage when HP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when HP is\n     below 50%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31362",
 		"jp_explainShort": "攻撃力劇的増＋ＨＰ一定以下時ダメージ大増",
 		"tr_explainShort": "Damage boosted + boost at low HP",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＨＰが一定以下の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage when HP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when HP is\n     below 50%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31363",
 		"jp_explainShort": "攻撃力増加＋必殺技が大強化",
 		"tr_explainShort": "Damage boosted + PAs boosted",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boost the power of PAs by 45%.\n<color=yellow>SP: </color>Boost the power of PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31364",
 		"jp_explainShort": "攻撃力大増加＋必殺技が大強化",
 		"tr_explainShort": "Damage boosted + PAs boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Boost the power of PAs by 55%.\n<color=yellow>SP: </color>Boost the power of PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31365",
 		"jp_explainShort": "アビリティレベル攻撃大増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 35% + 1% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 2% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31366",
 		"jp_explainShort": "アビリティレベル攻撃劇的増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55% + 3% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 65% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31367",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice Techs by 30% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts Ice Techs by 40% + 4% x this chip's ability\n     level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31368",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice Techs by 50% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts Ice Techs by 60% + 4% x this chip's ability\n     level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31369",
 		"jp_explainShort": "攻撃絶大増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage against bosses by a further 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n③  Reduces damage taken from bosses by 5% x the\n     number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31370",
 		"jp_explainShort": "攻撃超絶増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage against bosses by a further 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n③  Reduces damage taken from bosses by 5% x the\n     number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31371",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 100% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31372",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 110% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 120% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31373",
 		"jp_explainShort": "法術劇的強化＋一定確率で回避",
 		"tr_explainShort": "Tech boost + chance to avoid damage",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 35% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31374",
 		"jp_explainShort": "法術劇的強化＋一定確率で回避",
 		"tr_explainShort": "Tech boost + chance to avoid damage",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 45% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31375",
 		"jp_explainShort": "消費ＣＰ減少＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31376",
 		"jp_explainShort": "消費ＣＰ減少＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31377",
 		"jp_explainShort": "攻撃力絶大増加＋炎属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Fire weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31378",
 		"jp_explainShort": "攻撃力絶大増加＋炎属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Fire weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31381",
 		"jp_explainShort": "闇属性大強化＋追加で大ダメージ",
 		"tr_explainShort": "Dark Element up + additional damage",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Dark Element.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 70.\n②  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31382",
 		"jp_explainShort": "闇属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Dark Element up + additional damage",
 		"jp_explainLong": "① 闇属性を劇的に強化する。\n② 追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases Dark Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your Dark Element by 80.\n<color=yellow>SP: </color>Increases your Dark Element by 90.\n②  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31383",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Immensely boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 120% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31384",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Immensely boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 160% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31385",
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% + 0.333% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 130% + 0.333% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31386",
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140% + 0.333% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 150% + 0.333% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31387",
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31388",
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31391",
 		"jp_explainShort": "攻撃小増＋必殺技のＣＰ消費増加と劇的強化",
 		"tr_explainShort": "Dam. boost + PA&Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 必殺技・法術の威力を劇的に強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31392",
 		"jp_explainShort": "攻撃小増＋必殺技のＣＰ消費増加と劇的強化",
 		"tr_explainShort": "Dam. boost + PA&Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 必殺技・法術の威力を劇的に強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31393",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力劇的増",
 		"tr_explainShort": "Damage boosted + boost at high CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further dramatically boosts damage while CP is\n    above a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 90% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31394",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力劇的増",
 		"tr_explainShort": "Damage boosted + boost at high CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further dramatically boosts damage while CP is\n    above a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 90% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31395",
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "Bullet Bow PA boost + actions quickened",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31396",
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "Bullet Bow PA boost + actions quickened",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31397",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "Gunslash PA boost + actions quickened",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31398",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "Gunslash PA boost + actions quickened",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31399",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Additional damage + 3 actions = ATK up",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31400",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Additional damage + 3 actions = ATK up",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000)\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31401",
 		"jp_explainShort": "攻撃力劇的増加＋チップ発動率上昇",
 		"tr_explainShort": "Damage boost + chip activation rates up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31402",
 		"jp_explainShort": "攻撃力劇的増加＋チップ発動率上昇",
 		"tr_explainShort": "Damage boost + chip activation rates up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31403",
 		"jp_explainShort": "攻撃力劇的増加＋被ダメ―ジ時ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery on injury",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からダメージを受けた際にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP when you take damage\n    from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 95%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% when you take damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31404",
 		"jp_explainShort": "攻撃力劇的増加＋被ダメ―ジ時ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery on injury",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からダメージを受けた際にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP when you take damage\n    from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 105%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% when you take damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31407",
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Natives by 90%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Natives by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 35%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31408",
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋大軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n    and Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Natives by 100%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Natives by 105%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31411",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n<color=yellow>SP: </color>Boosts damage by 29% every 3 seconds.\n     (Maximum boost: 170%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31412",
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n<color=yellow>SP: </color>Boosts damage by 32% every 3 seconds.\n     (Maximum boost: 190%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31413",
 		"jp_explainShort": "攻撃力超絶増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31414",
 		"jp_explainShort": "攻撃力超絶増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31415",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP increased",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力をわずかに強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK based on this chip's ability\n    level.\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 20 x this chip's ability\n     level.\n<color=yellow>SP: </color>Increases your ATK by 30 x this chip's ability\n     level.\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31416",
 		"jp_explainShort": "ジャストアタックごと攻撃力強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP increased",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力を強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Increases ATK based on this chip's ability level.\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 40 x this chip's ability\n     level.\n<color=yellow>SP: </color>Increases your ATK by 60 x this chip's ability\n     level.\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31421",
 		"jp_explainShort": "攻撃力超絶増＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ジャストアタックで与えたダメージの一部を\n　　 自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt by Just\n    Attacks as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 205%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.1% of damage dealt by Just Attacks\n     as HP.\n     (Maximum recovery: 3% of your max HP).\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31422",
 		"jp_explainShort": "攻撃力超絶増＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ジャストアタックで与えたダメージの一部を\n　　 自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt by Just\n    Attacks as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 215%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.1% of damage dealt by Just Attacks\n     as HP.\n     (Maximum recovery: 3% of your max HP).\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31423",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 60% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31424",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31429",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     32% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31430",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     34% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     36% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31431",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31432",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31433",
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts the power of PAs by 3% x this\n     chip's  ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31434",
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs by 15% + 3% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31435",
 		"jp_explainShort": "全種族に対してダメージが増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against all races based on this\n    chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against all races by 20% +\n     1% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against all races by 25% +\n     1% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31436",
 		"jp_explainShort": "全種族に対してダメージが大増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against all races based\n    on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against all races by 30% +\n     1% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against all races by 35% +\n     1% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31439",
 		"jp_explainShort": "追加ダメージ＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Add. dam. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 125% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31440",
 		"jp_explainShort": "追加ダメージ＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Add. dam. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 135% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31441",
 		"jp_explainShort": "ダメージ軽減＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Damage resist + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31442",
 		"jp_explainShort": "ダメージ軽減＋光弱点時ダメージ絶大増加",
 		"tr_explainShort": "Damage resist + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31445",
 		"jp_explainShort": "攻撃力大増加＋氷風闇の技・法の威力大増",
 		"tr_explainShort": "Dam. boost + Ice/Wind/Dark move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが氷・風・闇属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts Ice, Wind and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Ice, Wind and Dark PAs and Techs by 45%.\n<color=yellow>SP: </color>Boosts Ice, Wind and Dark PAs and Techs by 50%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31446",
 		"jp_explainShort": "攻撃力大増加＋氷風闇の技・法の威力大増",
 		"tr_explainShort": "Dam. boost + Ice/Wind/Dark move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが氷・風・闇属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts Ice, Wind and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Ice, Wind and Dark PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts Ice, Wind and Dark PAs and Techs by 60%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31447",
 		"jp_explainShort": "炎属性上限上昇＋炎弱点時ダメージ絶大増加",
 		"tr_explainShort": "Fire weakness boosted, max value up",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31448",
 		"jp_explainShort": "炎属性上限上昇＋炎弱点時ダメージ絶大増加",
 		"tr_explainShort": "Fire weakness boosted, max value up",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31449",
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 10% x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% + 10% x the number of\n     Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.2% damage to enemies x\n     your Fire Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31450",
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% + 10% x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 40% + 10% x the number of\n     Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.2% damage to enemies x\n     your Fire Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31451",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 85% + 20% x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 105% + 20% x the number of\n     Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31452",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 125% + 20% x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 145% + 20% x the number of\n     Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31455",
 		"jp_explainShort": "攻撃力劇的増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 115%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     20%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     25%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31456",
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     30%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     35%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31459",
 		"jp_explainShort": "ダメージ軽減＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Damage resist + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31460",
 		"jp_explainShort": "ダメージ軽減＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Damage resist + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31461",
 		"jp_explainShort": "氷属性上限上昇＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Ice weakness boosted, maximum value up",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31462",
 		"jp_explainShort": "氷属性上限上昇＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Ice weakness boosted, maximum value up",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31463",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 70% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31464",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31465",
 		"jp_explainShort": "ダメージ軽減＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. resist + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31466",
 		"jp_explainShort": "ダメージ軽減＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "Dam. resist + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31467",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 185%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 1% x the number of Ice chips\n     equipped each time a chip effect activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 2 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31468",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 195%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 1% x the number of Ice chips\n     equipped each time a chip effect activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 2 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31469",
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "Damage boosted + always Just Attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31470",
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "Damage boosted + always Just Attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31471",
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals heavy additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 0.4% damage x the number of\n     Weaponoid Chips discovered in the Chip Lab.\n     (Maximum additional damage: 40%)\n<color=yellow>SP: </color>(Maximum additional damage: 60%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31472",
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 0.4% damage x the number of\n     Weaponoid Chips discovered in the Chip Lab.\n     (Maximum additional damage: 80%)\n<color=yellow>SP: </color>(Maximum additional damage: 100%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31473",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
 	},
 	{
 		"assign": "31474",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
 	},
 	{
 		"assign": "31477",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 45% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
 	},
 	{
 		"assign": "31478",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 55% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
 	},
 	{
 		"assign": "31479",
 		"jp_explainShort": "攻撃力大増加＋炎雷光の技・法の威力大増",
 		"tr_explainShort": "Dam. + Fire/Lightning/Light move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが炎・雷・光属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts Fire, Lightning and Light PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Lightning and Light PAs and Techs by\n     45%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Light PAs and Techs by\n     50%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31480",
 		"jp_explainShort": "攻撃力大増加＋炎雷光の技・法の威力大増",
 		"tr_explainShort": "Dam. + Fire/Lightning/Light move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが炎・雷・光属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts Fire, Lightning and Light PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Lightning and Light PAs and Techs by\n     55%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Light PAs and Techs by\n     60%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31481",
 		"jp_explainShort": "雷属性上限上昇＋雷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Lightning weakness boosted, max up",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Lightning value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31482",
 		"jp_explainShort": "雷属性上限上昇＋雷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Lightning weakness boosted, max up",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Lightning value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31487",
 		"jp_explainShort": "機甲種にダメージ劇的増＋弱点属性大強化",
 		"tr_explainShort": "Dam. boost vs Mechs + weak Elem. up",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Mechs by 105%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 60.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31488",
 		"jp_explainShort": "機甲種にダメージ劇的増＋弱点属性大強化",
 		"tr_explainShort": "Dam. boost vs Mechs + weak Elem. up",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Mechs by 115%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 70.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 80.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31489",
 		"jp_explainShort": "追加ダメージ＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31490",
 		"jp_explainShort": "追加ダメージ＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31491",
 		"jp_explainShort": "全属性を小強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements by 15.\n<color=yellow>SP: </color>Increases all Elements by 20.\n②  Deals an addititional 5% damage to enemies x\n     the number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31492",
 		"jp_explainShort": "全属性を強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements by 25.\n<color=yellow>SP: </color>Increases all Elements by 30.\n②  Deals an addititional 5% damage to enemies x\n     the number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31493",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋炎属性大強化",
 		"tr_explainShort": "Damage boost vs Darkers + Fire Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 炎属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Fire Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Fire Element by 50.\n<color=yellow>SP: </color>Increases your Fire Element by 60.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31494",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋炎属性大強化",
 		"tr_explainShort": "Damage boost vs Darkers + Fire Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 炎属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Fire Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage against Darkers by 115%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 80.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31495",
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 170% + 5% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 180% + 5% x the number of\n     Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31496",
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 190% + 5% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 200% + 5% x the number of\n     Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31497",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31498",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31501",
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 35% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31502",
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31503",
 		"jp_explainShort": "ダメージ軽減＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵からのダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31504",
 		"jp_explainShort": "ダメージ軽減＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Add. damage + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵からのダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31505",
 		"jp_explainShort": "追加ダメージ＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31506",
 		"jp_explainShort": "追加ダメージ＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31511",
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 200% + 5% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 205% + 5% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31512",
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 210% + 5% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 215% + 5% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31513",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against Oceanids and Natives\n    based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids and Natives by\n     15% + 2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against Oceanids and Natives by\n     20% + 2% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 20%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 25%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31514",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ大増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを大きく増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against Oceanids and\n    Natives based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Oceanids and Natives by\n     25% + 2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against Oceanids and Natives by\n     30% + 2% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 25%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31515",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 120%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31516",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 160%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 180%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31521",
 		"jp_explainShort": "追加ダメージ＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31522",
 		"jp_explainShort": "追加ダメージ＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31525",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + act rate up + CP use down",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n③  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31526",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + act rate up + CP use down",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n③  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31527",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. res. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 70% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31528",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. res. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 100% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31529",
 		"jp_explainShort": "追加ダメージ＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. dam. + Lightning weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31530",
 		"jp_explainShort": "追加ダメージ＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. dam. + Lightning weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31531",
 		"jp_explainShort": "攻撃力劇的増＋炎氷風の技・法威力絶大増",
 		"tr_explainShort": "Damage + Fire/Ice/Wind PA&Tech boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Fire, Ice and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Ice and Wind PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 135%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31532",
 		"jp_explainShort": "攻撃力劇的増＋炎氷風の技・法威力絶大増",
 		"tr_explainShort": "Damage + Fire/Ice/Wind PA&Tech boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Fire, Ice and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Ice and Wind PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 145%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31535",
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 15.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 20.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     5% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 25.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 30.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     5% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31537",
 		"jp_explainShort": "氷雷闇の技・法の威力絶大増",
 		"tr_explainShort": "Ice/Lightning/Dark PA & Tech boost",
 		"jp_explainLong": "① 必殺技・法術チップが氷・雷・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Ice, Lightning and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice, Lightning and Dark PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Ice, Lightning and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31538",
 		"jp_explainShort": "氷雷闇の技・法の威力絶大増",
 		"tr_explainShort": "Ice/Lightning/Dark PA & Tech boost",
 		"jp_explainLong": "① 必殺技・法術チップが氷・雷・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Ice, Lightning and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice, Lightning and Dark PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Ice, Lightning and Dark PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31541",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP use down + dam. boost + no status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 大剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31542",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP use down + dam. boost + no status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 大剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31545",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 28% every 3 seconds.\n     (Maximum boost: 165%)\n<color=yellow>SP: </color>Boosts damage by 31% every 3 seconds.\n     (Maximum boost: 185%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31546",
 		"jp_explainShort": "定期的に攻撃力を増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 33% every 3 seconds.\n     (Maximum boost: 195%)\n<color=yellow>SP: </color>Boosts damage by 36% every 3 seconds.\n     (Maximum boost: 215%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31547",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31548",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31549",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31550",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 180%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31551",
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 45% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 50% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31552",
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 55% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 60% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31553",
 		"jp_explainShort": "攻撃力劇的増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 15% each time you use a PA\n     or Tech.\n     (Maximum boost: 75%)\n<color=yellow>SP: </color>Boosts damage by 20% each time you use a PA\n     or Tech.\n     (Maximum boost: 100%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31554",
 		"jp_explainShort": "攻撃力劇的増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 25% each time you use a PA\n     or Tech.\n     (Maximum boost: 125%)\n<color=yellow>SP: </color>Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31557",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 25% every 3 seconds.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31558",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 29% every 3 seconds.\n     (Maximum boost: 170%)\n<color=yellow>SP: </color>Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31559",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31560",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31561",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31562",
 		"jp_explainShort": "攻撃力超絶増＋定期ＨＰ小回復＋ダウン無効",
 		"tr_explainShort": "Dam. boost + HP recov. + no knockdown",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 205%.\n<color=yellow>SP: </color>Boosts damage by 215%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 5% every 4.8 seconds.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31563",
 		"jp_explainShort": "攻撃力超絶増＋定期ＨＰ小回復＋ダウン無効",
 		"tr_explainShort": "Dam. boost + HP recov. + no knockdown",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 225%.\n<color=yellow>SP: </color>Boosts damage by 235%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 5% every 4.8 seconds.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31564",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     6% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31568",
 		"jp_explainShort": "技・法威力大強化＋光弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\r\n　　 与えるダメージを劇的に増加する。\r\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\r\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31569",
 		"jp_explainShort": "技・法威力大強化＋光弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\r\n　　 与えるダメージを劇的に増加する。\r\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 85% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31572",
 		"jp_explainShort": "攻撃力絶大増＋消費ＣＰ減少＋ダメージ軽減",
 		"tr_explainShort": "Dam. boost + CP use down + dam. res.",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 20%.\n③  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31573",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減少＋ダメージ軽減",
 		"tr_explainShort": "Dam. boost + CP use down + dam. res.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 20%.\n③  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31574",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by up to 5000 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 6000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31575",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が絶大強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を絶大に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by up to 7000 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 8000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31579",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31580",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31583",
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31584",
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 80% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31585",
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 25% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Raises the activation rate of all Support Chips by\n     50%.\n③  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31586",
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Raises the activation rate of all Support Chips by\n     50%.\n③  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31587",
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 145% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 155% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31588",
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 175% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31591",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ劇的増",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 必殺技にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict random status\n    effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict random status\n     effects.\n②  Boosts damage by 110% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31592",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 必殺技にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict random status\n    effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict random status\n     effects.\n②  Boosts damage by 150% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31593",
 		"jp_explainShort": "有効弱点属性武器で攻撃力が劇的増加",
 		"tr_explainShort": "Weapon elemental weakness boosted",
 		"jp_explainLong": "① 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage when your\n    weapon's Element matches the target's\n    elemental weakness.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 80% if the equipped weapon's\n     element matches the target's elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 90% if the equipped weapon's\n     element matches the target's elemental weakness.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31594",
 		"jp_explainShort": "有効弱点属性武器で攻撃力が劇的増加",
 		"tr_explainShort": "Weapon elemental weakness boosted",
 		"jp_explainLong": "① 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage when your\n    weapon's Element matches the target's\n    elemental weakness.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 100% if the equipped weapon's\n     element matches the target's elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 110% if the equipped weapon's\n     element matches the target's elemental weakness.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31595",
 		"jp_explainShort": "攻撃力絶大増＋被状態異常時攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + boost when under status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身が状態異常の場合に攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage while you are\n    affected by a status effect.\n    <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 80% while you are affected by\n     a status effect.\n     <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31596",
 		"jp_explainShort": "攻撃力絶大増＋被状態異常時攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + boost when under status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身が状態異常の場合に攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage while you are\n    affected by a status effect.\n    <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 80% while you are affected by\n     a status effect.\n     <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31597",
 		"jp_explainShort": "闇属性上限上昇＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Max Dark up + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies that\n    are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Dark value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against enemies that\n     are weak to Dark by 160%.\n<color=yellow>SP: </color>Boosts damage against enemies that\n     are weak to Dark by 170%.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Dark value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31598",
 		"jp_explainShort": "闇属性上限上昇＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Max Dark up + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemies that\n    are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Dark value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against enemies that\n     are weak to Dark by 180%.\n<color=yellow>SP: </color>Boosts damage against enemies that\n     are weak to Dark by 190%.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Dark value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31601",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 85% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n<color=yellow>SP: </color>Recovers CP by 7 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 95% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 105% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 4.9 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31603",
 		"jp_explainShort": "攻撃力劇的強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 5000.\n<color=yellow>SP: </color>Increases your ATK by 5500.\n②  Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31604",
 		"jp_explainShort": "攻撃力絶大強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 6000.\n<color=yellow>SP: </color>Increases your ATK by 6500.\n②  Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31607",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 必殺技に「ミラージュ」効果を与える。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Mirage].\n②  Boosts damage by 90% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31608",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 必殺技に「ミラージュ」効果を与える。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Mirage].\n②  Boosts damage by 110% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31611",
 		"jp_explainShort": "攻撃大増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies\n     x your Lightning Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31612",
 		"jp_explainShort": "攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies\n     x your Lightning Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31613",
 		"jp_explainShort": "炎雷風技法威力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 120%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 130%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31614",
 		"jp_explainShort": "炎雷風技法威力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 140%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 150%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31615",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 抜剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31616",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 抜剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31617",
 		"jp_explainShort": "技法威力絶大強化＋ダメージ減＋ＨＰ小回復",
 		"tr_explainShort": "Tech&PA boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31618",
 		"jp_explainShort": "技法威力絶大強化＋ダメージ減＋ＨＰ小回復",
 		"tr_explainShort": "Tech&PA boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 155%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 165%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31619",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、攻撃力をわずかに増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 195%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% each time a chip effect\n     activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 3 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31620",
 		"jp_explainShort": "攻撃力超絶増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップが発動するたびに、攻撃力をわずかに増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 205%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% each time a chip effect\n     activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 3 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31621",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 245%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31622",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31623",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31626",
 		"jp_explainShort": "風光闇の技・法の威力絶大増",
 		"tr_explainShort": "Wind/Light/Dark PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Wind, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31627",
 		"jp_explainShort": "風光闇の技・法の威力絶大増",
 		"tr_explainShort": "Wind/Light/Dark PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Wind, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31628",
 		"jp_explainShort": "雷光武器攻撃力絶大増＋ダーカー大ダメージ",
 		"tr_explainShort": "Light/Lightning wep boost + vs Darkers",
 		"jp_explainLong": "① 装備中の武器の属性が雷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② ダーカーに与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Lightning or\n    Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120% if using a Lightning or\n     Light weapon.\n<color=yellow>SP: </color>Boosts damage by 140% if using a Lightning or\n     Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31629",
 		"jp_explainShort": "雷光武器攻撃力絶大増＋ダーカー大ダメージ",
 		"tr_explainShort": "Light/Lightning wep boost + vs Darkers",
 		"jp_explainLong": "① 装備中の武器の属性が雷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② ダーカーに与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Lightning or\n    Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 160% if using a Lightning or\n     Light weapon.\n<color=yellow>SP: </color>Boosts damage by 180% if using a Lightning or\n     Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31630",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31631",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31632",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31636",
 		"jp_explainShort": "攻撃力絶大増加＋ＨＰ小回復＋ＣＰ回復",
 		"tr_explainShort": "Damage boosted + HP & CP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31637",
 		"jp_explainShort": "攻撃力絶大増加＋ＨＰ小回復＋ＣＰ回復",
 		"tr_explainShort": "Damage boosted + HP & CP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 145%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31638",
 		"jp_explainShort": "追加特大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     50%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31639",
 		"jp_explainShort": "追加絶大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 130% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 140% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     50%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31640",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力小強化",
 		"tr_explainShort": "CP usage down + PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力をわずかに強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31641",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力強化",
 		"tr_explainShort": "CP usage down + PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 35%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31642",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31643",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31648",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加絶大ダメージ",
 		"tr_explainShort": "HP recovery + CP recovery + add. dam.",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 130% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 140% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 8%.\n<color=yellow>SP: </color>Recovers HP by 10%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
 	},
 	{
 		"assign": "31649",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加絶大ダメージ",
 		"tr_explainShort": "HP recovery + CP recovery + add. dam.",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 150% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 160% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 12%.\n<color=yellow>SP: </color>Recovers HP by 15%.\n③  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
 	},
 	{
 		"assign": "31650",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 27% each time you use a PA\n     or Tech.\n     (Maximum boost: 135%)\n<color=yellow>SP: </color>Boosts damage by 29% each time you use a PA\n     or Tech.\n     (Maximum boost: 145%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31651",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 31% each time you use a PA\n     or Tech.\n     (Maximum boost: 155%)\n<color=yellow>SP: </color>Boosts damage by 33% each time you use a PA\n     or Tech.\n     (Maximum boost: 165%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31654",
 		"jp_explainShort": "炎氷風の技・法の威力劇的増＋大追撃",
 		"tr_explainShort": "Fire/Ice/Wind moves boosted + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Fire, Ice and Wind PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Wind PAs and Techs by 70%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 75%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31655",
 		"jp_explainShort": "炎氷風の技・法の威力劇的増＋大追撃",
 		"tr_explainShort": "Fire/Ice/Wind moves boosted + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Fire, Ice and Wind PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Wind PAs and Techs by 80%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 85%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31656",
 		"jp_explainShort": "絶大追撃＋海王種大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost vs Oceanids + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 海王種に与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 170% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Oceanids by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31657",
 		"jp_explainShort": "絶大追撃＋海王種大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost vs Oceanids + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 海王種に与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 175% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 180% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Oceanids by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31658",
 		"jp_explainShort": "技法威力絶大強化＋有効弱点ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を絶大に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31659",
 		"jp_explainShort": "技法威力絶大強化＋有効弱点ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を絶大に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31660",
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 30% damage to enemies +\n     1% x this chip's ability level.\n     <color=yellow>[Chase]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31661",
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 40% damage to enemies +\n     1% x this chip's ability level.\n     <color=yellow>[Chase]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31669",
 		"jp_explainShort": "種族必殺技・法術威力強化＋ダメージ防御",
 		"tr_explainShort": "PA & Tech boost vs Darkers + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 攻撃対象の敵がダーカーの場合\n　　 さらに必殺技・法術の威力を大きく強化する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Further greatly boosts PAs and Techs\n    against Darkers.\n    <color=yellow>[A-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 90%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 95%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts the power of PAs and Techs by a further\n     45% against Darkers.\n     <color=yellow>[A-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31670",
 		"jp_explainShort": "種族必殺技・法術威力強化＋ダメージ防御",
 		"tr_explainShort": "PA & Tech boost vs Darkers + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 攻撃対象の敵がダーカーの場合\n　　 さらに必殺技・法術の威力を大きく強化する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Further greatly boosts PAs and Techs\n    against Darkers.\n    <color=yellow>[A-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 100%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 105%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts the power of PAs and Techs by a further\n     45% against Darkers.\n     <color=yellow>[A-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31671",
 		"jp_explainShort": "定期的に攻撃力を増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 190%)\n<color=yellow>SP: </color>Boosts damage by 35% every 3 seconds.\n     (Maximum boost: 210%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31672",
 		"jp_explainShort": "定期的に攻撃力を増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：超絶）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 37% every 3 seconds.\n     (Maximum boost: 220%)\n<color=yellow>SP: </color>Boosts damage by 40% every 3 seconds.\n     (Maximum boost: 240%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31675",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ小増加",
 		"tr_explainShort": "Dam. resist + weakness damage boosted",
 		"jp_explainLong": "① 敵からのダメージを軽減する。\n② 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージをわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n② Slightly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 25%.\n②  Boosts damage by 25% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31676",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ増加",
 		"tr_explainShort": "Dam. resist + weakness damage boosted",
 		"jp_explainLong": "① 敵からのダメージを軽減する。\n② 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n② Boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 35%.\n②  Boosts damage by 25% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31679",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力小増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力をわずかに増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 20%.\n<color=yellow>SP: </color>Boosts power by 25%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 30%.\n<color=yellow>SP: </color>Boosts power by 35%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31681",
 		"jp_explainShort": "攻撃力劇的増加＋覇滅種にダメージ劇的増加",
 		"tr_explainShort": "Dam. boost + dam. boost against Superior",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 覇滅種に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 110% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 115% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31682",
 		"jp_explainShort": "攻撃力劇的増加＋覇滅種にダメージ絶大増加",
 		"tr_explainShort": "Dam. boost + dam. boost against Superior",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 覇滅種に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 120% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 125% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31683",
 		"jp_explainShort": "技法威力劇的強化＋ダメージ減＋ＨＰ回復",
 		"tr_explainShort": "PA & Tech boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 105%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 110%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31684",
 		"jp_explainShort": "技法威力劇的強化＋ダメージ減＋ＨＰ回復",
 		"tr_explainShort": "PA & Tech boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 115%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 120%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31685",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power by (1 + 0.005% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n<color=yellow>SP: </color>Boosts elemental power by (1 + 0.01% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n     <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31686",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power by (1 + 0.015% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n<color=yellow>SP: </color>Boosts elemental power by (1 + 0.02% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n     <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31687",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 17% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31688",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 20% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 22% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31689",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 200% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 205% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31690",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 215% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 220% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31691",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 230% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 235% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31692",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 鋼拳を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31693",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 鋼拳を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31694",
 		"jp_explainShort": "攻撃力絶大増＋闇光属性武器で攻撃力大増",
 		"tr_explainShort": "Dam. boost + Light/Dark weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光・闇の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage if equipped with a Light\n    or Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% if equipped with a Light\n     or Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31695",
 		"jp_explainShort": "攻撃力絶大増＋闇光属性武器で攻撃力大増",
 		"tr_explainShort": "Dam. boost + Light/Dark weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光・闇の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage if equipped with a Light\n    or Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% if equipped with a Light\n     or Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31696",
 		"jp_explainShort": "攻撃力絶大増加＋全アクティブチップ発動",
 		"tr_explainShort": "Damage boosted + all chips activated",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31697",
 		"jp_explainShort": "攻撃力絶大増加＋全アクティブチップ発動",
 		"tr_explainShort": "Damage boosted + all chips activated",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31698",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 必殺技に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Panic].\n② Dramatically boosts damage against enemies\n    affected by [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31699",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 必殺技に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Panic].\n② Dramatically boosts damage against enemies\n    affected by [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Panic].\n②  Boosts damage by 110% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31705",
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31706",
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31707",
 		"jp_explainShort": "炎氷光技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Fire/Ice/Light move boost + CP use",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・光属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Fire, Ice and Light PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Light PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Light PAs and Techs by 90%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31708",
 		"jp_explainShort": "炎氷光技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Fire/Ice/Light move boost + CP use",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・光属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Fire, Ice and Light PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Light PAs and Techs by 95%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Light PAs and Techs by 100%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31709",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 35% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31710",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 45% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31715",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "Status imbued + dam. boost, res. vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly reduces damage taken from enemies\n    affected by status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 65% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31716",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "Status imbued + dam. boost, res. vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly reduces damage taken from enemies\n    affected by status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 75% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31717",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Elem weak boost + max CP up & recov.",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 70% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 15.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31718",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Elem weak boost + max CP up & recov.",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 15.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31719",
 		"jp_explainShort": "大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31720",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31721",
 		"jp_explainShort": "ダーカーにダメージ増加＋攻撃力劇的強化",
 		"tr_explainShort": "Damage boost vs Darkers + ATK up",
 		"jp_explainLong": "① ダーカーに与えるダメージを増加する。\n② 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Darkers by 35%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your ATK by 5000.\n<color=yellow>SP: </color>Increases your ATK by 5500.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31722",
 		"jp_explainShort": "ダーカーにダメージ大増加＋攻撃力絶大強化",
 		"tr_explainShort": "Damage boost vs Darkers + ATK up",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n② 攻撃力を絶大に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Immensely increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Darkers by 40%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your ATK by 6000.\n<color=yellow>SP: </color>Increases your ATK by 6500.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31723",
 		"jp_explainShort": "氷光武器攻撃力絶大増加＋氷属性上限上昇",
 		"tr_explainShort": "Ice/Light weapons boosted + max Ice up",
 		"jp_explainLong": "① 装備中の武器の属性が氷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using an Ice or Light\n    weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 150% if using an Ice or Light\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 160% if using an Ice or Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Ice value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31724",
 		"jp_explainShort": "氷光武器攻撃力絶大増加＋氷属性上限上昇",
 		"tr_explainShort": "Ice/Light weapons boosted + max Ice up",
 		"jp_explainLong": "① 装備中の武器の属性が氷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using an Ice or Light\n    weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 170% if using an Ice or Light\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 180% if using an Ice or Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Ice value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31725",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 125%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31726",
 		"jp_explainShort": "ダーカー以外にダメージ絶大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against non-Darkers by 145%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 165%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31727",
 		"jp_explainShort": "追加特大ダメージ＋ＣＰ回復",
 		"tr_explainShort": "Additional damage + CP recovered",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers CP by 14.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31728",
 		"jp_explainShort": "追加特大ダメージ＋ＣＰ回復",
 		"tr_explainShort": "Additional damage + CP recovered",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers CP by 15.\n<color=yellow>SP: </color>Recovers CP by 16.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31731",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋ダメージ防御",
 		"tr_explainShort": "PAs & Techs boosted + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 65%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 75%.\n     <color=yellow>[A-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31732",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋ダメージ防御",
 		"tr_explainShort": "PAs & Techs boosted + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 95%.\n     <color=yellow>[A-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31736",
 		"jp_explainShort": "定期的に攻撃力を増加＋追加大ダメージ",
 		"tr_explainShort": "Boost over time + add. dam x # Elems",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n<color=yellow>SP: </color>Boosts damage by 32% every 3 seconds.\n     (Maximum boost: 190%)\n     <color=yellow>[G-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31737",
 		"jp_explainShort": "定期的に攻撃力を増加＋追加大ダメージ",
 		"tr_explainShort": "Boost over time + add. dam x # Elems",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：超絶）\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 34% every 3 seconds.\n     (Maximum boost: 200%)\n<color=yellow>SP: </color>Boosts damage by 35% every 3 seconds.\n     (Maximum boost: 210%)\n     <color=yellow>[G-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31738",
 		"jp_explainShort": "必殺技・法術の威力小強化＋ＨＰ小回復",
 		"tr_explainShort": "PAs & Techs boosted + HP recovered",
 		"jp_explainLong": "① 必殺技・法術の威力をわずかに強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 20%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 25%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31739",
 		"jp_explainShort": "必殺技・法術の威力強化＋ＨＰ小回復",
 		"tr_explainShort": "PAs & Techs boosted + HP recovered",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 30%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 35%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31740",
 		"jp_explainShort": "攻撃力大増加＋属性種類ダメージ軽減",
 		"tr_explainShort": "Dam. boost + dam. res x # Elems",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies based on\n    the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 5% x\n     the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31741",
 		"jp_explainShort": "攻撃力大増加＋属性種類ダメージ軽減",
 		"tr_explainShort": "Dam. boost + dam. res x # Elems",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies based on\n    the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 5% x\n     the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31744",
 		"jp_explainShort": "アビリティＬｖ炎武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Fire weapon boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31745",
 		"jp_explainShort": "アビリティＬｖ炎武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Fire weapon boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31746",
 		"jp_explainShort": "氷光闇の技・法の威力絶大増＋特大追撃",
 		"tr_explainShort": "Ice/Light/Dark move boost + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが氷・光・闇属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Ice, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice, Light and Dark PAs and Techs by\n     120%.\n<color=yellow>SP: </color>Boosts Ice, Light and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31747",
 		"jp_explainShort": "氷光闇の技・法の威力絶大増＋特大追撃",
 		"tr_explainShort": "Ice/Light/Dark move boost + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが氷・光・闇属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Ice, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice, Light and Dark PAs and Techs by\n     140%.\n<color=yellow>SP: </color>Boosts Ice, Light and Dark PAs and Techs by\n     150%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31755",
 		"jp_explainShort": "雷枚数攻撃力超絶強化＋機甲種大ダメージ",
 		"tr_explainShort": "ATK up x # Lightning + boost vs Mech",
 		"jp_explainLong": "① 装備中チップの雷属性チップの枚数に応じて\n　　 攻撃力を超絶に強化する。\n② 機甲種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK based on the\n    number of Lightning chips equipped.\n② Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 8250 + 500 x the\n     number of Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 9250 + 500 x the\n     number of Lightning chips equipped.\n②  Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31756",
 		"jp_explainShort": "雷枚数攻撃力超絶強化＋機甲種大ダメージ",
 		"tr_explainShort": "ATK up x # Lightning + boost vs Mech",
 		"jp_explainLong": "① 装備中チップの雷属性チップの枚数に応じて\n　　 攻撃力を超絶に強化する。\n② 機甲種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK based on the\n    number of Lightning chips equipped.\n② Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 10250 + 500 x the\n     number of Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 11250 + 500 x the\n     number of Lightning chips equipped.\n②  Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31761",
 		"jp_explainShort": "追加特大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Additional damage + barrier",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31762",
 		"jp_explainShort": "追加特大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Additional damage + barrier",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31763",
 		"jp_explainShort": "雷風闇技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Ln/Wi/Da boost + CP usage down",
 		"jp_explainLong": "① 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Lightning, Wind and Dark\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning, Wind and Dark PAs and Techs\n     by 85%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 90%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31764",
 		"jp_explainShort": "雷風闇技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Ln/Wi/Da boost + CP usage down",
 		"jp_explainLong": "① 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Lightning, Wind and Dark\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning, Wind and Dark PAs and Techs\n     by 95%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 100%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31765",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 255%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31766",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 270%.\n<color=yellow>SP: </color>Boosts damage by 275%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31767",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 295%.\n<color=yellow>SP: </color>Boosts damage by 300%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31768",
 		"jp_explainShort": "アビリティＬｖ風武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Wind wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31769",
 		"jp_explainShort": "アビリティＬｖ風武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Wind wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31770",
 		"jp_explainShort": "攻撃力増加＋必殺技・法術使用毎に大増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by ??% each time you use a PA or\n     Tech.\n     (Maximum boost: ???%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31771",
 		"jp_explainShort": "攻撃力増加＋必殺技・法術使用毎に大増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 45% each time you use a PA or\n     Tech.\n     (Maximum boost: 225%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "31774",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 必殺技に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31775",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 必殺技に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Poison].\n②  Boosts damage by 110% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31776",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを７５％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Cuts your current HP by 75%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Cuts your current HP by 75%.\n②  Increases your ATK by 9750.\n<color=yellow>SP: </color>Increases your ATK by 10500.\n③  Recovers HP by 5% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31777",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを７５％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Cuts your current HP by 75%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Cuts your current HP by 75%.\n②  Increases your ATK by 11250.\n<color=yellow>SP: </color>Increases your ATK by 12000.\n③  Recovers HP by 5% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31782",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ劇的増",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs [Burn]",
 		"jp_explainLong": "① 必殺技に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Burn].\n②  Boosts damage by 85% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31783",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ劇的増",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs [Burn]",
 		"jp_explainLong": "① 必殺技に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives PAs a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives PAs a chance to inflict [Burn].\n②  Boosts damage by 95% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31784",
 		"jp_explainShort": "技法威力小強化＋有効弱点ダメージ大増加",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 必殺技・法術の威力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 45% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31785",
 		"jp_explainShort": "技法威力小強化＋有効弱点ダメージ大増加",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 必殺技・法術の威力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 50% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 55% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31786",
 		"jp_explainShort": "威力増加＋光武器攻撃力増加＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. boost + Light wep boost + CP regen",
 		"jp_explainLong": "① 威力を増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 35%.\n<color=yellow>SP: </color>Boosts power by 40%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 10% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 2 every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31787",
 		"jp_explainShort": "威力大増加＋光武器攻撃力増加＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. boost + Light wep boost + CP regen",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 40%.\n<color=yellow>SP: </color>Boosts power by 45%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 10% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 2 every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31792",
 		"jp_explainShort": "光闇属性武器で攻撃力劇的増",
 		"tr_explainShort": "Light/Dark weapons boosted",
 		"jp_explainLong": "① 装備中の武器の属性が光・闇の場合\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage if using a Light or\n    Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 110% if using a Light or Dark\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 115% if using a Light or Dark\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31793",
 		"jp_explainShort": "光闇属性武器で攻撃力劇的増",
 		"tr_explainShort": "Light/Dark weapons boosted",
 		"jp_explainLong": "① 装備中の武器の属性が光・闇の場合\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage if using a Light or\n    Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 115% if using a Light or Dark\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 120% if using a Light or Dark\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31796",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 70%.\n<color=yellow>SP: </color>Boosts power by 80%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31797",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 90%.\n<color=yellow>SP: </color>Boosts power by 100%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31798",
 		"jp_explainShort": "属性ダメージ＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental damage by 115% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 135% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31799",
 		"jp_explainShort": "属性ダメージ＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental damage by 155% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 175% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31800",
 		"jp_explainShort": "ＪＡ威力絶大増加＋ＪＡ成功３回毎にＣＰ回復",
 		"tr_explainShort": "JA boost x elems + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Just Attacks by 30% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 35% x the number of\n     different chip elements equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31801",
 		"jp_explainShort": "ＪＡ威力超絶増加＋ＪＡ成功３回毎にＣＰ回復",
 		"tr_explainShort": "JA boost x elems + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Just Attacks by 35% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 40% x the number of\n     different chip elements equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31802",
 		"jp_explainShort": "アビリティＬｖ闇武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Dark wep boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's\n     ability level if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's\n     ability level if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31803",
 		"jp_explainShort": "アビリティＬｖ闇武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Dark wep boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's\n     ability level if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's\n     ability level if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 25.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31804",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31805",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31806",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31807",
 		"jp_explainShort": "威力劇的増＋光闇技法威力小増＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. + Light/Dark move boost + CP recov.",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 必殺技・法術チップが光・闇属性の場合は\n　　 威力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts Light and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 110%.\n<color=yellow>SP: </color>Boosts power by 115%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts Light and Dark PAs and Techs by 20%.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 3 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31808",
 		"jp_explainShort": "威力劇的増＋光闇技法威力小増＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. + Light/Dark move boost + CP recov.",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 必殺技・法術チップが光・闇属性の場合は\n　　 威力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts Light and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 115%.\n<color=yellow>SP: </color>Boosts power by 120%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts Light and Dark PAs and Techs by 20%.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 3 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31809",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 27% each time you use a PA\n     or Tech.\n     (Maximum boost: 135%)\n<color=yellow>SP: </color>Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31810",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 33% each time you use a PA\n     or Tech.\n     (Maximum boost: 165%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31811",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 700 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n<color=yellow>SP: </color>Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n②  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31812",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31813",
 		"jp_explainShort": "攻撃力絶大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status cured",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31814",
 		"jp_explainShort": "攻撃力絶大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status cured",
+		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 145%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31815",
 		"jp_explainShort": "攻撃力絶大強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃ヒット時\n[効果時間]短い時間",
-		"tr_explainLong": "① Immensely increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 6600.\n<color=yellow>SP: </color>Increases your ATK by 6900.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31816",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 7200.\n<color=yellow>SP: </color>Increases your ATK by 7500.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31817",
 		"jp_explainShort": "攻撃ダメージ増＋弱属武器攻撃力増＋定期ＣＰ回復",
 		"tr_explainShort": "Attack boost + weak wep. boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 装備中の武器の属性が氷属性か攻撃対象の\n　　 敵の弱点に有効な属性の場合、攻撃力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if the equipped weapon's element\n    is Ice, or if it matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 30% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 31% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31818",
 		"jp_explainShort": "攻撃ダメージ増＋弱属武器攻撃力増＋定期ＣＰ回復",
 		"tr_explainShort": "Attack boost + weak wep. boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 装備中の武器の属性が氷属性か攻撃対象の\n　　 敵の弱点に有効な属性の場合、攻撃力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if the equipped weapon's element\n    is Ice, or if it matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 32% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 33% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31819",
 		"jp_explainShort": "威力劇的増＋属性ダメージ＋定期ＨＰ回復",
 		"tr_explainShort": "Pow. boost + elem. dam. boost + HP regen",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 属性によるダメージを大きく増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Boosts elemental damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[S-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 100%.\n<color=yellow>SP: </color>Boosts power by 110%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts elemental damage by 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[S-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31820",
 		"jp_explainShort": "威力絶大増＋属性ダメージ＋定期ＨＰ回復",
 		"tr_explainShort": "Pow. boost + elem. dam. boost + HP regen",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中チップの属性種類数に応じて\n　　 属性によるダメージを大きく増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Boosts elemental damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[S-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 130%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts elemental damage by 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[S-Frame]</color>\n③  Recovers HP by 5% every 4.91 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31821",
 		"jp_explainShort": "攻撃力劇的増加＋雷風闇の技法威力絶大増",
 		"tr_explainShort": "Damage boosted + Fi/Ic/Wi moves boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Lightning, Wind and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Lightning, Wind and Dark PAs and Techs\n     by 130%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 135%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31822",
 		"jp_explainShort": "攻撃力劇的増加＋雷風闇の技法威力絶大増",
 		"tr_explainShort": "Damage boosted + Fi/Ic/Wi moves boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Lightning, Wind and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Lightning, Wind and Dark PAs and Techs\n   by 140%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n   by 145%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31825",
 		"jp_explainShort": "アビリティＬｖ氷武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Ice wep. boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's\n     ability level if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's\n     ability level if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31826",
 		"jp_explainShort": "アビリティＬｖ氷武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Ice wep. boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's\n     ability level if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's\n     ability level if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31827",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 235%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31828",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31829",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31832",
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. x # Light + all JAs + quickened",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals overwhelming additional damage to enemies\n    based on the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 205% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 210% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31833",
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. x # Light + all JAs + quickened",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals overwhelming additional damage to enemies\n    based on the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 215% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 220% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31836",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "PA&Tech boost + weak elem. wep. boost",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly boosts damage if the equipped weapon's\n    element matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31837",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "PA&Tech boost + weak elem. wep. boost",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly boosts damage if the equipped weapon's\n    element matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31838",
 		"jp_explainShort": "風光闇技法攻撃力超絶増＋消費ＣＰ減",
 		"tr_explainShort": "Wi/Li/Da PA&Tech boost + CP use down",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts Wind, Light and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     265%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     270%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31839",
 		"jp_explainShort": "風光闇技法攻撃力超絶増＋消費ＣＰ減",
 		"tr_explainShort": "Wi/Li/Da PA&Tech boost + CP use down",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts Wind, Light and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     275%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     280%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31854",
 		"jp_explainShort": "アビＬｖ風技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Wind boost x ab. lv. + extension x # Wind",
 		"jp_explainLong": "① 必殺技・法術チップが風属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wind PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Wind Support\n    Chips' abilities based on the number of Wind chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Wind PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Wind Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31855",
 		"jp_explainShort": "アビＬｖ風技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Wind boost x ab. lv. + extension x # Wind",
 		"jp_explainLong": "① 必殺技・法術チップが風属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Wind PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Wind Support\n    Chips' abilities based on the number of Wind chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Wind PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Wind PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Wind Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31856",
 		"jp_explainShort": "アビＬｖ雷技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Thun. boost x ab. lv. + extension x # Thun.",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Lightning PAs and Techs\n    based on this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Lightning Support\n    Chips' abilities based on the number of Lightning\n    chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Lightning PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Lightning Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31857",
 		"jp_explainShort": "アビＬｖ雷技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Thun. boost x ab. lv. + extension x # Thun.",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Lightning PAs and Techs\n    based on this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Lightning Support\n    Chips' abilities based on the number of Lightning\n    chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Lightning PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Lightning Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31860",
 		"jp_explainShort": "威力を劇的増加",
 		"tr_explainShort": "Power boosted",
 		"jp_explainLong": "① 威力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 100%.\n<color=yellow>SP: </color>Boosts power by 110%.\n     <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31861",
 		"jp_explainShort": "威力を絶大増加",
 		"tr_explainShort": "Power boosted",
 		"jp_explainLong": "① 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 130%.\n     <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31862",
 		"jp_explainShort": "炎雷風の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fi/Ln/Wi PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 125%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31863",
 		"jp_explainShort": "炎雷風の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fi/Ln/Wi PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 135%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31866",
 		"jp_explainShort": "攻撃力絶大増＋炎氷属性武器で攻撃力大増",
 		"tr_explainShort": "Damage boost + Ice/Fire weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎・氷の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage when using an Ice or Fire\n    weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% when using an Ice or Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31867",
 		"jp_explainShort": "攻撃力絶大増＋炎氷属性武器で攻撃力大増",
 		"tr_explainShort": "Damage boost + Ice/Fire weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎・氷の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage when using an Ice or Fire\n    weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% when using an Ice or Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31868",
 		"jp_explainShort": "アビＬｖ炎技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Fire boost x ab. lv. + extension x # Fire",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Fire PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Fire Support Chips'\n    abilities based on the number of Fire chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Fire PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Fire Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31869",
 		"jp_explainShort": "アビＬｖ炎技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Fire boost x ab. lv. + extension x # Fire",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Fire PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Fire Support Chips'\n    abilities based on the number of Fire chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Fire PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Fire Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31870",
 		"jp_explainShort": "アビＬｖ闇技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Dark boost x ab. lv. + extension x # Dark",
 		"jp_explainLong": "① 必殺技・法術チップが闇属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dark PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Dark Support Chips'\n    abilities based on the number of Dark chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Dark PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Dark PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Dark Support\n     Chips' abilities by 2 seconds x the number of\n     Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31871",
 		"jp_explainShort": "アビＬｖ闇技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Dark boost x ab. lv. + extension x # Dark",
 		"jp_explainLong": "① 必殺技・法術チップが闇属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Dark PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Dark Support Chips'\n    abilities based on the number of Dark chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Dark PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Dark PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Dark Support\n     Chips' abilities by 2 seconds x the number of\n     Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31872",
 		"jp_explainShort": "攻撃ダメージ増＋弱属技法威力増＋定期ＣＰ回復",
 		"tr_explainShort": "Boost + weak PA&Tech boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 必殺技・法術チップが攻撃対象の敵の弱点に\n　　 有効な属性の場合、威力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts PAs and Techs if their element matches\n    the targeted enemy's weakness element.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts the power of PAs and Techs by 30% if\n     their element matches the targeted enemy's\n     weakness element.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 31% if\n     their element matches the targeted enemy's\n     weakness element.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31873",
 		"jp_explainShort": "攻撃ダメージ増＋弱属技法威力増＋定期ＣＰ回復",
 		"tr_explainShort": "Boost + weak PA&Tech boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 必殺技・法術チップが攻撃対象の敵の弱点に\n　　 有効な属性の場合、威力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts PAs and Techs if their element matches\n    the targeted enemy's weakness element.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts the power of PAs and Techs by 32% if\n     their element matches the targeted enemy's\n     weakness element.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 33% if\n     their element matches the targeted enemy's\n     weakness element.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31874",
 		"jp_explainShort": "必殺技・法術威力超絶強化＋一定確率で回避",
 		"tr_explainShort": "PA & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 240%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 250%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 35% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31875",
 		"jp_explainShort": "必殺技・法術威力超絶強化＋一定確率で回避",
 		"tr_explainShort": "PA & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 260%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 270%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 45% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31876",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31877",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31878",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31879",
 		"jp_explainShort": "アビＬｖ光技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Light boost x ab. lv. + extension x # Light",
 		"jp_explainLong": "① 必殺技・法術チップが光属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Light PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Light Support Chips'\n    abilities based on the number of Light chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Light PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Light PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Light Support\n     Chips' abilities by 2 seconds x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31880",
 		"jp_explainShort": "アビＬｖ光技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Light boost x ab. lv. + extension x # Light",
 		"jp_explainLong": "① 必殺技・法術チップが光属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Light PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Light Support Chips'\n    abilities based on the number of Light chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Light PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Light PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Light Support\n     Chips' abilities by 2 seconds x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31883",
 		"jp_explainShort": "威力絶大増＋炎武器攻撃力大増＋炎属性上限上昇",
 		"tr_explainShort": "Pow. boost + Fire weapon boost + max Fire up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 攻撃力を大きく増加する。\n③ 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31884",
 		"jp_explainShort": "威力絶大増＋炎武器攻撃力大増＋炎属性上限上昇",
 		"tr_explainShort": "Pow. boost + Fire weapon boost + max Fire up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 攻撃力を大きく増加する。\n③ 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 150%.\n<color=yellow>SP: </color>Boosts power by 160%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31889",
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "Dam. effect boost x JA + actions quickened",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects for each successful\n    Just Attack.\n    <color=yellow>[Z-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31890",
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "Dam. effect boost x JA + actions quickened",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects for each successful\n    Just Attack.\n    <color=yellow>[Z-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31891",
 		"jp_explainShort": "雷属性ダメージ＋回避",
 		"tr_explainShort": "Lightning elem. boosted + chance to evade",
 		"jp_explainLong": "① 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Lightning elemental damage\n    against enemies weak to Lightning.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning elemental damage by 145%\n     against enemies weak to Lightning.\n<color=yellow>SP: </color>Boosts Lightning elemental damage by 150%\n     against enemies weak to Lightning.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31892",
 		"jp_explainShort": "雷属性ダメージ＋回避",
 		"tr_explainShort": "Lightning elem. boosted + chance to evade",
 		"jp_explainLong": "① 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Lightning elemental damage\n    against enemies weak to Lightning.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Lightning elemental damage by 155%\n     against enemies weak to Lightning.\n<color=yellow>SP: </color>Boosts Lightning elemental damage by 160%\n     against enemies weak to Lightning.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31893",
 		"jp_explainShort": "必殺技・法術の威力大強化＋加速",
 		"tr_explainShort": "PAs & Techs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技・法術の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31894",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋加速",
 		"tr_explainShort": "PAs & Techs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31895",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals dramatic additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%.\n③  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31896",
 		"jp_explainShort": "ＨＰ回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Deals dramatic additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 18%.\n③  Recovers CP by 12.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31897",
 		"jp_explainShort": "全地形で攻撃力超絶増加＋弱点属性強化",
 		"tr_explainShort": "Dam. boost in all areas + weak elements up",
 		"jp_explainLong": "① 全てのエリアの戦闘で攻撃力を超絶に増加する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage when fighting in\n    all areas.\n    <color=yellow>[I-Frame]</color>\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 240% when fighting in any\n     area.\n<color=yellow>SP: </color>Boosts damage by 250% when fighting in any\n     area.\n     <color=yellow>[I-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 20.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31898",
 		"jp_explainShort": "全地形で攻撃力超絶増加＋弱点属性強化",
 		"tr_explainShort": "Dam. boost in all areas + weak elements up",
 		"jp_explainLong": "① 全てのエリアの戦闘で攻撃力を超絶に増加する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts damage when fighting in\n    all areas.\n    <color=yellow>[I-Frame]</color>\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 260% when fighting in any\n     area.\n<color=yellow>SP: </color>Boosts damage by 270% when fighting in any\n     area.\n     <color=yellow>[I-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 20.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31905",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack power by 105% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 110% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31906",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack power by 115% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 120% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31910",
 		"jp_explainShort": "アビＬｖ氷技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Ice boost x ab. lv. + extension x # Ice",
 		"jp_explainLong": "① 必殺技・法術チップが氷属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Ice PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Ice Support Chips'\n    abilities based on the number of Ice chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Ice PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Ice Support\n     Chips' abilities by 2 seconds x the number of\n     Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31911",
 		"jp_explainShort": "アビＬｖ氷技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Ice boost x ab. lv. + extension x # Ice",
 		"jp_explainLong": "① 必殺技・法術チップが氷属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts Ice PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Ice Support Chips'\n    abilities based on the number of Ice chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Ice PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Ice PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Ice Support\n     Chips' abilities by 2 seconds x the number of\n     Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31912",
 		"jp_explainShort": "闇属性ダメージ＋ダメージ防御＋ポイズン付与",
 		"tr_explainShort": "Dark elem. boosted + barrier + counter-Poison",
 		"jp_explainLong": "① 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Dark elemental damage\n    against enemies weak to Dark.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Dark elemental damage by 150%\n     against enemies weak to Dark.\n<color=yellow>SP: </color>Boosts Dark elemental damage by 155%\n     against enemies weak to Dark.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31913",
 		"jp_explainShort": "闇属性ダメージ＋ダメージ防御＋ポイズン付与",
 		"tr_explainShort": "Dark elem. boosted + barrier + counter-Poison",
 		"jp_explainLong": "① 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Dark elemental damage\n    against enemies weak to Dark.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Dark elemental damage by 160%\n     against enemies weak to Dark.\n<color=yellow>SP: </color>Boosts Dark elemental damage by 165%\n     against enemies weak to Dark.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31914",
 		"jp_explainShort": "攻撃ダメージ増＋特定属性チップ装備攻撃力増",
 		"tr_explainShort": "Attack damage boost + weakness chip boost",
 		"jp_explainLong": "① 攻撃ダメージを劇的に増加する。\n② 敵の弱点に有効な属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n③ ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Immensely boosts damage when equipped with a\n    chip of an element the targeted enemy is weak to.\n    <color=yellow>[2A-Frame]</color>\n③ Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 65%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 140% when equipped with a\n     chip of an element the target is weak to.\n<color=yellow>SP: </color>Boosts damage by 145% when equipped with a\n     chip of an element the target is weak to.\n     <color=yellow>[2A-Frame]</color>\n③  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31915",
 		"jp_explainShort": "攻撃ダメージ増＋特定属性チップ装備攻撃力増",
 		"tr_explainShort": "Attack damage boost + weakness chip boost",
 		"jp_explainLong": "① 攻撃ダメージを劇的に増加する。\n② 敵の弱点に有効な属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n③ ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Immensely boosts damage when equipped with a\n    chip of an element the targeted enemy is weak to.\n    <color=yellow>[2A-Frame]</color>\n③ Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 65%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 150% when equipped with a\n     chip of an element the target is weak to.\n<color=yellow>SP: </color>Boosts damage by 155% when equipped with a\n     chip of an element the target is weak to.\n     <color=yellow>[2A-Frame]</color>\n③  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31916",
 		"jp_explainShort": "攻撃力増＋雷属性上限上昇＋定期的にＨＰ小回復",
 		"tr_explainShort": "Lightning chip boost + max up x # Lightning",
 		"jp_explainLong": "① 雷属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage when equipped with a\n    Lightning chip.\n    <color=yellow>[2A-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 145% when equipped with a\n     Lightning chip.\n<color=yellow>SP: </color>Boosts damage by 150% when equipped with a\n     Lightning chip.\n     <color=yellow>[2A-Frame]</color>\n②  Increases your maximum Lightning by 10 x the\n     number of Lightning chips equipped.\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31917",
 		"jp_explainShort": "攻撃力増＋雷属性上限上昇＋定期的にＨＰ小回復",
 		"tr_explainShort": "Lightning chip boost + max up x # Lightning",
 		"jp_explainLong": "① 雷属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage when equipped with a\n    Lightning chip.\n    <color=yellow>[2A-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 155% when equipped with a\n     Lightning chip.\n<color=yellow>SP: </color>Boosts damage by 160% when equipped with a\n     Lightning chip.\n     <color=yellow>[2A-Frame]</color>\n②  Increases your maximum Lightning by 10 x the\n     number of Lightning chips equipped.\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31918",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＨＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Ice/Wind/Light + HP regen",
 		"jp_explainLong": "① アビリティレベルと氷・風・光属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts elemental power based on this\n    chip's ability level and the total value of your Ice,\n    Wind and Light elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power by 5% + 8% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 9% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31919",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＨＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Ice/Wind/Light + HP regen",
 		"jp_explainLong": "① アビリティレベルと氷・風・光属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts elemental power based on this\n    chip's ability level and the total value of your Ice,\n    Wind and Light elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power by 5% + 10% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 11% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31920",
 		"jp_explainShort": "闇武器攻撃力絶大増加＋闇属性上限上昇",
 		"tr_explainShort": "Dark weapons boosted + max Dark up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Dark element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Dark Element by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31921",
 		"jp_explainShort": "闇武器攻撃力絶大増加＋闇属性上限上昇",
 		"tr_explainShort": "Dark weapons boosted + max Dark up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Dark element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Dark Element by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31924",
 		"jp_explainShort": "氷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＨＰ回復",
 		"tr_explainShort": "JAs boosted x # Ice + 3 JAs = HP recovery",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of Ice chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers HP every time you successfully\n    perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Just Attacks by 35% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 40% x the number of\n     Ice chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers HP by 5% every time you successfully\n     perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31925",
 		"jp_explainShort": "氷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＨＰ回復",
 		"tr_explainShort": "JAs boosted x # Ice + 3 JAs = HP recovery",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts Just Attacks based on the\n    number of Ice chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers HP every time you successfully\n    perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Just Attacks by 45% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 50% x the number of\n     Ice chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers HP by 5% every time you successfully\n     perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31926",
 		"jp_explainShort": "アビＬｖ技法大強化＋炎枚数炎属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Fire act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 大きく強化する。\n② 装備中の炎属性チップの枚数に応じて、炎属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 炎属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Fire Support Chips\n    based on the number of Fire chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Fire chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts PAs and Techs by 15% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 25% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Fire\n     Support Chips by 2% x the number of Fire\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31927",
 		"jp_explainShort": "アビＬｖ技法劇的強化＋炎枚数炎属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Fire act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 劇的に強化する。\n② 装備中の炎属性チップの枚数に応じて、炎属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 炎属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Fire Support Chips\n    based on the number of Fire chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Fire chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts PAs and Techs by 35% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 45% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Fire\n     Support Chips by 2% x the number of Fire\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31928",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Dam. boost vs weakness + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 145% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 150% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 10%.\n<color=yellow>SP: </color>Reduces CP consumption by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31929",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Dam. boost vs weakness + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 155% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 160% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 20%.\n<color=yellow>SP: </color>Reduces CP consumption by 25%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31930",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋バーン付与",
 		"tr_explainShort": "PA&Tech boost + barrier + counter-Burn",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「バーン」効果を与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts all PAs and Techs based on this chip's\n    ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts all PAs and Techs by 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 3% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     3% of your maximum HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31931",
 		"jp_explainShort": "アビＬｖ技法大増加＋ダメージ防御＋バーン付与",
 		"tr_explainShort": "PA&Tech boost + barrier + counter-Burn",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「バーン」効果を与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts all PAs and Techs by 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 5% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     3% of your maximum HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31932",
 		"jp_explainShort": "全クエストダメージ増＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost in all quests + Wind CP use down",
 		"jp_explainLong": "① 全てのクエストで敵に与えるダメージを\n　　 アビリティレベルに応じて増加する。\n② リンクスロットに装備したチップの属性が\n　　 風属性の場合、風属性チップの消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against enemies in all quests based\n    on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n② Decreases the CP consumption of Wind chips if\n    there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against enemies in all quests by\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against enemies in all quests by\n     3% x this chip's ability level.\n     <color=yellow>[X-Frame]</color>\n②  Decreases the CP consumption of Wind chips by\n     10% if there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31933",
 		"jp_explainShort": "全クエストダメージ増＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost in all quests + Wind CP use down",
 		"jp_explainLong": "① 全てのクエストで敵に与えるダメージを\n　　 アビリティレベルに応じて大きく増加する。\n② リンクスロットに装備したチップの属性が\n　　 風属性の場合、風属性チップの消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage against enemies in all\n    quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n② Decreases the CP consumption of Wind chips if\n    there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against enemies in all quests by\n     4% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against enemies in all quests by\n     5% x this chip's ability level.\n     <color=yellow>[X-Frame]</color>\n②  Decreases the CP consumption of Wind chips by\n     10% if there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31934",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. dam.",
 		"jp_explainLong": "① 敵に追加でダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 5%.\n<color=yellow>SP: </color>Recovers HP by 6%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 6.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
 	},
 	{
 		"assign": "31935",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. dam.",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 7%.\n<color=yellow>SP: </color>Recovers HP by 8%.\n③  Recovers CP by 7.\n<color=yellow>SP: </color>Recovers CP by 8.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
 	},
 	{
 		"assign": "31936",
 		"jp_explainShort": "炎武器攻撃力絶大増加＋炎属性上限上昇",
 		"tr_explainShort": "Fire weapons boosted + max Fire up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Fire value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31937",
 		"jp_explainShort": "炎武器攻撃力絶大増加＋炎属性上限上昇",
 		"tr_explainShort": "Fire weapons boosted + max Fire up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Fire value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31940",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 140% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31941",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 150% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 160% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n② Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31942",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 170% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 180% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n② Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31945",
 		"jp_explainShort": "風武器攻撃力絶大増加＋風属性上限上昇",
 		"tr_explainShort": "Wind weapons boosted + max Wind up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 攻撃力を絶大に増加する。\n② 風属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Wind value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 130% if using a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Wind value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31946",
 		"jp_explainShort": "風武器攻撃力絶大増加＋風属性上限上昇",
 		"tr_explainShort": "Wind weapons boosted + max Wind up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 攻撃力を絶大に増加する。\n② 風属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Wind value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 140% if using a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Wind value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31947",
 		"jp_explainShort": "属性種類数ダメージ増＋ダメージ防御＋防御効果",
 		"tr_explainShort": "Dam. boost x # elems + barrier + defenses",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 与えるダメージを極度に増加する。\n② 装備中チップの属性種類数に応じて\n　　 ダメージを防ぐ効果をＨＰに上乗せする。\n③ 装備中チップの属性種類数が\n　　 1以上の場合、敵から受けるダメージを軽減する。\n　　 2以上の場合、のけぞり無効となる効果を付与する。\n　　 3以上の場合、ダウン無効となる効果を付与する。\n　　 4以上の場合、自身を状態異常にならなくする。\n　　 5以上の場合、敵からの攻撃を一定確率で回避する。\n　　 6の場合、スライド操作時の無敵時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage dealt based on the\n    number of different chip elements equipped.\n    <color=yellow>[2B-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Depends on the number of chip elements equipped:\n    1 or more: Reduces damage taken from enemies.\n    2 or more: Grants flinching immunity.\n    3 or more: Grants knockdown immunity.\n    4 or more: Makes you immune to status effects.\n    5 or more: Grants a chance to evade damage.\n    6: Extends invincibility time of Slide Actions.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage dealt by 230% + 20% x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage dealt by 240% + 20% x the\n     number of different chip elements equipped.\n     <color=yellow>[2B-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% x the number of different chip\n     elements equipped.\n③  Depends on the number of chip elements equipped:\n     1 or more: Reduces damage taken by 30%.\n     2 or more: Grants flinching immunity.\n     3 or more: Grants knockdown immunity.\n     4 or more: Makes you immune to status effects.\n     5 or more: Grants a 50% evasion chance.\n     6: Extends dodge invincibility by 0.83 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31948",
 		"jp_explainShort": "属性種類数ダメージ増＋ダメージ防御＋防御効果",
 		"tr_explainShort": "Dam. boost x # elems + barrier + defenses",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 与えるダメージを極度に増加する。\n② 装備中チップの属性種類数に応じて\n　　 ダメージを防ぐ効果をＨＰに上乗せする。\n③ 装備中チップの属性種類数が\n　　 1以上の場合、敵から受けるダメージを軽減する。\n　　 2以上の場合、のけぞり無効となる効果を付与する。\n　　 3以上の場合、ダウン無効となる効果を付与する。\n　　 4以上の場合、自身を状態異常にならなくする。\n　　 5以上の場合、敵からの攻撃を一定確率で回避する。\n　　 6の場合、スライド操作時の無敵時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Maximally boosts damage dealt based on the\n    number of different chip elements equipped.\n    <color=yellow>[2B-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Depends on the number of chip elements equipped:\n    1 or more: Reduces damage taken from enemies.\n    2 or more: Grants flinching immunity.\n    3 or more: Grants knockdown immunity.\n    4 or more: Makes you immune to status effects.\n    5 or more: Grants a chance to evade damage.\n    6: Extends invincibility time of Slide Actions.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage dealt by 250% + 20% x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage dealt by 260% + 20% x the\n     number of different chip elements equipped.\n     <color=yellow>[2B-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% x the number of different chip\n     elements equipped.\n③  Depends on the number of chip elements equipped:\n     1 or more: Reduces damage taken by 30%.\n     2 or more: Grants flinching immunity.\n     3 or more: Grants knockdown immunity.\n     4 or more: Makes you immune to status effects.\n     5 or more: Grants a 50% evasion chance.\n     6: Extends dodge invincibility by 0.83 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31955",
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31956",
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31957",
 		"jp_explainShort": "攻撃力強化＋攻撃力増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "ATK up + low HP damage boost + one survival",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 自身のＨＰが５０％以下の場合に\n　　 攻撃力を大きく増加する。\n③ 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly boosts damage when your HP is below\n    50%.\n    <color=yellow>[O-Frame]</color>\n③ Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 12000.\n<color=yellow>SP: </color>Increases your ATK by 13000.\n②  Boosts damage by 50% when your HP is below\n     50%.\n     <color=yellow>[O-Frame]</color>\n③  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31958",
 		"jp_explainShort": "攻撃力強化＋攻撃力増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "ATK up + low HP damage boost + one survival",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 自身のＨＰが５０％以下の場合に\n　　 攻撃力を大きく増加する。\n③ 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly boosts damage when your HP is below\n    50%.\n    <color=yellow>[O-Frame]</color>\n③ Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 14000.\n<color=yellow>SP: </color>Increases your ATK by 15000.\n②  Boosts damage by 50% when your HP is below\n     50%.\n     <color=yellow>[O-Frame]</color>\n③  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31959",
 		"jp_explainShort": "技・法威力大強化＋氷弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + dam. boost vs Ice weak",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Boosts PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31960",
 		"jp_explainShort": "技・法威力大強化＋氷弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + dam. boost vs Ice weak",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 85% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Boosts PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31961",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が超絶強化",
 		"tr_explainShort": "Damage taken reduced + ATK increased",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 11000.\n<color=yellow>SP: </color>Increases your ATK by 13000.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31962",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が超絶強化",
 		"tr_explainShort": "Damage taken reduced + ATK increased",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 14000.\n<color=yellow>SP: </color>Increases your ATK by 16000.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31969",
 		"jp_explainShort": "アビＬｖ技法大強化＋氷枚数氷属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Ice act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 大きく強化する。\n② 装備中の氷属性チップの枚数に応じて、氷属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 氷属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Ice Support chips\n    based on the number of Ice chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Ice chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts PAs and Techs by 15% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 25% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Ice\n     Support Chips by 2% x the number of Ice\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31970",
 		"jp_explainShort": "アビＬｖ技法劇的強化＋氷枚数氷属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Ice act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 劇的に強化する。\n② 装備中の氷属性チップの枚数に応じて、氷属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 氷属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Ice Support chips\n    based on the number of Ice chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Ice chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts PAs and Techs by 35% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 45% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Ice\n     Support Chips by 2% x the number of Ice\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31971",
 		"jp_explainShort": "攻撃ダメージ増＋光属武器攻撃力増＋定期ＨＰ回復",
 		"tr_explainShort": "Attk. boost + Light wep. boost + HP over time",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 30% if using a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 31% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31972",
 		"jp_explainShort": "攻撃ダメージ増＋光属武器攻撃力増＋定期ＨＰ回復",
 		"tr_explainShort": "Attk. boost + Light wep. boost + HP over time",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 32% if using a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 33% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31975",
 		"jp_explainShort": "光枚数属性攻撃力を絶大増加＋光枚数消費ＣＰ減少",
 		"tr_explainShort": "Elem. pow. boost & CP cost down x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 属性攻撃力を絶大に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts elemental power based on the\n    number of Light chips equipped.\n    <color=yellow>[R-Frame]</color>\n② Reduces CP consumption based on the number of\n    Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power  by 135% + 10% x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Boosts elemental power  by 145% + 10% x the\n     number of Light chips equipped.\n     <color=yellow>[R-Frame]</color>\n②  Reduces CP consumption by 5% x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31976",
 		"jp_explainShort": "光枚数属性攻撃力を超絶増加＋光枚数消費ＣＰ減少",
 		"tr_explainShort": "Elem. pow. boost & CP cost down x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 属性攻撃力を超絶に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of Light chips equipped.\n    <color=yellow>[R-Frame]</color>\n② Reduces CP consumption based on the number of\n    Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts elemental power  by 155% + 10% x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Boosts elemental power  by 165% + 10% x the\n     number of Light chips equipped.\n     <color=yellow>[R-Frame]</color>\n②  Reduces CP consumption by 5% x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31982",
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31983",
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31984",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増＋雷属性上限上昇",
 		"tr_explainShort": "Dam. boost x PA/Tech uses + max Ltn up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 56% each time you use a PA\n     or Tech.\n     (Maximum boost: 280%)\n<color=yellow>SP: </color>Boosts damage by 58% each time you use a PA\n     or Tech.\n     (Maximum boost: 290%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum Lightning by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31985",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増＋雷属性上限上昇",
 		"tr_explainShort": "Dam. boost x PA/Tech uses + max Ltn up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：極度）\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Greatly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Maximal)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 60% each time you use a PA\n     or Tech.\n     (Maximum boost: 300%)\n<color=yellow>SP: </color>Boosts damage by 62% each time you use a PA\n     or Tech.\n     (Maximum boost: 310%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum Lightning by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31986",
 		"jp_explainShort": "炎氷雷の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fire/Ice/Lightning PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・雷属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Ice and Lightning PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Lightning PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Lightning PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31987",
 		"jp_explainShort": "炎氷雷の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fire/Ice/Lightning PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・雷属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts Fire, Ice and Lightning PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts Fire, Ice and Lightning PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Lightning PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31988",
 		"jp_explainShort": "追加大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dealing additional damage + quickened",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31989",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dealing additional damage + quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31990",
 		"jp_explainShort": "威力絶大増＋氷武器攻撃力小増＋氷属性上限上昇",
 		"tr_explainShort": "Power boost + Ice weapon boost + max Ice up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 攻撃力をわずかに増加する。\n③ 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 140%.\n<color=yellow>SP: </color>Boosts power by 1505%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 25% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31991",
 		"jp_explainShort": "威力絶大増＋氷武器攻撃力小増＋氷属性上限上昇",
 		"tr_explainShort": "Power boost + Ice weapon boost + max Ice up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 攻撃力をわずかに増加する。\n③ 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 170%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 25% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "2210",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 670.\n<color=yellow>SP: </color>Increases your ATK by 690.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "2220",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 720.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "2310",
 		"jp_explainShort": "ＨＰが回復する",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers HP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 17%.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "2320",
 		"jp_explainShort": "ＨＰが回復する",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers HP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers HP by 18%.\n<color=yellow>SP: </color>Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "80110",
 		"jp_explainShort": "一定以下になった際、ＨＰ・ＣＰが大回復",
 		"tr_explainShort": "HP and CP recovery at low HP",
 		"jp_explainLong": "① ＨＰを大きく回復する。\n② ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時",
-		"tr_explainLong": "① Greatly recovers HP.\n② Greatly recovers CP.\n[Activation Trigger] Damaged to a certain HP level"
+		"tr_explainLong": "①  Recovers HP by 70%.\n<color=yellow>SP: </color>Recovers HP by 75%.\n②  Recovers CP by 70.\n<color=yellow>SP: </color>Recovers CP by 75.\n[Activation Trigger] Damaged to below 50% HP\n[Cooldown] 15 seconds"
 	},
 	{
 		"assign": "80120",
 		"jp_explainShort": "一定以下になった際、ＨＰ・ＣＰが劇的回復",
 		"tr_explainShort": "HP and CP recovery at low HP",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n② ＣＰを劇的に回復する。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時",
-		"tr_explainLong": "① Dramatically recovers HP.\n② Dramatically recovers CP.\n[Activation Trigger] Damaged to a certain HP level"
+		"tr_explainLong": "①  Recovers HP by 80%.\n<color=yellow>SP: </color>Recovers HP by 85%.\n②  Recovers CP by 80.\n<color=yellow>SP: </color>Recovers CP by 85.\n[Activation Trigger] Damaged to below 50% HP\n[Cooldown] 15 seconds"
 	},
 	{
 		"assign": "80310",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 670.\n<color=yellow>SP: </color>Increases your ATK by 690.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "80320",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 720.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "80610",
 		"jp_explainShort": "龍族に対してダメージが大増加",
 		"tr_explainShort": "Damage boosted against Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 45%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 55%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "80620",
 		"jp_explainShort": "龍族に対してダメージが劇的増加",
 		"tr_explainShort": "Damage boosted against Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Dragonkin by 65%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 75%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "81310",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 7.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 2 seconds"
 	},
 	{
 		"assign": "81320",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 12.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 2 seconds"
 	},
 	{
 		"assign": "81410",
 		"jp_explainShort": "敵から受けるダメージが大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]必殺技チップ発動時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Short"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 50%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 55%.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 5 seconds"
 	},
 	{
 		"assign": "81420",
 		"jp_explainShort": "敵から受けるダメージが大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]必殺技チップ発動時\n[効果時間]短い時間",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Short"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 60%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 65%.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 5 seconds"
 	},
 	{
 		"assign": "81510",
 		"jp_explainShort": "ＣＰが大回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でダウンした時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Knocked down by an enemy"
+		"tr_explainLong": "①  Recovers CP by 40.\n<color=yellow>SP: </color>Recovers CP by 50.\n[Activation Trigger] Knocked down by an enemy"
 	},
 	{
 		"assign": "81520",
 		"jp_explainShort": "ＣＰが大回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でダウンした時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Knocked down by an enemy"
+		"tr_explainLong": "①  Recovers CP by 50.\n<color=yellow>SP: </color>Recovers CP by 60.\n[Activation Trigger] Knocked down by an enemy"
 	},
 	{
 		"assign": "40001",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40002",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40003",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40004",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40005",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40006",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40007",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40008",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40009",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40010",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40011",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40012",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40013",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40014",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40015",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40016",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40017",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40018",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40019",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40020",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40021",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40022",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40023",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40024",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40025",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40026",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40027",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40028",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40029",
 		"jp_explainShort": "定期的にＨＰが小回復＋炎の法術が強化",
 		"tr_explainShort": "HP over time + Fire Techs boosted",
 		"jp_explainLong": "① 炎属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Fire Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Fire Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Fire Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40030",
 		"jp_explainShort": "定期的にＨＰが小回復＋炎の法術が大強化",
 		"tr_explainShort": "HP over time + Fire Techs boosted",
 		"jp_explainLong": "① 炎属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Fire Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Fire Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Fire Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40031",
 		"jp_explainShort": "定期的にＨＰが小回復＋氷の法術が強化",
 		"tr_explainShort": "HP over time + Ice Techs boosted",
 		"jp_explainLong": "① 氷属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Ice Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Ice Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Ice Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40032",
 		"jp_explainShort": "定期的にＨＰが小回復＋氷の法術が大強化",
 		"tr_explainShort": "HP over time + Ice Techs boosted",
 		"jp_explainLong": "① 氷属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Ice Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Ice Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Ice Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40033",
 		"jp_explainShort": "定期的にＨＰが小回復＋風の法術が強化",
 		"tr_explainShort": "HP over time + Wind Techs boosted",
 		"jp_explainLong": "① 風属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wind Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40034",
 		"jp_explainShort": "定期的にＨＰが小回復＋風の法術が大強化",
 		"tr_explainShort": "HP over time + Wind Techs boosted",
 		"jp_explainLong": "① 風属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wind Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40035",
 		"jp_explainShort": "定期的にＨＰが小回復＋雷の法術が強化",
 		"tr_explainShort": "HP over time + Lightning Techs boosted",
 		"jp_explainLong": "① 雷属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Lightning Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Lightning Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Lightning Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40036",
 		"jp_explainShort": "定期的にＨＰが小回復＋雷の法術が大強化",
 		"tr_explainShort": "HP over time + Lightning Techs boosted",
 		"jp_explainLong": "① 雷属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Lightning Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Lightning Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Lightning Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40037",
 		"jp_explainShort": "定期的にＨＰが小回復＋光の法術が強化",
 		"tr_explainShort": "HP over time + Light Techs boosted",
 		"jp_explainLong": "① 光属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Light Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Light Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40038",
 		"jp_explainShort": "定期的にＨＰが小回復＋光の法術が大強化",
 		"tr_explainShort": "HP over time + Light Techs boosted",
 		"jp_explainLong": "① 光属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Light Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Light Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40039",
 		"jp_explainShort": "定期的にＨＰが小回復＋闇の法術が強化",
 		"tr_explainShort": "HP over time + Dark Techs boosted",
 		"jp_explainLong": "① 闇属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dark Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dark Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40040",
 		"jp_explainShort": "定期的にＨＰが小回復＋闇の法術が大強化",
 		"tr_explainShort": "HP over time + Dark Techs boosted",
 		"jp_explainLong": "① 闇属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dark Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dark Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40041",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40042",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40043",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40044",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40045",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40046",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40047",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40048",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40049",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40050",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40051",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40052",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40053",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40054",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40055",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40056",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40057",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40058",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40059",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40060",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40061",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40062",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40063",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40064",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40065",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40066",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40067",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40068",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40069",
@@ -6003,1022 +6003,1022 @@
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Sword.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Sword.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40082",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Sword.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Sword.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40083",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 自在槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Wired Lances.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Wired Lances.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40084",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 自在槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Wired Lances.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Wired Lances.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40085",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Partizan.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40086",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Partizan.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40087",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双小剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Daggers.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Twin Daggers.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40088",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双小剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Daggers.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Twin Daggers.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40089",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 両剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Double Saber.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Double Saber.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40090",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 両剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Double Saber.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Double Saber.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40091",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 鋼拳装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Knuckles.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Knuckles.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40092",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 鋼拳装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Knuckles.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Knuckles.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40093",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 銃剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Gunslash.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Gunslash.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40094",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 銃剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Gunslash.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Gunslash.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40095",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    an Assault Rifle.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     an Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     an Assault Rifle.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40096",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    an Assault Rifle.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     an Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     an Assault Rifle.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40097",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大砲装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Launcher.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Launcher.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40098",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大砲装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Launcher.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Launcher.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40099",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双機銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Machineguns.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Twin Machineguns.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40100",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双機銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Machineguns.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Twin Machineguns.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40101",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Rod.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Rod.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40102",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Rod.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Rod.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40103",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 導具装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Talis.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Talis.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40104",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 導具装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Talis.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Talis.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40105",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 短杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Wand.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Wand.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40106",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 短杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Wand.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Wand.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40107",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 抜剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Katana.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40108",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 抜剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Katana.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40109",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 強弓装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Bullet Bow.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Bullet Bow.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40110",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 強弓装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Bullet Bow.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Bullet Bow.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40111",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 魔装脚装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップもしくは法術チップ使用時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Jet Boots.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Jet Boots.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40112",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 魔装脚装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップもしくは法術チップ使用時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Jet Boots.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Jet Boots.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40113",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 飛翔剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Dual Blades.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40114",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 飛翔剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Dual Blades.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "40115",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40116",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40117",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40118",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40119",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40120",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40121",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40122",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40123",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40124",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40125",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40126",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40127",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40128",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40129",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40130",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40131",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40132",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40133",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40134",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40135",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40136",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40137",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40138",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40139",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40140",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40141",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40142",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40143",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40144",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40145",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40146",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40147",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40148",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40149",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40150",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40151",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40152",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40153",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40154",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40155",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40156",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40157",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40158",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40159",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40160",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40161",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40162",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40163",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40164",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40165",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40166",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40167",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40168",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40169",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40170",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40171",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40172",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40173",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40174",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40175",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40176",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40177",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40178",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40179",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40180",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40181",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40182",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40183",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40184",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40185",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40186",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40187",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40188",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40189",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40190",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40191",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40192",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40193",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40194",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40195",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40196",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40197",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40198",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40199",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40200",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40201",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40202",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40203",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40204",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40205",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40206",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40207",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40208",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40209",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40210",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40211",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40212",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40213",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40214",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40215",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40216",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40217",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40218",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40219",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40220",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40221",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40222",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40223",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40224",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40225",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40226",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40227",
@@ -7039,28 +7039,28 @@
 		"jp_explainShort": "氷属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Sword boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40230",
 		"jp_explainShort": "氷属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Sword boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40231",
 		"jp_explainShort": "雷属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Sword boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40232",
 		"jp_explainShort": "雷属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Sword boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40233",
@@ -7081,14 +7081,14 @@
 		"jp_explainShort": "光属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Sword boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40236",
 		"jp_explainShort": "光属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Sword boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40237",
@@ -7123,14 +7123,14 @@
 		"jp_explainShort": "氷属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & W. Lance boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40242",
 		"jp_explainShort": "氷属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & W. Lance boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40243",
@@ -7151,14 +7151,14 @@
 		"jp_explainShort": "風属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & W. Lance boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40246",
 		"jp_explainShort": "風属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & W. Lance boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40247",
@@ -7179,28 +7179,28 @@
 		"jp_explainShort": "闇属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & W. Lance boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40250",
 		"jp_explainShort": "闇属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & W. Lance boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40251",
 		"jp_explainShort": "炎属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Partizan boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40252",
 		"jp_explainShort": "炎属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Partizan boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40253",
@@ -7235,28 +7235,28 @@
 		"jp_explainShort": "風属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Partizan boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40258",
 		"jp_explainShort": "風属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Partizan boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40259",
 		"jp_explainShort": "光属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Partizan boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40260",
 		"jp_explainShort": "光属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Partizan boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40261",
@@ -7319,56 +7319,56 @@
 		"jp_explainShort": "風属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40270",
 		"jp_explainShort": "風属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40271",
 		"jp_explainShort": "光属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40272",
 		"jp_explainShort": "光属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40273",
 		"jp_explainShort": "闇属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40274",
 		"jp_explainShort": "闇属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40275",
 		"jp_explainShort": "炎属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & D. Saber boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40276",
 		"jp_explainShort": "炎属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & D. Saber boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40277",
@@ -7417,42 +7417,42 @@
 		"jp_explainShort": "光属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & D. Saber boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40284",
 		"jp_explainShort": "光属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & D. Saber boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40285",
 		"jp_explainShort": "闇属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & D. Saber boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40286",
 		"jp_explainShort": "闇属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & D. Saber boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40287",
 		"jp_explainShort": "炎属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Knuckles boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40288",
 		"jp_explainShort": "炎属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Knuckles boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40289",
@@ -7473,14 +7473,14 @@
 		"jp_explainShort": "雷属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Knuckles boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40292",
 		"jp_explainShort": "雷属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Knuckles boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40293",
@@ -7515,42 +7515,42 @@
 		"jp_explainShort": "闇属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Knuckles boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40298",
 		"jp_explainShort": "闇属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Knuckles boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40299",
 		"jp_explainShort": "炎属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Gunslash boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40300",
 		"jp_explainShort": "炎属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Gunslash boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40301",
 		"jp_explainShort": "氷属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Gunslash boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40302",
 		"jp_explainShort": "氷属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Gunslash boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40303",
@@ -7571,14 +7571,14 @@
 		"jp_explainShort": "風属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Gunslash boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40306",
 		"jp_explainShort": "風属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Gunslash boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40307",
@@ -7613,14 +7613,14 @@
 		"jp_explainShort": "炎属性時小増＋抜剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Katana boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 抜剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40312",
 		"jp_explainShort": "炎属性時増＋抜剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Katana boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 抜剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40313",
@@ -7641,14 +7641,14 @@
 		"jp_explainShort": "雷属性時小増＋抜剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Katana boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 抜剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40316",
 		"jp_explainShort": "雷属性時増＋抜剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Katana boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 抜剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40317",
@@ -7711,14 +7711,14 @@
 		"jp_explainShort": "氷属性時小増＋飛翔剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 飛翔剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40326",
 		"jp_explainShort": "氷属性時増＋飛翔剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 飛翔剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40327",
@@ -7739,14 +7739,14 @@
 		"jp_explainShort": "風属性時小増＋飛翔剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 飛翔剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40330",
 		"jp_explainShort": "風属性時増＋飛翔剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 飛翔剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40331",
@@ -7781,14 +7781,14 @@
 		"jp_explainShort": "炎属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rifle boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40336",
 		"jp_explainShort": "炎属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rifle boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40337",
@@ -7823,14 +7823,14 @@
 		"jp_explainShort": "風属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Rifle boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40342",
 		"jp_explainShort": "風属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Rifle boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40343",
@@ -7851,14 +7851,14 @@
 		"jp_explainShort": "闇属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rifle boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40346",
 		"jp_explainShort": "闇属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rifle boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40347",
@@ -7879,42 +7879,42 @@
 		"jp_explainShort": "氷属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Launcher boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40350",
 		"jp_explainShort": "氷属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Launcher boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40351",
 		"jp_explainShort": "雷属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Launcher boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40352",
 		"jp_explainShort": "雷属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Launcher boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40353",
 		"jp_explainShort": "風属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Launcher boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40354",
 		"jp_explainShort": "風属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Launcher boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40355",
@@ -7949,28 +7949,28 @@
 		"jp_explainShort": "炎属性時小増＋双機銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & TMG boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 双機銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40360",
 		"jp_explainShort": "炎属性時増＋双機銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & TMG boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 双機銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40361",
 		"jp_explainShort": "氷属性時小増＋双機銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 双機銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40362",
 		"jp_explainShort": "氷属性時増＋双機銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 双機銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40363",
@@ -8061,14 +8061,14 @@
 		"jp_explainShort": "雷属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40376",
 		"jp_explainShort": "雷属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40377",
@@ -8089,28 +8089,28 @@
 		"jp_explainShort": "光属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40380",
 		"jp_explainShort": "光属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40381",
 		"jp_explainShort": "闇属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40382",
 		"jp_explainShort": "闇属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40383",
@@ -8145,14 +8145,14 @@
 		"jp_explainShort": "雷属性時小増＋魔装脚時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & J. Boots boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 魔装脚の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40388",
 		"jp_explainShort": "雷属性時増＋魔装脚時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & J. Boots boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 魔装脚の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40389",
@@ -8173,14 +8173,14 @@
 		"jp_explainShort": "光属性時小増＋魔装脚時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Jet Boots boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 魔装脚の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40392",
 		"jp_explainShort": "光属性時増＋魔装脚時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Jet Boots boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 魔装脚の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40393",
@@ -8201,28 +8201,28 @@
 		"jp_explainShort": "炎属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rod boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40396",
 		"jp_explainShort": "炎属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rod boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40397",
 		"jp_explainShort": "氷属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Rod boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40398",
 		"jp_explainShort": "氷属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Rod boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40399",
@@ -8271,14 +8271,14 @@
 		"jp_explainShort": "闇属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rod boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40406",
 		"jp_explainShort": "闇属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rod boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40407",
@@ -8299,14 +8299,14 @@
 		"jp_explainShort": "氷属性時小増＋導具時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Talis boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 導具の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40410",
 		"jp_explainShort": "氷属性時増＋導具時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Talis boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 導具の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40411",
@@ -8341,14 +8341,14 @@
 		"jp_explainShort": "光属性時小増＋導具時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Talis boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 導具の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40416",
 		"jp_explainShort": "光属性時増＋導具時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Talis boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 導具の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40417",
@@ -8397,28 +8397,28 @@
 		"jp_explainShort": "雷属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Wand boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40424",
 		"jp_explainShort": "雷属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Wand boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40425",
 		"jp_explainShort": "風属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Wand boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40426",
 		"jp_explainShort": "風属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Wand boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40427",
@@ -8439,182 +8439,182 @@
 		"jp_explainShort": "闇属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Wand boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "40430",
 		"jp_explainShort": "闇属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Wand boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "21310",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 10.\n<color=yellow>SP: </color>Increases your Fire Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "21410",
 		"jp_explainShort": "炎属性が強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Fire Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "21510",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 10.\n<color=yellow>SP: </color>Increases your Ice Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "21610",
 		"jp_explainShort": "氷属性が強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Ice Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 20.\n<color=yellow>SP: </color>Increases your Ice Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "21710",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 10.\n<color=yellow>SP: </color>Increases your Lightning Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "21810",
 		"jp_explainShort": "雷属性が強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Lightning Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 20.\n<color=yellow>SP: </color>Increases your Lightning Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "21910",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 10.\n<color=yellow>SP: </color>Increases your Wind Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "22010",
 		"jp_explainShort": "風属性が強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Wind Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 20.\n<color=yellow>SP: </color>Increases your Wind Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "22110",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 10.\n<color=yellow>SP: </color>Increases your Light Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "22210",
 		"jp_explainShort": "光属性が強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Light Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 20.\n<color=yellow>SP: </color>Increases your Light Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "22310",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 10.\n<color=yellow>SP: </color>Increases your Dark Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "22410",
 		"jp_explainShort": "闇属性が強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "① Increases Dark Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 20.\n<color=yellow>SP: </color>Increases your Dark Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "3410",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 45.\n<color=yellow>SP: </color>Increases your ATK by 50.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "3420",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your ATK by 60.\n<color=yellow>SP: </color>Increases your ATK by 72.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "3510",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 2.\n<color=yellow>SP: </color>Increases your Dark Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "3520",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 4.\n<color=yellow>SP: </color>Increases your Dark Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "3610",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 4.\n<color=yellow>SP: </color>Increases your Dark Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "3620",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Dark Element by 7.\n<color=yellow>SP: </color>Increases your Dark Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "3710",
 		"jp_explainShort": "一定確率で「ポイズン」状態にする",
 		"tr_explainShort": "[Poison] imbued",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "3720",
 		"jp_explainShort": "一定確率で「ポイズン」状態にする",
 		"tr_explainShort": "[Poison] imbued",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4210",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 72.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "4220",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
+		"tr_explainLong": "①  Increases your DEF by 78.\n<color=yellow>SP: </color>Increases your DEF by 93.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "4410",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 7% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4420",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 12% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4610",
@@ -8635,210 +8635,210 @@
 		"jp_explainShort": "闇属性が強化＋攻撃力が小強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Increases Dark Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 100.\n<color=yellow>SP: </color>Increases your ATK by 110.\n②  Increases your Dark Element by 30.\n<color=yellow>SP: </color>Increases your Dark Element by 35.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "4720",
 		"jp_explainShort": "闇属性が強化＋攻撃力が小強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Increases Dark Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 120.\n<color=yellow>SP: </color>Increases your ATK by 130.\n②  Increases your Dark Element by 40.\n<color=yellow>SP: </color>Increases your Dark Element by 45.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20001",
 		"jp_explainShort": "攻撃力と防御力が小強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 防御力をわずかに強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Slightly increases DEF.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 240.\n②  Increases your DEF by 200.\n<color=yellow>SP: </color>Increases your DEF by 240.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20002",
 		"jp_explainShort": "攻撃力と防御力が小強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 防御力をわずかに強化する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Slightly increases DEF.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 250.\n<color=yellow>SP: </color>Increases your ATK by 300.\n②  Increases your DEF by 250.\n<color=yellow>SP: </color>Increases your DEF by 300.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "5210",
 		"jp_explainShort": "ダーカーから受けるダメージが軽減",
 		"tr_explainShort": "Damage from Darkers reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]ダーカーからダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Darkers"
+		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Darkers\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "5220",
 		"jp_explainShort": "ダーカーから受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Darkers reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]ダーカーからダメージを受けた時",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Darkers"
+		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Darkers\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "20013",
 		"jp_explainShort": "攻撃力小増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 12%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 10% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20014",
 		"jp_explainShort": "攻撃力小増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 10% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20015",
 		"jp_explainShort": "攻撃力小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]バトル開始時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Start of battle\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 5%.\n<color=yellow>SP: </color>Boosts damage by 6%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% damage dealt as HP.\n     (Maximum recovery: 1% of your max HP).\n[Activation Trigger] Start of battle\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20016",
 		"jp_explainShort": "攻撃力小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]バトル開始時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Start of battle\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 8%.\n<color=yellow>SP: </color>Boosts damage by 10%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% damage dealt as HP.\n     (Maximum recovery: 1% of your max HP).\n[Activation Trigger] Start of battle\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20041",
 		"jp_explainShort": "攻撃力小増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boosted + CP consumption down",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 5%.\n<color=yellow>SP: </color>Boosts damage by 8%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 5%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20042",
 		"jp_explainShort": "攻撃力小増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boosted + CP consumption down",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 11%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 5%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20047",
 		"jp_explainShort": "攻撃力小増加＋追加小ダメージ＋加速",
 		"tr_explainShort": "Dam. boost + add. dam. + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20048",
 		"jp_explainShort": "攻撃力小増加＋追加小ダメージ＋加速",
 		"tr_explainShort": "Dam. boost + add. dam. + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "5610",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 2.\n<color=yellow>SP: </color>Increases your Wind Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "5620",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 4.\n<color=yellow>SP: </color>Increases your Wind Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "5710",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 4.\n<color=yellow>SP: </color>Increases your Wind Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "5720",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Wind Element by 7.\n<color=yellow>SP: </color>Increases your Wind Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "5810",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "5820",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 50.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "5910",
 		"jp_explainShort": "敵からのダメージが軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 25%.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "5920",
 		"jp_explainShort": "敵からのダメージが軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "①  Reduces damage taken from enemies by 30%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 35%.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "6210",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 2.\n<color=yellow>SP: </color>Increases your Ice Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "6220",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 4.\n<color=yellow>SP: </color>Increases your Ice Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "6310",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 4.\n<color=yellow>SP: </color>Increases your Ice Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "6320",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Ice Element by 7.\n<color=yellow>SP: </color>Increases your Ice Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "6510",
 		"jp_explainShort": "追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "6520",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "6910",
 		"jp_explainShort": "原生種から受けるダメージが軽減",
 		"tr_explainShort": "Damage from Natives reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]原生種からダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Natives"
+		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Natives\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "6920",
 		"jp_explainShort": "原生種から受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Natives reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]原生種からダメージを受けた時",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Natives"
+		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Natives\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "7610",
@@ -8859,433 +8859,433 @@
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "7720",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your DEF by 80.\n<color=yellow>SP: </color>Increases your DEF by 100.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "7810",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "7820",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 45.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "7910",
 		"jp_explainShort": "ＣＰが小回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "7920",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "8010",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 4.\n<color=yellow>SP: </color>Increases your Fire Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "8020",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 7.\n<color=yellow>SP: </color>Increases your Fire Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "8110",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 2.\n<color=yellow>SP: </color>Increases your Fire Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "8120",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Fire Element by 4.\n<color=yellow>SP: </color>Increases your Fire Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "8210",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "8220",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your DEF by 80.\n<color=yellow>SP: </color>Increases your DEF by 100.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "8310",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "8320",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 45.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "8410",
 		"jp_explainShort": "ＣＰが小回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "8420",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "①  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "8510",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 4.\n<color=yellow>SP: </color>Increases your Light Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "8520",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 7.\n<color=yellow>SP: </color>Increases your Light Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "8610",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 2.\n<color=yellow>SP: </color>Increases your Light Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "8620",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Light Element by 4.\n<color=yellow>SP: </color>Increases your Light Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "8810",
 		"jp_explainShort": "龍族から受けるダメージが軽減",
 		"tr_explainShort": "Reduces damage from Dragonkin",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]龍族からダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Dragonkin"
+		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Dragonkin\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "8820",
 		"jp_explainShort": "龍族から受けるダメージが大軽減",
 		"tr_explainShort": "Reduces damage from Dragonkin",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]龍族からダメージを受けた時",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Dragonkin"
+		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Dragonkin\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "9010",
 		"jp_explainShort": "一定確率で「パニック」状態にする",
 		"tr_explainShort": "[Panic] imbued",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "9020",
 		"jp_explainShort": "一定確率で「パニック」状態にする",
 		"tr_explainShort": "[Panic] imbued",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "20023",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost + barrier",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 12%.\n<color=yellow>SP: </color>Boosts damage by 18%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     35% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "20024",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost + barrier",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
+		"tr_explainLong": "①  Boosts damage by 24%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     45% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20029",
 		"jp_explainShort": "攻撃力が小強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 250.\n<color=yellow>SP: </color>Increases your ATK by 300.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20030",
 		"jp_explainShort": "攻撃力が強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 350.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20031",
 		"jp_explainShort": "光属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Light Element up + actions quickened",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Light Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Light Element by 60.\n<color=yellow>SP: </color>Increases your Light Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20032",
 		"jp_explainShort": "光属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Light Element up + actions quickened",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Light Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "9510",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 2.\n<color=yellow>SP: </color>Increases your Lightning Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "9520",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 4.\n<color=yellow>SP: </color>Increases your Lightning Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "9610",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 4.\n<color=yellow>SP: </color>Increases your Lightning Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
 	},
 	{
 		"assign": "9620",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your Lightning Element by 7.\n<color=yellow>SP: </color>Increases your Lightning Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
 	},
 	{
 		"assign": "9710",
 		"jp_explainShort": "機甲種から受けるダメージが軽減",
 		"tr_explainShort": "Damage from Mechs reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]機甲種からダメージを受けた時",
-		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Mechs"
+		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Mechs\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "9720",
 		"jp_explainShort": "機甲種から受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Mechs reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]機甲種からダメージを受けた時",
-		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Mechs"
+		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Mechs\n[Cooldown] 5 seconds"
 	},
 	{
 		"assign": "20033",
 		"jp_explainShort": "攻撃３回毎に攻撃力小強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Great)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
+		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 15% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 20% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20034",
 		"jp_explainShort": "攻撃３回毎に攻撃力小強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Great)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20039",
 		"jp_explainShort": "攻撃力小増加＋ダメージ大軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + down + knockback immune",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20040",
 		"jp_explainShort": "攻撃力小増加＋ダメージ大軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + down + knockback immune",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "25310",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② チップ強化の素材に使うと効果大。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 50.\n②  A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "25410",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② チップ強化の素材に使うと効果大。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly increases ATK.\n② A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your ATK by 60.\n<color=yellow>SP: </color>Increases your ATK by 70.\n②  A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20003",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your ATK by 75% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 85% against enemy\n     elemental weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20004",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts your ATK by 100% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 120% against enemy\n     elemental weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20021",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
+		"tr_explainLong": "①  Recovers CP by 50.\n<color=yellow>SP: </color>Recovers CP by 60.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "20022",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
+		"tr_explainLong": "①  Recovers CP by 70.\n<color=yellow>SP: </color>Recovers CP by 80.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "20045",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Short"
+		"tr_explainLong": "①  Boosts damage by 1%.\n<color=yellow>SP: </color>Boosts damage by 3%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 1% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Taking an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20046",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 6%.\n<color=yellow>SP: </color>Boosts damage by 10%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 1% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20051",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 5% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage\n     up to 10% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20052",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage\n     up to 15% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Taking an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20055",
 		"jp_explainShort": "必殺技・法術威力強化＋一定確率で回避",
 		"tr_explainShort": "PAs & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 30%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 35%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 15% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 20% chance to avoid damage from\n     enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20056",
 		"jp_explainShort": "必殺技・法術威力大強化＋一定確率で回避",
 		"tr_explainShort": "PAs & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を大きく強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 25% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 30% chance to avoid damage from\n     enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20057",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 海岸か海底での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    the Coast or the Seabed.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% when fighting in\n     the Coast or the Seabed.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20058",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 海岸か海底での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    the Coast or the Seabed.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% when fighting in\n     the Coast or the Seabed.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "20061",
 		"jp_explainShort": "闇属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dark Element up + actions quickened",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Dark Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20062",
 		"jp_explainShort": "闇属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dark Element up + actions quickened",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "① Greatly increases Dark Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20063",
 		"jp_explainShort": "攻撃力小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted + damage reduced",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20064",
 		"jp_explainShort": "攻撃力小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted + damage reduced",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20067",
 		"jp_explainShort": "黒の民にダメージ小増加＋闇属性強化",
 		"tr_explainShort": "Dam. boost vs Kuronites + Dark elem. up",
 		"jp_explainLong": "① 黒の民に与えるダメージをわずかに増加する。\n② 闇属性を強化する。\n[発動条件]黒の民に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage against Kuronites.\n    <color=yellow>[B-Frame]</color>\n② Increases Dark Element.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Kuronites by 15%.\n<color=yellow>SP: </color>Boosts damage against Kuronites by 20%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Dark Element by 20.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20068",
 		"jp_explainShort": "黒の民にダメージ増加＋闇属性強化",
 		"tr_explainShort": "Dam. boost vs Kuronites + Dark elem. up",
 		"jp_explainLong": "① 黒の民に与えるダメージを増加する。\n② 闇属性を強化する。\n[発動条件]黒の民に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Boosts damage against Kuronites.\n    <color=yellow>[B-Frame]</color>\n② Increases Dark Element.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage against Kuronites by 25%.\n<color=yellow>SP: </color>Boosts damage against Kuronites by 30%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Dark Element by 20.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20069",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 黒ノ領域での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    Kuron.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when fighting in\n     Kuron.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20070",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 黒ノ領域での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    Kuron.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
+		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when fighting in\n     Kuron.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	}
 ]

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -2,5917 +2,5917 @@
 	{
 		"assign": "710",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "HP recovery",
+		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "①  Recovers HP by 80%.\n<color=yellow>SP: </color>Recovers HP by 85%.\n[Activation Trigger] End of battle"
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "720",
 		"jp_explainShort": "ＨＰが劇的回復",
-		"tr_explainShort": "HP recovery",
+		"tr_explainShort": "Dramatic HP recovery",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n[発動条件]バトル終了時",
-		"tr_explainLong": "①  Recovers HP by 95%.\n<color=yellow>SP: </color>Recovers HP by 100%.\n[Activation Trigger] End of battle"
+		"tr_explainLong": "① Dramatically recovers HP.\n[Activation Trigger] End of battle"
 	},
 	{
 		"assign": "810",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 540.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "820",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "1010",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1020",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "1210",
 		"jp_explainShort": "チップのＣＰ消費量が減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "①  Reduces CP consumption by 50%.\n<color=yellow>SP: </color>Reduces CP consumption by 65%.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "1220",
 		"jp_explainShort": "チップのＣＰ消費量が大減少",
 		"tr_explainShort": "CP consumption decreased",
 		"jp_explainLong": "① 消費ＣＰを減少する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "①  Reduces CP consumption by 80%.\n<color=yellow>SP: </color>Reduces CP consumption by 99%.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Decreases CP consumption.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "1410",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "①  Allows you to survive with 1 HP.\n[Activation Trigger] Defeated at 30% or more HP\n<color=yellow>SP: </color>[Activation Trigger] Defeated at 25% or more HP\n[Cooldown] 30 seconds"
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
 	},
 	{
 		"assign": "1420",
 		"jp_explainShort": "ＨＰ１で耐えることがある",
 		"tr_explainShort": "Survive with 1 HP",
 		"jp_explainLong": "① ＨＰ１で耐えることがある。\n[発動条件]戦闘不能になるダメージを受けた時",
-		"tr_explainLong": "①  Allows you to survive with 1 HP.\n[Activation Trigger] Defeated at 20% or more HP\n<color=yellow>SP: </color>[Activation Trigger] Defeated at 15% or more HP\n[Cooldown] 30 seconds"
+		"tr_explainLong": "① Allows you to survive with 1 HP.\n[Activation Trigger] Taking lethal damage"
 	},
 	{
 		"assign": "1630",
 		"jp_explainShort": "ダーカーに追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Darkers",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]ダーカーに攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
 	},
 	{
 		"assign": "1640",
 		"jp_explainShort": "ダーカーに追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Darkers",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]ダーカーに攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Darkers"
 	},
 	{
 		"assign": "1650",
 		"jp_explainShort": "機甲種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Mechs",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]機甲種に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
 	},
 	{
 		"assign": "1660",
 		"jp_explainShort": "機甲種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Mechs",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]機甲種に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Mechs"
 	},
 	{
 		"assign": "1670",
 		"jp_explainShort": "龍族に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Dragonkin",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]龍族に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
 	},
 	{
 		"assign": "1680",
 		"jp_explainShort": "龍族に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Dragonkin",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]龍族に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Dragonkin"
 	},
 	{
 		"assign": "11010",
 		"jp_explainShort": "原生種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Natives",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]原生種に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
 	},
 	{
 		"assign": "11020",
 		"jp_explainShort": "原生種に追加で特大ダメージ",
 		"tr_explainShort": "Massive additional damage to Natives",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]原生種に攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing attacks on Natives"
 	},
 	{
 		"assign": "11030",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 260.\n<color=yellow>SP: </color>Increases your ATK by 280.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "11040",
 		"jp_explainShort": "攻撃力が強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 300.\n<color=yellow>SP: </color>Increases your ATK by 320.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30009",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30010",
 		"jp_explainShort": "追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30011",
 		"jp_explainShort": "チップの効果時間が延長",
 		"tr_explainShort": "Chip Effect Duration extended",
 		"jp_explainLong": "① アクティブチップのアビリティ効果時間を\n　　 延長する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "①  Extends the Effect Duration of an Active Chip's\n     ability by 8 seconds.\n<color=yellow>SP: </color>Extends the Effect Duration of an Active Chip's\n     ability by 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 12 seconds"
+		"tr_explainLong": "① Extends the Effect Duration of Active Chips'\n    abilities.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "30012",
 		"jp_explainShort": "チップの効果時間が延長",
 		"tr_explainShort": "Chip Effect Duration extended",
 		"jp_explainLong": "① アクティブチップのアビリティ効果時間を\n　　 延長する。\n[発動条件]アクティブチップ発動時",
-		"tr_explainLong": "①  Extends the Effect Duration of an Active Chip's\n     ability by 10 seconds.\n<color=yellow>SP: </color>Extends the Effect Duration of an Active Chip's\n     ability by 12 seconds.\n[Activation Trigger] Activating an Active Chip\n[Cooldown] 10 seconds"
+		"tr_explainLong": "① Extends the Effect Duration of Active Chips'\n    abilities.\n[Activation Trigger] Activating an Active Chip"
 	},
 	{
 		"assign": "30019",
 		"jp_explainShort": "攻撃力が大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30020",
 		"jp_explainShort": "攻撃力が大強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30021",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ＨＰが最大で攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30022",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ＨＰが最大で攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Hit enemy while your HP is full\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30023",
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30024",
 		"jp_explainShort": "光チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Light chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30025",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30026",
 		"jp_explainShort": "炎チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30035",
 		"jp_explainShort": "状態異常の敵に対してダメージ量が大増加",
 		"tr_explainShort": "Damage boosted vs status",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30036",
 		"jp_explainShort": "状態異常の敵に対してダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted vs status",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30037",
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 14% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 15% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30038",
 		"jp_explainShort": "属性種数に応じ攻撃力劇的増・ダメージ軽減",
 		"tr_explainShort": "Damage boost & reduction x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken by 5% x the number of\n     different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken based on the number of\n    different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30039",
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "[Freeze] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30040",
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "[Freeze] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30041",
 		"jp_explainShort": "ダメージ軽減＋風の法術が大強化",
 		"tr_explainShort": "Wind Techs boosted + damage reduction",
 		"jp_explainLong": "① 風属性の法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wind Techs by 50%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Strongly boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30042",
 		"jp_explainShort": "ダメージ大軽減＋風の法術が劇的強化",
 		"tr_explainShort": "Wind Techs boosted + damage reduction",
 		"jp_explainLong": "① 風属性の法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wind Techs by 70%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30045",
 		"jp_explainShort": "ダメージ軽減＋大剣の必殺技が大強化",
 		"tr_explainShort": "Sword PAs boosted + damage reduction",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30046",
 		"jp_explainShort": "ダメージ大軽減＋大剣の必殺技が劇的強化",
 		"tr_explainShort": "Sword PAs boosted + damage reduction",
 		"jp_explainLong": "① 大剣の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30049",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 8%.\n<color=yellow>SP: </color>Recovers HP by 10%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "30050",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 12%.\n<color=yellow>SP: </color>Recovers HP by 15%.\n③  Recovers CP by 10.\n<color=yellow>SP: </color>Recovers CP by 12.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "30051",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 5% every 4.8 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.8 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Damaged to below 70% HP\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Damaged to a certain HP level\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30052",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 8% every 4.8 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.8 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Damaged to below 70% HP\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Damaged to a certain HP level\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30055",
 		"jp_explainShort": "炎属性が大強化＋攻撃力が強化",
 		"tr_explainShort": "Fire Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 炎属性を大きく強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases your Fire Element by 60.\n<color=yellow>SP: </color>Increases your Fire Element by 70.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Greatly increases Fire Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30056",
 		"jp_explainShort": "炎属性が劇的強化＋攻撃力が大強化",
 		"tr_explainShort": "Fire Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 炎属性を劇的に強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases your Fire Element by 85.\n<color=yellow>SP: </color>Increases your Fire Element by 95.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Dramatically increases Fire Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30057",
 		"jp_explainShort": "闇属性が大強化＋攻撃力が強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 闇属性を大きく強化する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 70.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Greatly increases Dark Element.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30058",
 		"jp_explainShort": "闇属性が劇的強化＋攻撃力が大強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 闇属性を劇的に強化する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases your Dark Element by 85.\n<color=yellow>SP: </color>Increases your Dark Element by 95.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Dramatically increases Dark Element.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30059",
 		"jp_explainShort": "弱点属性が強化＋攻撃力が強化",
 		"tr_explainShort": "Weak Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 360.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Increases all Elements that the target is weak\n     to by 40.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30060",
 		"jp_explainShort": "弱点属性が大強化＋攻撃力が大強化",
 		"tr_explainShort": "Weak Element up + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 80.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30061",
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "[Poison] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30062",
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "[Poison] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30063",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30064",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "[Mirage] imbued + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30065",
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
-		"tr_explainShort": "Add. damage x number of chips found",
+		"tr_explainShort": "Add. damage x # chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 0.25% damage to enemies\n     x the number of chips discovered in the Chip Lab.\n     (Maximum additional damage: 65%)\n<color=yellow>SP: </color>(Maximum additional damage: 80%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30066",
 		"jp_explainShort": "発見済みチップ数に応じて追加特大ダメージ",
-		"tr_explainShort": "Add. damage x number of chips found",
+		"tr_explainShort": "Add. damage x # chips found",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 0.25% damage to enemies\n     x the number of chips discovered in the Chip Lab.\n     (Maximum additional damage: 90%)\n<color=yellow>SP: </color>(Maximum additional damage: 100%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of chips discovered in the\n    Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "30069",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "ATK up + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30070",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "ATK up + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
 	},
 	{
 		"assign": "30073",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 2% every 2.4 seconds.\n<color=yellow>SP: </color>Recovers HP by 3% every 2.4 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30074",
 		"jp_explainShort": "定期的にＨＰが小回復＋ダウン無効",
 		"tr_explainShort": "HP up over time + knockdown immunity",
 		"jp_explainLong": "① 定期的にＨＰをわずかに回復する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Recovers HP by 4% every 2.4 seconds.\n<color=yellow>SP: </color>Recovers HP by 5% every 2.4 seconds.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly recovers HP at regular intervals.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30075",
 		"jp_explainShort": "攻撃力とＣＰの回復速度が劇的強化",
-		"tr_explainShort": "ATK and CP regeneration up",
+		"tr_explainShort": "ATK and CP recovery up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 1500.\n<color=yellow>SP: </color>Increases your ATK by 1800.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "30076",
 		"jp_explainShort": "攻撃力とＣＰの回復速度が劇的強化",
-		"tr_explainShort": "ATK and CP regeneration up",
+		"tr_explainShort": "ATK and CP recovery up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 2000.\n<color=yellow>SP: </color>Increases your ATK by 2400.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "30077",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30078",
 		"jp_explainShort": "氷チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Ice chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30079",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 170 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 180 x the number of\n     Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30080",
 		"jp_explainShort": "闇チップ数に応じて攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x number of equipped Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 200 x the number of\n     Dark chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 220 x the number of\n     Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on the number\n    of Dark chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30087",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 520.\n<color=yellow>SP: </color>Increases your ATK by 540.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30088",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 570.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30091",
 		"jp_explainShort": "状態異常確率上昇＋ＣＰ消費量微減少",
 		"tr_explainShort": "Status rate up + CP usage down",
 		"jp_explainLong": "① 状態異常の発生率を上昇させる。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts status effect infliction rate by 100%.\n②  Reduces CP consumption by 20%.\n<color=yellow>SP: </color>Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases status effect infliction rate.\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30092",
 		"jp_explainShort": "状態異常確率上昇＋ＣＰ消費量減少",
 		"tr_explainShort": "Status rate up + CP usage down",
 		"jp_explainLong": "① 状態異常の発生率を上昇させる。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts status effect infliction rate by 100%.\n②  Reduces CP consumption by 40%.\n<color=yellow>SP: </color>Reduces CP consumption by 50%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases status effect infliction rate.\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30093",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 600.\n<color=yellow>SP: </color>Increases your ATK by 700.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30094",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 750.\n<color=yellow>SP: </color>Increases your ATK by 900.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30095",
 		"jp_explainShort": "一定ダメージ防御＋大剣・抜剣が超絶強化",
 		"tr_explainShort": "Barrier + Sword & Katana ATK up",
 		"jp_explainLong": "① 大剣か抜剣を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Sword or Katana.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Sword or Katana.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Sword or Katana.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30096",
 		"jp_explainShort": "一定ダメージ防御＋大剣・抜剣が超絶強化",
 		"tr_explainShort": "Barrier + Sword & Katana ATK up",
 		"jp_explainLong": "① 大剣か抜剣を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Sword or Katana.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Sword or Katana.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Sword or Katana.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30097",
 		"jp_explainShort": "一定ダメージ防御＋長槍が超絶強化",
 		"tr_explainShort": "Barrier + Partisan ATK up",
 		"jp_explainLong": "① 長槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Partizan.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Partizan.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30098",
 		"jp_explainShort": "一定ダメージ防御＋長槍が超絶強化",
 		"tr_explainShort": "Barrier + Partisan ATK up",
 		"jp_explainLong": "① 長槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Partizan.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Partizan.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30099",
 		"jp_explainShort": "一定ダメージ防御＋導具が超絶強化",
 		"tr_explainShort": "Barrier + Talis ATK up",
 		"jp_explainLong": "① 導具を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Talis.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Talis.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Talis.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "30100",
 		"jp_explainShort": "一定ダメージ防御＋導具が超絶強化",
 		"tr_explainShort": "Barrier + Talis ATK up",
 		"jp_explainLong": "① 導具を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Talis.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Talis.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Talis.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31001",
 		"jp_explainShort": "一定ダメージ防御＋長杖が超絶強化",
 		"tr_explainShort": "Barrier + Rod ATK up",
 		"jp_explainLong": "① 長杖を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Rod.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Rod.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Rod.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31002",
 		"jp_explainShort": "一定ダメージ防御＋長杖が超絶強化",
 		"tr_explainShort": "Barrier + Rod ATK up",
 		"jp_explainLong": "① 長杖を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Rod.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Rod.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Rod.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31003",
 		"jp_explainShort": "一定ダメージ防御＋鋼拳・自在槍が超絶強化",
 		"tr_explainShort": "Barrier + Knuckles & W. Lance ATK up",
 		"jp_explainLong": "① 鋼拳か自在槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     Knuckles or Wired Lances.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     Knuckles or Wired Lances.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with Knuckles or Wired Lances.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31004",
 		"jp_explainShort": "一定ダメージ防御＋鋼拳・自在槍が超絶強化",
 		"tr_explainShort": "Barrier + Knuckles & W. Lance ATK up",
 		"jp_explainLong": "① 鋼拳か自在槍を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     Knuckles or Wired Lances.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     Knuckles or Wired Lances.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with Knuckles or Wired Lances.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31005",
 		"jp_explainShort": "一定ダメージ防御＋銃剣・長銃が超絶強化",
 		"tr_explainShort": "Barrier + Gunslash & Rifle ATK up",
 		"jp_explainLong": "① 銃剣か長銃を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8000 if equipped with\n     a Gunslash or an Assault Rifle.\n<color=yellow>SP: </color>Increases your ATK by 8500 if equipped with\n     a Gunslash or an Assault Rifle.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Gunslash or an Assault Rifle.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31006",
 		"jp_explainShort": "一定ダメージ防御＋銃剣・長銃が超絶強化",
 		"tr_explainShort": "Barrier + Gunslash & Rifle ATK up",
 		"jp_explainLong": "① 銃剣か長銃を装備している場合に\n　　 攻撃力を超絶に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 9000 if equipped with\n     a Gunslash or an Assault Rifle.\n<color=yellow>SP: </color>Increases your ATK by 9500 if equipped with\n     a Gunslash or an Assault Rifle.\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK if equipped\n    with a Gunslash or an Assault Rifle.\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31007",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "All chips activated + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31008",
 		"jp_explainShort": "全アクティブチップ発動＋攻撃力劇的増加",
 		"tr_explainShort": "All chips activated + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 85%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31013",
 		"jp_explainShort": "ダーカーに対してダメージが大増加",
 		"tr_explainShort": "Damage boosted against Darkers",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 45%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 55%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31014",
 		"jp_explainShort": "ダーカーに対してダメージが劇的増加",
 		"tr_explainShort": "Damage boosted against Darkers",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 65%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 75%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31015",
 		"jp_explainShort": "攻撃力大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "ATK up + 3 actions = ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31016",
 		"jp_explainShort": "攻撃力劇的強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "ATK up + 3 actions = ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 800.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31017",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "Lightning up + 3 actions = ATK up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 66.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases Lightning Element.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31018",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "Lightning up + 3 actions = ATK up",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Greatly increases Lightning Element.\n② Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31019",
 		"jp_explainShort": "攻撃力が大強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 540.\n②  Recovers HP by 12% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31020",
 		"jp_explainShort": "攻撃力が大強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Recovers HP by 12% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31021",
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が大強化",
 		"tr_explainShort": "Actions quickened + Wind up",
 		"jp_explainLong": "① 風属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 77.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases Wind Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31022",
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が劇的強化",
 		"tr_explainShort": "Actions quickened + Wind up",
 		"jp_explainLong": "① 風属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 80.\n<color=yellow>SP: </color>Increases your Wind Element by 96.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases Wind Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31023",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by up to 1500 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 1600 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31024",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力を劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by up to 1800 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 2000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31027",
 		"jp_explainShort": "ダメージ軽減＋魔装脚の必殺技が大強化",
 		"tr_explainShort": "Damage reduced + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 50%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31028",
 		"jp_explainShort": "ダメージ大軽減＋魔装脚の必殺技が劇的強化",
 		"tr_explainShort": "Damage reduced + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 70%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31031",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が大強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 600.\n<color=yellow>SP: </color>Increases your ATK by 720.\n②  Reduces damage taken from enemies by 60%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31032",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力を劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 800.\n<color=yellow>SP: </color>Increases your ATK by 960.\n②  Reduces damage taken from enemies by 60%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31033",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Boosts your ATK by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 110% against enemy\n     elemental weaknesses.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31034",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Boosts your ATK by 120% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 145% against enemy\n     elemental weaknesses.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31035",
 		"jp_explainShort": "ダメージが大増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31036",
 		"jp_explainShort": "ダメージが劇的増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31037",
 		"jp_explainShort": "状態異常ダメージ大増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Damage boost vs status + HP over time",
 		"jp_explainLong": "① 状態異常の敵に対して大きくダメージを増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31038",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Damage boost vs status + HP over time",
 		"jp_explainLong": "① 状態異常の敵に対して劇的にダメージを増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 8% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31039",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & dam. reduced vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージを軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 80%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 35%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31040",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & dam. reduced vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージを大きく軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 90%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 50%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31041",
 		"jp_explainShort": "風チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31042",
 		"jp_explainShort": "風チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Wind chips",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31043",
 		"jp_explainShort": "ダメージ軽減＋法術が大強化",
 		"tr_explainShort": "Techs boosted + damage reduced",
 		"jp_explainLong": "① 法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 50%.\n<color=yellow>SP: </color>Boosts the power of Techs by 60%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31044",
 		"jp_explainShort": "ダメージ大軽減＋法術が劇的強化",
 		"tr_explainShort": "Techs boosted + damage reduced",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 70%.\n<color=yellow>SP: </color>Boosts the power of Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31053",
 		"jp_explainShort": "炎チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31054",
 		"jp_explainShort": "炎チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Fire chips",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31055",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31056",
 		"jp_explainShort": "氷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31057",
 		"jp_explainShort": "消費ＣＰ減少＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31058",
 		"jp_explainShort": "消費ＣＰ減少＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31059",
 		"jp_explainShort": "ダメージ絶大増加",
-		"tr_explainShort": "Damage boosted",
+		"tr_explainShort": "Damage immensely boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 165%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31060",
 		"jp_explainShort": "ダメージ絶大増加",
-		"tr_explainShort": "Damage boosted",
+		"tr_explainShort": "Damage immensely boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31065",
 		"jp_explainShort": "ダメージ増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31066",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31069",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 800.\n<color=yellow>SP: </color>Increases your ATK by 960.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31070",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が劇的強化",
 		"tr_explainShort": "Damage reduced + ATK up",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 1000.\n<color=yellow>SP: </color>Increases your ATK by 1200.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31073",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen increased",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your maximum CP by 20.\n<color=yellow>SP: </color>Increases your maximum CP by 25.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31074",
 		"jp_explainShort": "ＣＰ最大値増加＋ＣＰ回復速度を劇的強化",
 		"tr_explainShort": "Max CP increased + CP regen increased",
 		"jp_explainLong": "① ＣＰの最大値を増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your maximum CP by 30.\n<color=yellow>SP: </color>Increases your maximum CP by 40.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases your maximum CP.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31075",
 		"jp_explainShort": "雷チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31076",
 		"jp_explainShort": "雷チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31077",
 		"jp_explainShort": "ダメージ大増加＋鋼拳・自在槍で大増加",
 		"tr_explainShort": "Damage boosted + fist weapons boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 鋼拳か自在槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Wired Lances or Knuckles.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    Wired Lances or Knuckles.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31078",
 		"jp_explainShort": "ダメージ劇的増加＋鋼拳・自在槍で大増加",
 		"tr_explainShort": "Damage boosted + fist weapons boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 鋼拳か自在槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Wired Lances or Knuckles.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    Wired Lances or Knuckles.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31079",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が大増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 80% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31080",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 120% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31081",
 		"jp_explainShort": "ダメージ大増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31082",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31083",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery per hit: 5% of max HP)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31084",
 		"jp_explainShort": "ダメージ絶大増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery per hit: 5% of max HP)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31089",
 		"jp_explainShort": "雷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15% + 0.35% x your\n     Lightning Element.\n<color=yellow>SP: </color>Boosts damage by 20% + 0.35% x your\n     Lightning Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31090",
 		"jp_explainShort": "雷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Lightning Element",
 		"jp_explainLong": "① 雷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25% + 0.35% x your\n     Lightning Element.\n<color=yellow>SP: </color>Boosts damage by 30% + 0.35% x your\n     Lightning Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on your\n    Lightning Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31091",
 		"jp_explainShort": "龍族にダメージ大増加＋被ダメージ小軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n② 龍族から受けるダメージをわずかに軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 50%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 60%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 10%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 12%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Slightly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31092",
 		"jp_explainShort": "龍族にダメージ劇的増加＋被ダメージ小軽減",
 		"tr_explainShort": "Dam. boost & dam. resist vs Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n② 龍族から受けるダメージをわずかに軽減する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 70%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 80%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Dragonkin by 15%.\n<color=yellow>SP: </color>Reduces damage taken from Dragonkin by 20%.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n② Slightly reduces damage taken from Dragonkin.\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31095",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31096",
 		"jp_explainShort": "ＨＰ回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Deals an additional 125% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 20%.\n③  Recovers CP by 10.\n<color=yellow>SP: </color>Recovers CP by 12.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31101",
 		"jp_explainShort": "ダメージが大増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31102",
 		"jp_explainShort": "ダメージが劇的増加",
 		"tr_explainShort": "Damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "31103",
 		"jp_explainShort": "ダメージが増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31104",
 		"jp_explainShort": "ダメージが大増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31105",
 		"jp_explainShort": "光属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31106",
 		"jp_explainShort": "光属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on your Light\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31107",
 		"jp_explainShort": "炎属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31108",
 		"jp_explainShort": "炎属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Fire Element",
 		"jp_explainLong": "① 炎属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Fire\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Fire\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on your Fire\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31109",
 		"jp_explainShort": "氷属性値に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 15% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31110",
 		"jp_explainShort": "氷属性値に応じてダメージ絶大増加",
 		"tr_explainShort": "Damage boosted x Ice Element",
 		"jp_explainLong": "① 氷属性値に応じて攻撃力を絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 0.35% x your Ice\n     Element.\n<color=yellow>SP: </color>Boosts damage by 25% + 0.35% x your Ice\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on your Ice\n    Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31111",
 		"jp_explainShort": "消費ＣＰ減少＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dark weakness boost + CP usage down",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31112",
 		"jp_explainShort": "消費ＣＰ減少＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dark weakness boost + CP usage down",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージ劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31113",
 		"jp_explainShort": "海王種・ダーカーにダメージ劇的増加＋軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Darkers",
 		"jp_explainLong": "① 海王種とダーカーに与えるダメージを劇的に増加する。\n② 海王種とダーカーから受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Darkers by 90%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Darkers by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Darkers by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Darkers by 35%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Darkers.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31114",
 		"jp_explainShort": "海王種・ダーカーにダメージ劇的増加＋大軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Darkers",
 		"jp_explainLong": "① 海王種とダーカーに与えるダメージを劇的に増加する。\n② 海王種とダーカーから受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Darkers by 100%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Darkers by 105%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Darkers by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Darkers by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n    and Darkers.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31115",
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 100% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31116",
 		"jp_explainShort": "チップの属性種数に応じてダメージ絶大増加",
 		"tr_explainShort": "Dam. boost x # Elems + CP usage down",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 140% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31117",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31118",
 		"jp_explainShort": "追加で特大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31121",
 		"jp_explainShort": "攻撃力が強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 300.\n<color=yellow>SP: </color>Increases your ATK by 330.\n②  Recovers HP by 1% every 2.4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31122",
 		"jp_explainShort": "攻撃力が強化＋定期的にＨＰが小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 340.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Recovers HP by 1% every 2.4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31123",
 		"jp_explainShort": "ダメージ増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 3% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31124",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 3% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31125",
 		"jp_explainShort": "ダメージ大増加＋長槍で大増加",
 		"tr_explainShort": "Damage boosted + Partizans boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 長槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    a Partizan.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31126",
 		"jp_explainShort": "ダメージ劇的増加＋長槍で大増加",
 		"tr_explainShort": "Damage boosted + Partizans boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 長槍を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage if equipped with\n    a Partizan.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31127",
 		"jp_explainShort": "光チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31128",
 		"jp_explainShort": "光チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boost x # of Light chips",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31129",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が大増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 80% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31130",
 		"jp_explainShort": "ＣＰ一定以下時にダメージ量が劇的増加",
 		"tr_explainShort": "Damage boosted at low CP",
 		"jp_explainLong": "① ＣＰが一定値以下の場合は攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100% while CP is below 60.\n<color=yellow>SP: </color>Boosts damage by 120% while CP is below 60.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage while CP is below a\n    certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31133",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 140% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31134",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 180% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 160% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31135",
 		"jp_explainShort": "属性種類数ダメージ大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31136",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋追加ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31139",
 		"jp_explainShort": "属性種類数ダメージ大増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 8% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 10% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.2% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n<color=yellow>SP: </color>Recovers HP by 0.4% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31140",
 		"jp_explainShort": "属性種類数ダメージ劇的増＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Elems",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 11% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 13% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.6% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n<color=yellow>SP: </color>Recovers HP by 0.8% x the number of\n     different chip elements equipped every 3.3\n     seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of different chip elements equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31143",
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Fire Element up + 3 actions = ATK up",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 25.\n②  Increases your ATK  by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n② Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31144",
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Fire Element up + 3 actions = ATK up",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 30.\n<color=yellow>SP: </color>Increases your Fire Element by 35.\n②  Increases your ATK  by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n② Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31147",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31148",
 		"jp_explainShort": "ダメージ大増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 自身を状態異常にならなくする。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31155",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds or next Slide Action"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31156",
 		"jp_explainShort": "ダメージ劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds or next Slide Action"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31157",
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 30% + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds or next Slide Action"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31158",
 		"jp_explainShort": "チップの属性種数に応じてダメージ劇的増加",
 		"tr_explainShort": "Damage boosted x number of Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]スライド操作時\n[効果時間]スライド操作を行うまでの長い時間",
-		"tr_explainLong": "①  Boosts damage by 40 + 10% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 50 + 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds or next Slide Action"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Slide Action\n[Effect Duration] Long, or until next Slide Action"
 	},
 	{
 		"assign": "31159",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が劇的増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% x 1.19 to the power of\n     the number of other Dark chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% x 1.19 to the power of\n     the number of other Dark chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31160",
 		"jp_explainShort": "闇チップ数に応じて攻撃力が絶大増加",
 		"tr_explainShort": "Damage boosted x # of Dark chips",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% x 1.19 to the power of\n     the number of other Dark chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% x 1.19 to the power of\n     the number of other Dark chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31161",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力大増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 50% + 3% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31162",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boosted x chip's ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 60% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 70% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31165",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15% x the number  of Fire\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number  of Fire\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.8% x the number of Fire chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers HP by 1.1% x the number of Fire chips\n     equipped every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31166",
 		"jp_explainShort": "炎チップ数ダメージ劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Damage boost & HP over time x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 18% x the number  of Fire\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number  of Fire\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 1.65% x the number of Fire chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers HP by 1.3% x the number of Fire chips\n     equipped every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Fire chips equipped.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31167",
 		"jp_explainShort": "属性種類数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 17% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31168",
 		"jp_explainShort": "属性種類数攻撃力絶大増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost x # Elems + add. damage",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 23% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 26% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31169",
 		"jp_explainShort": "チップ発見数攻撃力劇的増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 0.11% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>Boosts damage by 0.13% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 130%)\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of different chips discovered in the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31170",
 		"jp_explainShort": "チップ発見数攻撃力絶大増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost x Lab + HP up over time",
 		"jp_explainLong": "① チップ研究室において発見済みチップが\n　　 多いほど攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 0.15% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 0.17% x the number of chips\n     discovered in the Chip Lab.\n     (Maximum boost: 170%)\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 5 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chips discovered in the Chip Lab.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31173",
 		"jp_explainShort": "消費ＣＰ減少＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Lightning weak boost",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31174",
 		"jp_explainShort": "消費ＣＰ減少＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Lightning weak boost",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31177",
 		"jp_explainShort": "氷チップ数攻撃力大増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 12% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage x the number of\n     Ice chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31178",
 		"jp_explainShort": "氷チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost, add. damage x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 14% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage x the number of\n     Ice chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31179",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31180",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boost + damage taken reduced",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31181",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 10% x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 30% + 10% x the number of\n     Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31182",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boost x # Light + CP use down",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 10% x the number of\n     Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% + 10% x the number of\n     Light chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31183",
 		"jp_explainShort": "攻撃力絶大増加＋弱点属性大強化",
-		"tr_explainShort": "Damage boosted + weakness Elems up",
+		"tr_explainShort": "Damage boosted + weakness Elem. up",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31184",
 		"jp_explainShort": "攻撃力絶大増加＋弱点属性劇的強化",
-		"tr_explainShort": "Damage boosted + weakness Elems up",
+		"tr_explainShort": "Damage boosted + weakness Elem. up",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 攻撃対象の敵の弱点属性を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases elements that the targeted\n    enemy is weak to.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31187",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 50% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31188",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増加",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31191",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 6% every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31192",
 		"jp_explainShort": "攻撃力劇的増加＋ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 8% every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 9% every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31193",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 45%.\n<color=yellow>SP: </color>Boosts power by 55%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31194",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power by 65%.\n<color=yellow>SP: </color>Boosts power by 75%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31195",
 		"jp_explainShort": "攻撃力大増加＋大剣・銃剣でさらに増加",
 		"tr_explainShort": "Damage boost + Sword/Gunslash boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 大剣か銃剣を装備している場合は\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 55%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n　　 a Sword or a Gunslash.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with\n　　 a Sword or a Gunslash.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31196",
 		"jp_explainShort": "攻撃力劇的増加＋大剣・銃剣でさらに増加",
 		"tr_explainShort": "Damage boost + Sword/Gunslash boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 大剣か銃剣を装備している場合は\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n<color=yellow>SP: </color>Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 30% if equipped with\n　　 a Sword or a Gunslash.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with\n　　 a Sword or a Gunslash.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31199",
 		"jp_explainShort": "攻撃力大増加＋定期的にＣＰが微回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 6 every 4 seconds.\n<color=yellow>SP: </color>Recovers CP by 7 every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31200",
 		"jp_explainShort": "攻撃力劇的増加＋定期的にＣＰが回復",
 		"tr_explainShort": "Damage boost + CP recovery over time",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 4 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 4 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31205",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ無で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を大きく増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31206",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ無で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 60%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31207",
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 14% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 16% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.4% x the number of Ice chips\n     equipped every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 0.6% x the number of Ice chips\n     equipped every 4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31208",
 		"jp_explainShort": "氷チップ数で攻撃力劇的増加＋定期ＨＰ回復",
 		"tr_explainShort": "Dam. boost + HP over time x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 18% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 22% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 0.8% x the number of Ice chips\n     equipped every 4 seconds.\n<color=yellow>SP: </color>Recovers HP by 1% x the number of Ice chips\n     equipped every 4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals based on\n    the number of Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31209",
 		"jp_explainShort": "機甲種にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Mechs",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 機甲種から受けるダメージを軽減する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 80%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Mechs by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Mechs by 35%.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Mechs.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31210",
 		"jp_explainShort": "機甲種ダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Mechs",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 機甲種から受けるダメージを大きく軽減する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 90%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Mechs by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Mechs by 50%.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Mechs.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31213",
 		"jp_explainShort": "原生種にダメージ劇的増加＋被ダメージ軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Natives",
 		"jp_explainLong": "① 原生種に与えるダメージを劇的に増加する。\n② 原生種から受けるダメージを軽減する。\n[発動条件]原生種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Natives by 80%.\n<color=yellow>SP: </color>Boosts damage against Natives by 85%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Natives by 35%.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Natives.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31214",
 		"jp_explainShort": "原生種ダメージ劇的増加＋被ダメージ大軽減",
 		"tr_explainShort": "Dam. boost & damage reduced vs Natives",
 		"jp_explainLong": "① 原生種に与えるダメージを劇的に増加する。\n② 原生種から受けるダメージを大きく軽減する。\n[発動条件]原生種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Natives by 90%.\n<color=yellow>SP: </color>Boosts damage against Natives by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Natives by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Natives by 50%.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Natives.\n[Activation Trigger] Landing attacks on Natives\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31217",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "Actions quickened + damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31218",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "Actions quickened + damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n②  自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n②  Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31219",
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31220",
 		"jp_explainShort": "氷チップ数でダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. res. + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 18% x the number of Ice chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Ice chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31221",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% x the number of Lightning chips equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     6% x the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31222",
 		"jp_explainShort": "雷チップ数でダメージ防御＋攻撃力劇的増加",
 		"tr_explainShort": "Dam. boost & barrier x # Lightning chips",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 18% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% x the number of Lightning chips equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% x the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of Lightning chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31223",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加小ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を大きく増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で小ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% x the number of Light\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 12% x the number of Light\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 4% damage to enemies x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 6% damage to enemies x the\n     number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on the number of\n    Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31224",
 		"jp_explainShort": "光チップ数攻撃力劇的増加＋追加大ダメージ",
 		"tr_explainShort": "Damage boost & add. damage x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 14% x the number of Light\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Light\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies x the\n     number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Light chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage based on the\n    number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31225",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by up to 90%, based on how\n     close you are to the target.\n<color=yellow>SP: </color>Boosts damage by up to 100%, based on how\n     close you are to the target.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31226",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的増加",
 		"tr_explainShort": "Damage boost x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by up to 110%, based on how\n     close you are to the target.\n<color=yellow>SP: </color>Boosts damage by up to 120%, based on how\n     close you are to the target.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on how close\n    you are to the target.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31229",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockback",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n③  Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31230",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + dam. res. + no knockback",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 敵から受けるダメージを軽減する。\n③ ダウンしなくなる。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n③  Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31231",
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.6 CP x the number of Dark chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers 0.9 CP x the number of Dark chips\n     equipped every 5 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals based on\n    the number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31232",
 		"jp_explainShort": "闇チップ数で攻撃力劇的増加＋定期ＣＰ回復",
 		"tr_explainShort": "Damage boost & CP recovery x # Dark",
 		"jp_explainLong": "① 装備中の闇属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 18% x the number of Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Dark\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1.2 CP x the number of Dark chips\n     equipped every 5 seconds.\n<color=yellow>SP: </color>Recovers 1.5 CP x the number of Dark chips\n     equipped every 5 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Dark chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals based on the\n    number of Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31233",
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31234",
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "[Burn] imbued + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31235",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 70% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n② Boosts damage against enemies affected by\n    [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31236",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n② Boosts damage against enemies affected by\n    [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31237",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "Damage boost + boost per normal attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum boost (including ①): 100%)\n<color=yellow>SP: </color>(Maximum boost (including ①): 110%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    perform a normal attack.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31238",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "Damage boost + boost per normal attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum boost (including ①): 120%)\n<color=yellow>SP: </color>(Maximum boost (including ①): 130%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts damage slightly further each time you\n    perform a normal attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31239",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＨＰが微回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 7% every 8 seconds.\n<color=yellow>SP: </color>Recovers HP by 8% every 8 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31240",
 		"jp_explainShort": "攻撃力絶大増加＋定期的にＨＰが微回復",
 		"tr_explainShort": "Damage boost + HP recovery over time",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 9% every 8 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 8 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31247",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     55% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31248",
 		"jp_explainShort": "攻撃力絶大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     55% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     60% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31251",
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 13% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 14% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31252",
 		"jp_explainShort": "ダメージ軽減＋雷チップ数で攻撃力劇的増加",
 		"tr_explainShort": "Dam. resist + dam. boost x # of Lightning",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31257",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力大増",
 		"tr_explainShort": "Damage boost + boost at low CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage while CP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31258",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力大増",
 		"tr_explainShort": "Damage boost + boost at low CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage while CP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31261",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dark Techs by 30% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 40% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31262",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル闇法術劇的強化",
 		"tr_explainShort": "CP usage down + Dark Techs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 闇属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dark Techs by 50% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 60% + 4% x\n     this chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Dark Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31263",
 		"jp_explainShort": "攻撃力大増加＋飛翔剣で大増加",
 		"tr_explainShort": "Damage boosted + Dual Blades boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 飛翔剣を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with Dual\n    Blades.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31264",
 		"jp_explainShort": "攻撃力劇的増加＋飛翔剣で大増加",
 		"tr_explainShort": "Damage boosted + Dual Blades boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 飛翔剣を装備している場合は\n　　 さらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% if equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if equipped with Dual\n    Blades.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31265",
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies x \n     your Wind Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31266",
 		"jp_explainShort": "風チップ数攻撃絶大増＋属性追加ダメージ",
 		"tr_explainShort": "Boost x # Wind + add. dam. x Wind Elem",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 風属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies x \n     your Wind Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Wind Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31273",
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     25%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     30%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31274",
 		"jp_explainShort": "攻撃力超絶増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     35%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     40%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31275",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31276",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "Actions quickened + dam. boost x # Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 19% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31279",
 		"jp_explainShort": "ダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Damage resist + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31280",
 		"jp_explainShort": "ダメージ軽減＋攻撃力劇的増加",
 		"tr_explainShort": "Damage resist + damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 85%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31281",
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性大強化",
 		"tr_explainShort": "[Poison] imbued + Weak Element up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を大きく強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly increases the target's weakness\n    Element value.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31282",
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性劇的強化",
 		"tr_explainShort": "[Poison] imbued + Weak Element up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases the target's weakness\n    Element value.\n② Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31283",
 		"jp_explainShort": "炎属性強化＋追加で特大ダメージ",
 		"tr_explainShort": "Fire Element up + additional damage",
 		"jp_explainLong": "① 炎属性を強化する。\n② 追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Fire Element by 45.\n<color=yellow>SP: </color>Increases your Fire Element by 50.\n②  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31284",
 		"jp_explainShort": "炎属性大強化＋追加で特大ダメージ",
 		"tr_explainShort": "Fire Element up + additional damage",
 		"jp_explainLong": "① 炎属性を大きく強化する。\n② 追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Fire Element by 55.\n<color=yellow>SP: </color>Increases your Fire Element by 60.\n②  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases Fire Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31285",
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 20% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31286",
 		"jp_explainShort": "攻撃力劇的増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 20% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31289",
 		"jp_explainShort": "攻撃力大増加＋JA毎に攻撃力小増加",
 		"tr_explainShort": "Damage boosted + damage boost per JA",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ジャストアタックごとに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     successfully perform a Just Attack.\n     (Maximum boost (including ①): 140%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further slightly boosts damage each time you\n    successfully perform a Just Attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31290",
 		"jp_explainShort": "攻撃力劇的増加＋JA毎に攻撃力小増加",
 		"tr_explainShort": "Damage boosted + damage boost per JA",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ジャストアタックごとに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     successfully perform a Just Attack.\n     (Maximum boost (including ①): 140%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further slightly boosts damage each time you\n    successfully perform a Just Attack.\n    (Maximum Boost: Immense)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31293",
 		"jp_explainShort": "攻撃力絶大増＋ダメージ無で攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 150%.\n<color=yellow>SP: </color>Boosts damage by 160%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31294",
 		"jp_explainShort": "攻撃力絶大増＋ダメージ無で攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + further boost if undamaged",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 一定時間ダメージを受けなければ\n　　 さらに攻撃力を増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 180%.\n     <color=yellow>[E-Frame]</color>\n②  If you do not take damage for 5 seconds after this\n     ability activates, boosts damage by a further 70%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage at regular intervals. This\n    boost stops increasing when you take damage.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31295",
 		"jp_explainShort": "攻撃力劇的増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31296",
 		"jp_explainShort": "攻撃力劇的増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 95%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31299",
 		"jp_explainShort": "攻撃力劇的増加＋弱点属性大強化",
 		"tr_explainShort": "Damage boosted + weak Element up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31300",
 		"jp_explainShort": "攻撃力劇的増加＋弱点属性大強化",
 		"tr_explainShort": "Damage boosted + weak Element up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31301",
 		"jp_explainShort": "ＨＰとＣＰが小回復＋追加大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 55% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 60% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 4%.\n<color=yellow>SP: </color>Recovers HP by 5%.\n③  Recovers CP by 3.\n<color=yellow>SP: </color>Recovers CP by 4.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31302",
 		"jp_explainShort": "ＨＰとＣＰが小回復＋追加特大ダメージ",
 		"tr_explainShort": "HP & CP recovery + additional damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 65% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 6%.\n<color=yellow>SP: </color>Recovers HP by 7%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 6.\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31303",
 		"jp_explainShort": "発見済みエネミーチップ数に応じ特大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 0.778% damage to enemies x\n     the number of Enemy Chips discovered in the\n     Chip Lab.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>(Maximum boost: 120%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of Enemy Chips discovered\n    in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31304",
 		"jp_explainShort": "発見済みエネミーチップ数に応じ絶大追撃",
 		"tr_explainShort": "Add. damage x discovered Enemy Chips",
 		"jp_explainLong": "① チップ研究室において発見済みエネミーチップが\n　　 多いほど追加で絶大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 0.778% damage to enemies x\n     the number of Enemy Chips discovered in the\n     Chip Lab.\n     (Maximum boost: 130%)\n<color=yellow>SP: </color>(Maximum boost: 140%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies\n    based on the number of Enemy Chips discovered\n    in the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31305",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋光属性大強化",
 		"tr_explainShort": "Dam. boost vs Darkers + Light Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 光属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Light Element by 50.\n<color=yellow>SP: </color>Increases your Light Element by 60.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Light Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31306",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋光属性大強化",
 		"tr_explainShort": "Dam. boost vs Darkers + Light Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 光属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 115%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 80.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Light Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31309",
 		"jp_explainShort": "攻撃力劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31310",
 		"jp_explainShort": "攻撃力劇的増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + max CP increased",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31313",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力劇的増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% + 8% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 35% + 8% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31314",
 		"jp_explainShort": "アビリティレベルに応じて攻撃力絶大増加",
 		"tr_explainShort": "Damage boost x chip ability level",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 8% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 8% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31317",
 		"jp_explainShort": "攻撃力劇的増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "Damage boost + survive 1 incapacitation",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31318",
 		"jp_explainShort": "攻撃力絶大増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "Damage boost + survive 1 incapacitation",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31321",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ一定以上時攻撃力大増加",
 		"tr_explainShort": "Damage boosted + boost at high HP",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＨＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 40% as long as HP is\n     at 75% or higher.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage as long as HP is above\n    a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31322",
 		"jp_explainShort": "攻撃力大増加＋ＨＰ一定以上時攻撃力大増加",
 		"tr_explainShort": "Damage boosted + boost at high HP",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② ＨＰが一定以上の場合はさらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 40% as long as HP is\n     at 75% or higher.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage as long as HP is above\n    a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31323",
 		"jp_explainShort": "消費ＣＰ減少＋炎弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Fire weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31324",
 		"jp_explainShort": "消費ＣＰ減少＋炎弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Fire weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31325",
 		"jp_explainShort": "攻撃力絶大増加＋光属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Light weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31326",
 		"jp_explainShort": "攻撃力絶大増加＋光属性武器で攻撃力増加",
 		"tr_explainShort": "Dam. boosted + Light weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 160%.\n<color=yellow>SP: </color>Boosts damage by 170%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31329",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 15% every 3 seconds.\n     (Maximum boost: 90%)\n<color=yellow>SP: </color>Boosts damage by 17% every 3 seconds.\n     (Maximum boost: 100%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31330",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 19% every 3 seconds.\n     (Maximum boost: 110%)\n<color=yellow>SP: </color>Boosts damage by 20% every 3 seconds.\n     (Maximum boost: 120%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Dramatic)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31331",
 		"jp_explainShort": "ダメージ軽減＋法術が大強化",
 		"tr_explainShort": "Damage taken reduced + Techs boosted",
 		"jp_explainLong": "① 法術の威力を大きく強化する。\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31332",
 		"jp_explainShort": "ダメージ大軽減＋法術が劇的強化",
 		"tr_explainShort": "Damage taken reduced + Techs boosted",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31333",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 100%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31334",
 		"jp_explainShort": "ダーカー以外にダメージ絶大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 140%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 160%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage against Natives,\n    Dragonkin, Mechs and Oceanids.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31337",
 		"jp_explainShort": "攻撃力超絶増加＋チップ効果時間延長",
 		"tr_explainShort": "Damage boosted + chip effects extended",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップ発動時のアビリティ効果時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Extends the Effect Duration of chips' abilities by\n     10 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Extends the Effect Duration of chips' abilities.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31338",
 		"jp_explainShort": "攻撃力超絶増加＋チップ効果時間延長",
 		"tr_explainShort": "Damage boosted + chip effects extended",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップ発動時のアビリティ効果時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Extends the Effect Duration of chips' abilities by\n     10 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Extends the Effect Duration of chips' abilities.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31341",
 		"jp_explainShort": "攻撃力劇的増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31342",
 		"jp_explainShort": "攻撃力劇的増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Slide Action\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31343",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery: 3% of max HP)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31344",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 2% of damage dealt as HP.\n     (Maximum recovery: 3% of max HP)\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31347",
 		"jp_explainShort": "必殺技大強化＋通常攻撃と移動加速",
 		"tr_explainShort": "PAs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31348",
 		"jp_explainShort": "必殺技劇的強化＋通常攻撃と移動加速",
 		"tr_explainShort": "PAs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31349",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Dam. boost vs status + HP up over time",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 7% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31350",
 		"jp_explainShort": "状態異常ダメージ劇的増＋定期的にＨＰ小回復",
 		"tr_explainShort": "Dam. boost vs status + HP up over time",
 		"jp_explainLong": "① 状態異常の敵に対してダメージを劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n②  Recovers HP by 8% every 4.9 seconds.\n<color=yellow>SP: </color>Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31351",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 70% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 35%.\n<color=yellow>SP: </color>Reduces CP consumption by 36%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31352",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 90% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 36%.\n<color=yellow>SP: </color>Reduces CP consumption by 37%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31353",
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 170% + 5% x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 180% + 5% x the number of\n     Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31354",
 		"jp_explainShort": "攻撃力超絶増加＋消費ＣＰ減少",
 		"tr_explainShort": "Dam. boost x # Lightning + CP use down",
 		"jp_explainLong": "① 装備中チップの雷属性の枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 190% + 5% x the number of\n     Lightning chips equipped.\n<color=yellow>SP: </color>Boosts damage by 200% + 5% x the number of\n     Lightning chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Lightning chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31357",
 		"jp_explainShort": "攻撃力超絶増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31358",
 		"jp_explainShort": "攻撃力超絶増加＋状態異常無効",
 		"tr_explainShort": "Damage boosted + status immunity",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31359",
 		"jp_explainShort": "攻撃力増加＋追加絶大ダメージ",
 		"tr_explainShort": "Damage boosted + additional damage",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 敵に追加で絶大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n<color=yellow>SP: </color>Boosts damage by 35%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31360",
 		"jp_explainShort": "攻撃力大増加＋追加絶大ダメージ",
 		"tr_explainShort": "Damage boosted + additional damage",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 敵に追加で絶大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 45%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 135% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31361",
 		"jp_explainShort": "攻撃力劇的増＋ＨＰ一定以下時ダメージ大増",
 		"tr_explainShort": "Damage boosted + boost at low HP",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＨＰが一定以下の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when HP is\n     below 50%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage when HP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31362",
 		"jp_explainShort": "攻撃力劇的増＋ＨＰ一定以下時ダメージ大増",
 		"tr_explainShort": "Damage boosted + boost at low HP",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② ＨＰが一定以下の場合はさらに攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when HP is\n     below 50%.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further greatly boosts damage when HP is\n    below a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31363",
 		"jp_explainShort": "攻撃力増加＋必殺技が大強化",
 		"tr_explainShort": "Damage boosted + PAs boosted",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 35%.\n<color=yellow>SP: </color>Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boost the power of PAs by 45%.\n<color=yellow>SP: </color>Boost the power of PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31364",
 		"jp_explainShort": "攻撃力大増加＋必殺技が大強化",
 		"tr_explainShort": "Damage boosted + PAs boosted",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 45%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Boost the power of PAs by 55%.\n<color=yellow>SP: </color>Boost the power of PAs by 60%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31365",
 		"jp_explainShort": "アビリティレベル攻撃大増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 35% + 1% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 2% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31366",
 		"jp_explainShort": "アビリティレベル攻撃劇的増＋定期ＣＰ小回復",
 		"tr_explainShort": "Dam. boost x ability + CP up over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を劇的に増加する。\n② 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% + 3% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 65% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31367",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice Techs by 30% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts Ice Techs by 40% + 4% x this chip's ability\n     level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31368",
 		"jp_explainShort": "ＣＰ消費減＋アビリティレベル氷法術劇的強化",
 		"tr_explainShort": "CP use down + Ice Tech boost x ability",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 氷属性の法術の威力を劇的に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice Techs by 50% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts Ice Techs by 60% + 4% x this chip's ability\n     level.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Ice Techs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31369",
 		"jp_explainShort": "攻撃絶大増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage against bosses by a further 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n③  Reduces damage taken from bosses by 5% x the\n     number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31370",
 		"jp_explainShort": "攻撃超絶増＋ボス時に炎チップ数で能力上昇",
 		"tr_explainShort": "Dam. boost + boost, res. vs boss x # Fire",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n③ ボス戦時は装備中の炎属性チップの枚数に応じて\n　　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage against bosses by a further 10% x\n     the number of Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n③  Reduces damage taken from bosses by 5% x the\n     number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage against bosses based on\n    the number of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n③ Reduces damage taken from bosses based on the\n    number of Fire chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31371",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 100% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31372",
 		"jp_explainShort": "アビリティレベル攻撃増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP regen up",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 110% + 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 120% + 4% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31373",
 		"jp_explainShort": "法術劇的強化＋一定確率で回避",
 		"tr_explainShort": "Tech boost + chance to avoid damage",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 35% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31374",
 		"jp_explainShort": "法術劇的強化＋一定確率で回避",
 		"tr_explainShort": "Tech boost + chance to avoid damage",
 		"jp_explainLong": "① 法術の威力を劇的に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 45% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31375",
 		"jp_explainShort": "消費ＣＰ減少＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31376",
 		"jp_explainShort": "消費ＣＰ減少＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP usage down + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31377",
 		"jp_explainShort": "攻撃力絶大増加＋炎属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Fire weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31378",
 		"jp_explainShort": "攻撃力絶大増加＋炎属性武器で攻撃力増加",
 		"tr_explainShort": "Damage boosted + Fire weapons boosted",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 さらに攻撃力を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 25% if using a Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31381",
 		"jp_explainShort": "闇属性大強化＋追加で大ダメージ",
 		"tr_explainShort": "Dark Element up + additional damage",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 70.\n②  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly increases Dark Element.\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31382",
 		"jp_explainShort": "闇属性劇的強化＋追加で特大ダメージ",
 		"tr_explainShort": "Dark Element up + additional damage",
 		"jp_explainLong": "① 闇属性を劇的に強化する。\n② 追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 80.\n<color=yellow>SP: </color>Increases your Dark Element by 90.\n②  Deals an additional 80% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 90% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically increases Dark Element.\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31383",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 120% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Immensely boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31384",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "[Burn] imbued + damage boost vs [Burn]",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 160% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Immensely boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31385",
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% + 0.333% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 130% + 0.333% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31386",
 		"jp_explainShort": "光属性値に応じて攻撃力超絶増加",
 		"tr_explainShort": "Damage boosted x Light Element",
 		"jp_explainLong": "① 光属性値に応じて攻撃力を超絶に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140% + 0.333% x your Light\n     Element.\n<color=yellow>SP: </color>Boosts damage by 150% + 0.333% x your Light\n     Element.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on your\n    Light Element value.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31387",
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31388",
 		"jp_explainShort": "追加特大ダメージ＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31391",
 		"jp_explainShort": "攻撃小増＋必殺技のＣＰ消費増加と劇的強化",
 		"tr_explainShort": "Dam. boost + PA&Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 必殺技・法術の威力を劇的に強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 80%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31392",
 		"jp_explainShort": "攻撃小増＋必殺技のＣＰ消費増加と劇的強化",
 		"tr_explainShort": "Dam. boost + PA&Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 必殺技・法術の威力を劇的に強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 90%.\n     <color=yellow>[A-Frame]</color>\n③  Increases the CP consumption of PAs and Techs\n     by 25%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31393",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力劇的増",
 		"tr_explainShort": "Damage boosted + boost at high CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 90% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further dramatically boosts damage while CP is\n    above a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31394",
 		"jp_explainShort": "攻撃力絶大増＋ＣＰ一定以上時攻撃力劇的増",
 		"tr_explainShort": "Damage boosted + boost at high CP",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＣＰが一定以上の場合はさらに攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 90% while CP is\n     above 50.\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further dramatically boosts damage while CP is\n    above a certain level.\n    <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31395",
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "Bullet Bow PA boost + actions quickened",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31396",
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "Bullet Bow PA boost + actions quickened",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31397",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "Gunslash PA boost + actions quickened",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31398",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "Gunslash PA boost + actions quickened",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31399",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Additional damage + 3 actions = ATK up",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31400",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "Additional damage + 3 actions = ATK up",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000)\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Greatly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Dramatic)\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31401",
 		"jp_explainShort": "攻撃力劇的増加＋チップ発動率上昇",
 		"tr_explainShort": "Damage boost + chip activation rates up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31402",
 		"jp_explainShort": "攻撃力劇的増加＋チップ発動率上昇",
 		"tr_explainShort": "Damage boost + chip activation rates up",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31403",
 		"jp_explainShort": "攻撃力劇的増加＋被ダメ―ジ時ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery on injury",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からダメージを受けた際にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 95%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% when you take damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP when you take damage\n    from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31404",
 		"jp_explainShort": "攻撃力劇的増加＋被ダメ―ジ時ＨＰ小回復",
 		"tr_explainShort": "Damage boost + HP recovery on injury",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 敵からダメージを受けた際にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 105%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% when you take damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP when you take damage\n    from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31407",
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Natives by 90%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Natives by 95%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 30%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 35%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31408",
 		"jp_explainShort": "海王種・原生種にダメージ劇的増加＋大軽減",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に与えるダメージを劇的に増加する。\n② 海王種と原生種から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids\n     and Natives by 100%.\n<color=yellow>SP: </color>Boosts damage against Oceanids\n     and Natives by 105%.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 40%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Oceanids\n    and Natives.\n    <color=yellow>[B-Frame]</color>\n② Greatly reduces damage taken from Oceanids\n    and Natives.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31411",
 		"jp_explainShort": "定期的に攻撃力が小増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n<color=yellow>SP: </color>Boosts damage by 29% every 3 seconds.\n     (Maximum boost: 170%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31412",
 		"jp_explainShort": "定期的に攻撃力が増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n<color=yellow>SP: </color>Boosts damage by 32% every 3 seconds.\n     (Maximum boost: 190%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31413",
 		"jp_explainShort": "攻撃力超絶増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31414",
 		"jp_explainShort": "攻撃力超絶増加＋ＣＰ最大値増加",
 		"tr_explainShort": "Damage boosted + maximum CP increased",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum CP by 60.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31415",
 		"jp_explainShort": "ジャストアタックごと攻撃力小強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP increased",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力をわずかに強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 20 x this chip's ability\n     level.\n<color=yellow>SP: </color>Increases your ATK by 30 x this chip's ability\n     level.\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly increases ATK based on this chip's ability\n    level.\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31416",
 		"jp_explainShort": "ジャストアタックごと攻撃力強化＋ＣＰ最大増",
 		"tr_explainShort": "ATK up + maximum CP increased",
 		"jp_explainLong": "① アビリティレベルに応じて、ジャストアタックごとに\n　　 攻撃力を強化する。\n② ＣＰの最大値を増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 40 x this chip's ability\n     level.\n<color=yellow>SP: </color>Increases your ATK by 60 x this chip's ability\n     level.\n②  Increases your maximum CP by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Increases ATK based on this chip's ability level.\n② Increases your maximum CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31421",
 		"jp_explainShort": "攻撃力超絶増＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ジャストアタックで与えたダメージの一部を\n　　 自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 205%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.1% of damage dealt by Just Attacks\n     as HP.\n     (Maximum recovery: 3% of your max HP).\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt by Just\n    Attacks as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31422",
 		"jp_explainShort": "攻撃力超絶増＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② ジャストアタックで与えたダメージの一部を\n　　 自身のＨＰとして回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 215%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 0.1% of damage dealt by Just Attacks\n     as HP.\n     (Maximum recovery: 3% of your max HP).\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt by Just\n    Attacks as HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31423",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 60% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31424",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Mirage].\n② Dramatically boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31429",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50%.\n<color=yellow>SP: </color>Boosts damage by 60%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     32% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31430",
 		"jp_explainShort": "攻撃力劇的増加＋ダメージ防御",
 		"tr_explainShort": "Damage boosted + barrier",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     34% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     36% of your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31431",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 5%.\n<color=yellow>SP: </color>Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31432",
 		"jp_explainShort": "消費ＣＰ減少＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "CP use down + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 105% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 15%.\n<color=yellow>SP: </color>Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31433",
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 3% x this\n     chip's  ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31434",
 		"jp_explainShort": "ＨＰが小回復＋必殺技が大強化",
 		"tr_explainShort": "HP recovery + PAs boosted",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 15% + 3% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31435",
 		"jp_explainShort": "全種族に対してダメージが増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against all races by 20% +\n     1% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against all races by 25% +\n     1% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against all races based on this\n    chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31436",
 		"jp_explainShort": "全種族に対してダメージが大増加",
 		"tr_explainShort": "Damage boosted vs all races",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 すべての種族に与えるダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against all races by 30% +\n     1% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against all races by 35% +\n     1% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage against all races based\n    on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31439",
 		"jp_explainShort": "追加ダメージ＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Add. dam. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 125% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31440",
 		"jp_explainShort": "追加ダメージ＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Add. dam. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 135% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31441",
 		"jp_explainShort": "ダメージ軽減＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Damage resist + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31442",
 		"jp_explainShort": "ダメージ軽減＋光弱点時ダメージ絶大増加",
 		"tr_explainShort": "Damage resist + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31445",
 		"jp_explainShort": "攻撃力大増加＋氷風闇の技・法の威力大増",
 		"tr_explainShort": "Dam. boost + Ice/Wind/Dark move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが氷・風・闇属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Ice, Wind and Dark PAs and Techs by 45%.\n<color=yellow>SP: </color>Boosts Ice, Wind and Dark PAs and Techs by 50%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts Ice, Wind and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31446",
 		"jp_explainShort": "攻撃力大増加＋氷風闇の技・法の威力大増",
 		"tr_explainShort": "Dam. boost + Ice/Wind/Dark move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが氷・風・闇属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Ice, Wind and Dark PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts Ice, Wind and Dark PAs and Techs by 60%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Boosts Ice, Wind and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31447",
 		"jp_explainShort": "炎属性上限上昇＋炎弱点時ダメージ絶大増加",
 		"tr_explainShort": "Fire weakness boosted, max value up",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31448",
 		"jp_explainShort": "炎属性上限上昇＋炎弱点時ダメージ絶大増加",
 		"tr_explainShort": "Fire weakness boosted, max value up",
 		"jp_explainLong": "① 攻撃対象の敵が炎属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Fire.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Fire.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Fire.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31449",
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 10% x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 20% + 10% x the number of\n     Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.2% damage to enemies x\n     your Fire Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31450",
 		"jp_explainShort": "炎チップ数攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Dam. boost x # Fire + add. dam. x Fire",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 炎属性値に応じて敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% + 10% x the number of\n     Fire chips equipped.\n<color=yellow>SP: </color>Boosts damage by 40% + 10% x the number of\n     Fire chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.2% damage to enemies x\n     your Fire Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage based on the number\n    of Fire chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals additional damage to enemies based on\n    your Fire Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31451",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 85% + 20% x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 105% + 20% x the number of\n     Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31452",
 		"jp_explainShort": "消費ＣＰ減少＋風チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + damage boost x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 125% + 20% x the number of\n     Wind chips equipped.\n<color=yellow>SP: </color>Boosts damage by 145% + 20% x the number of\n     Wind chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31455",
 		"jp_explainShort": "攻撃力劇的増加＋追加ダメージ効果小増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 115%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     20%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     25%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31456",
 		"jp_explainShort": "攻撃力絶大増加＋追加ダメージ効果増加",
 		"tr_explainShort": "Damage boosted + add. damage boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     30%.\n<color=yellow>SP: </color>Increases the strength of all <color=yellow>[Chase]</color> effects by\n     35%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases the strength of all <color=yellow>[Chase]</color> effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31459",
 		"jp_explainShort": "ダメージ軽減＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Damage resist + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31460",
 		"jp_explainShort": "ダメージ軽減＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Damage resist + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31461",
 		"jp_explainShort": "氷属性上限上昇＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Ice weakness boosted, maximum value up",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31462",
 		"jp_explainShort": "氷属性上限上昇＋氷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Ice weakness boosted, maximum value up",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31463",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 70% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31464",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31465",
 		"jp_explainShort": "ダメージ軽減＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. resist + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31466",
 		"jp_explainShort": "ダメージ軽減＋風弱点時ダメージ絶大増加",
 		"tr_explainShort": "Dam. resist + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31467",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 185%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 1% x the number of Ice chips\n     equipped each time a chip effect activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 2 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31468",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、装備中の\n　　 氷属性の枚数に応じてわずかに攻撃力を増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 195%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 1% x the number of Ice chips\n     equipped each time a chip effect activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 2 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage based on the number of\n    Ice chips equipped each time a chip effect\n    activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31469",
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "Damage boosted + always Just Attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31470",
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "Damage boosted + always Just Attack",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31471",
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 0.4% damage x the number of\n     Weaponoid Chips discovered in the Chip Lab.\n     (Maximum additional damage: 40%)\n<color=yellow>SP: </color>(Maximum additional damage: 60%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Deals heavy additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31472",
 		"jp_explainShort": "発見済みウェポノイドチップ数で追加ダメージ",
 		"tr_explainShort": "Add. damage x # Weaponoids discovered",
 		"jp_explainLong": "① チップ研究室において発見済みウェポノイドチップが\n　　 多いほど追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 0.4% damage x the number of\n     Weaponoid Chips discovered in the Chip Lab.\n     (Maximum additional damage: 80%)\n<color=yellow>SP: </color>(Maximum additional damage: 100%)\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage based on the\n    number of Weaponoid Chips discovered in\n    the Chip Lab.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31473",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31474",
 		"jp_explainShort": "追加大ダメージ＋風チップ数攻撃力絶大増加",
 		"tr_explainShort": "Add. damage + damage boot x # Wind",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of Wind chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31477",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 45% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31478",
 		"jp_explainShort": "追加特大ダメージ＋有効弱点時ダメージ大増",
 		"tr_explainShort": "Weakness boosted + additional damage",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 55% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 26 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31479",
 		"jp_explainShort": "攻撃力大増加＋炎雷光の技・法の威力大増",
 		"tr_explainShort": "Dam. + Fire/Lightning/Light move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが炎・雷・光属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Lightning and Light PAs and Techs by\n     45%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Light PAs and Techs by\n     50%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts Fire, Lightning and Light PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31480",
 		"jp_explainShort": "攻撃力大増加＋炎雷光の技・法の威力大増",
 		"tr_explainShort": "Dam. + Fire/Lightning/Light move boost",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 必殺技・法術チップが炎・雷・光属性の場合は\n　　 威力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Lightning and Light PAs and Techs by\n     55%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Light PAs and Techs by\n     60%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts Fire, Lightning and Light PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31481",
 		"jp_explainShort": "雷属性上限上昇＋雷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Lightning weakness boosted, max up",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Lightning value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31482",
 		"jp_explainShort": "雷属性上限上昇＋雷弱点時ダメージ絶大増加",
 		"tr_explainShort": "Lightning weakness boosted, max up",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 180% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 190% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Lightning value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31487",
 		"jp_explainShort": "機甲種にダメージ劇的増＋弱点属性大強化",
 		"tr_explainShort": "Dam. boost vs Mechs + weak Elem. up",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 105%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 50.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 60.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31488",
 		"jp_explainShort": "機甲種にダメージ劇的増＋弱点属性大強化",
 		"tr_explainShort": "Dam. boost vs Mechs + weak Elem. up",
 		"jp_explainLong": "① 機甲種に与えるダメージを劇的に増加する。\n② 攻撃対象の敵の弱点属性を大きく強化する。\n[発動条件]機甲種に攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Mechs by 115%.\n<color=yellow>SP: </color>Boosts damage against Mechs by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 70.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 80.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases the target's weakness\n    Element value.\n[Activation Trigger] Landing attacks on Mechs\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31489",
 		"jp_explainShort": "追加ダメージ＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31490",
 		"jp_explainShort": "追加ダメージ＋光弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Light weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31491",
 		"jp_explainShort": "全属性を小強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements by 15.\n<color=yellow>SP: </color>Increases all Elements by 20.\n②  Deals an addititional 5% damage to enemies x\n     the number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31492",
 		"jp_explainShort": "全属性を強化＋属性種類数追加ダメージ",
 		"tr_explainShort": "All Elems up + add. damage x # Elements",
 		"jp_explainLong": "① 全属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加でダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements by 25.\n<color=yellow>SP: </color>Increases all Elements by 30.\n②  Deals an addititional 5% damage to enemies x\n     the number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases all elements.\n② Deals addititional damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31493",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋炎属性大強化",
 		"tr_explainShort": "Damage boost vs Darkers + Fire Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 炎属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 110%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Fire Element by 50.\n<color=yellow>SP: </color>Increases your Fire Element by 60.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Fire Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31494",
 		"jp_explainShort": "ダーカーにダメージ劇的増加＋炎属性大強化",
 		"tr_explainShort": "Damage boost vs Darkers + Fire Elem. up",
 		"jp_explainLong": "① ダーカーに与えるダメージを劇的に増加する。\n② 炎属性を大きく強化する。\n[発動条件]ダーカーに攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 115%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 120%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Fire Element by 70.\n<color=yellow>SP: </color>Increases your Fire Element by 80.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Greatly increases Fire Element.\n[Activation Trigger] Landing attacks on Darkers\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31495",
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 170% + 5% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 180% + 5% x the number of\n     Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31496",
 		"jp_explainShort": "消費ＣＰ減少＋氷チップ数攻撃力超絶増加",
 		"tr_explainShort": "CP use down + dam. boost x # Ice chips",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 190% + 5% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts damage by 200% + 5% x the number of\n     Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 40%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of Ice chips equipped.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31497",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31498",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31501",
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 35% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31502",
 		"jp_explainShort": "アビリティレベル攻撃大増＋ＣＰ回復速度強化",
 		"tr_explainShort": "Dam. boost x ability level + CP recovery",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を大きく増加する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 45% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Dramatically increases CP regeneration.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31503",
 		"jp_explainShort": "ダメージ軽減＋闇弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵からのダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 100% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31504",
 		"jp_explainShort": "ダメージ軽減＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Add. damage + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 敵からのダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% against enemies that are\n     weak to Dark.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies that are\n     weak to Dark.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies\n    that are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31505",
 		"jp_explainShort": "追加ダメージ＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31506",
 		"jp_explainShort": "追加ダメージ＋風弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Wind weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が風属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Wind.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Wind.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Wind.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31511",
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 200% + 5% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 205% + 5% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31512",
 		"jp_explainShort": "ＨＰ小回復＋属性種類数攻撃力超絶増加",
 		"tr_explainShort": "HP recovery + dam. boost x # Elements",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を超絶に増加する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 210% + 5% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 215% + 5% x the number of\n     different chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage based on the\n    number of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31513",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids and Natives by\n     15% + 2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against Oceanids and Natives by\n     20% + 2% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 20%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 25%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against Oceanids and Natives\n    based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31514",
 		"jp_explainShort": "海王種・原生種に軽減＋ダメージ大増加",
 		"tr_explainShort": "Dam. boost, resist vs Oceanids & Natives",
 		"jp_explainLong": "① 海王種と原生種に\n　　 アビリティレベルに応じ与えるダメージを大きく増加する。\n② 海王種と原生種から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Oceanids and Natives by\n     25% + 2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against Oceanids and Natives by\n     30% + 2% x this chip's ability level.\n     <color=yellow>[B-Frame]</color>\n②  Reduces damage taken from Oceanids and\n     Natives by 25%.\n<color=yellow>SP: </color>Reduces damage taken from Oceanids and\n     Natives by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Oceanids and\n    Natives based on this chip's ability level.\n    <color=yellow>[B-Frame]</color>\n② Reduces damage taken from Oceanids and\n    Natives.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31515",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 120%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31516",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力絶大強化",
 		"tr_explainShort": "CP usage down + PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 160%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 180%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31521",
 		"jp_explainShort": "追加ダメージ＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31522",
 		"jp_explainShort": "追加ダメージ＋氷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. damage + Ice weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31525",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + act rate up + CP use down",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n③  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31526",
 		"jp_explainShort": "攻撃力劇的増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + act rate up + CP use down",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 110%.\n<color=yellow>SP: </color>Boosts damage by 120%.\n     <color=yellow>[E-Frame]</color>\n②  Increases activation rate of all Support Chips by\n     20%.\n③  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31527",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. res. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31528",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ劇的増加",
 		"tr_explainShort": "Dam. res. + elemental weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 100% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces damage taken from enemies by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31529",
 		"jp_explainShort": "追加ダメージ＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. dam. + Lightning weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31530",
 		"jp_explainShort": "追加ダメージ＋雷弱点時ダメージ劇的増加",
 		"tr_explainShort": "Add. dam. + Lightning weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が雷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 95% against enemies that are\n     weak to Lightning.\n<color=yellow>SP: </color>Boosts damage by 105% against enemies that are\n     weak to Lightning.\n     <color=yellow>[D-Frame]</color>\n②  Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Lightning.\n    <color=yellow>[D-Frame]</color>\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31531",
 		"jp_explainShort": "攻撃力劇的増＋炎氷風の技・法威力絶大増",
 		"tr_explainShort": "Damage + Fire/Ice/Wind PA&Tech boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Ice and Wind PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 135%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Fire, Ice and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31532",
 		"jp_explainShort": "攻撃力劇的増＋炎氷風の技・法威力絶大増",
 		"tr_explainShort": "Damage + Fire/Ice/Wind PA&Tech boost",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Fire, Ice and Wind PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 145%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Fire, Ice and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31535",
 		"jp_explainShort": "弱点属性小強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性をわずかに強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 15.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 20.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     5% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31536",
 		"jp_explainShort": "弱点属性強化＋追加ダメージ効果増加",
 		"tr_explainShort": "Weak Element up + add. damage boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を強化する。\n② 装備中チップの属性種類数に応じて\n　　 追加ダメージ威力をそれぞれ増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 25.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 30.\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     5% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases the enemy's weakness element.\n② Increases the strength of all <color=yellow>[Chase]</color> effects\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31537",
 		"jp_explainShort": "氷雷闇の技・法の威力絶大増",
 		"tr_explainShort": "Ice/Lightning/Dark PA & Tech boost",
 		"jp_explainLong": "① 必殺技・法術チップが氷・雷・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice, Lightning and Dark PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Ice, Lightning and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Ice, Lightning and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31538",
 		"jp_explainShort": "氷雷闇の技・法の威力絶大増",
 		"tr_explainShort": "Ice/Lightning/Dark PA & Tech boost",
 		"jp_explainLong": "① 必殺技・法術チップが氷・雷・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice, Lightning and Dark PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Ice, Lightning and Dark PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Ice, Lightning and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31541",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP use down + dam. boost + no status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 大剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31542",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP use down + dam. boost + no status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 大剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31545",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 28% every 3 seconds.\n     (Maximum boost: 165%)\n<color=yellow>SP: </color>Boosts damage by 31% every 3 seconds.\n     (Maximum boost: 185%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31546",
 		"jp_explainShort": "定期的に攻撃力を増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% every 3 seconds.\n     (Maximum boost: 195%)\n<color=yellow>SP: </color>Boosts damage by 36% every 3 seconds.\n     (Maximum boost: 215%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31547",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31548",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Additional damage + actions quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31549",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31550",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力絶大増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]アクティブチップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 180%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 9 seconds.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating an Active Chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31551",
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 45% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 50% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31552",
 		"jp_explainShort": "属性数攻撃力絶大増＋覇滅種にダメージ大増",
 		"tr_explainShort": "Damage boost + dam. boost vs Superior",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 覇滅種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 55% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 60% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31553",
 		"jp_explainShort": "攻撃力劇的増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 15% each time you use a PA\n     or Tech.\n     (Maximum boost: 75%)\n<color=yellow>SP: </color>Boosts damage by 20% each time you use a PA\n     or Tech.\n     (Maximum boost: 100%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Dramatic)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31554",
 		"jp_explainShort": "攻撃力劇的増＋必殺技・法術使用毎に小増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 75%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 25% each time you use a PA\n     or Tech.\n     (Maximum boost: 125%)\n<color=yellow>SP: </color>Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31557",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 25% every 3 seconds.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 27% every 3 seconds.\n     (Maximum boost: 160%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31558",
 		"jp_explainShort": "定期的に攻撃力を小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted over time + dam. resist",
 		"jp_explainLong": "① 定期的に攻撃力をわずかに増加する。（最大時：絶大）\n② 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 29% every 3 seconds.\n     (Maximum boost: 170%)\n<color=yellow>SP: </color>Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n     <color=yellow>[G-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Slightly boosts damage at regular intervals.\n    (Maximum boost: Immense)\n    <color=yellow>[G-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31559",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31560",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は光属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     Light PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    Light PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31561",
 		"jp_explainShort": "攻撃力が極度に増加＋光属性上限上昇",
 		"tr_explainShort": "Damage boosted + maximum Light up",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② リンクスロットに装備したチップの属性が\n　　 光属性の場合、光属性の上限値が上昇する。\n③ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Increases your maximum Light value by 20 if\n     there is a Light chip in this chip's link slot.\n③  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Increases your maximum Light value if there is a\n    Light chip in this chip's link slot.\n③ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31562",
 		"jp_explainShort": "攻撃力超絶増＋定期ＨＰ小回復＋ダウン無効",
 		"tr_explainShort": "Dam. boost + HP recov. + no knockdown",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 205%.\n<color=yellow>SP: </color>Boosts damage by 215%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 5% every 4.8 seconds.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31563",
 		"jp_explainShort": "攻撃力超絶増＋定期ＨＰ小回復＋ダウン無効",
 		"tr_explainShort": "Dam. boost + HP recov. + no knockdown",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 225%.\n<color=yellow>SP: </color>Boosts damage by 235%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 5% every 4.8 seconds.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31564",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     5% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     6% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + actions quickened",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     7% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     8% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31568",
 		"jp_explainShort": "技・法威力大強化＋光弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\r\n　　 与えるダメージを劇的に増加する。\r\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\r\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31569",
 		"jp_explainShort": "技・法威力大強化＋光弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + Light weakness boost",
 		"jp_explainLong": "① 攻撃対象の敵が光属性弱点の場合に\r\n　　 与えるダメージを劇的に増加する。\r\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 85% against enemies that are\n     weak to Light.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies that are\n     weak to Light.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Light.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31572",
 		"jp_explainShort": "攻撃力絶大増＋消費ＣＰ減少＋ダメージ軽減",
 		"tr_explainShort": "Dam. boost + CP use down + dam. res.",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 190%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 20%.\n③  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31573",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減少＋ダメージ軽減",
 		"tr_explainShort": "Dam. boost + CP use down + dam. res.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 210%.\n<color=yellow>SP: </color>Boosts damage by 220%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 20%.\n③  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Reduces damage taken from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31574",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が劇的強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by up to 5000 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 6000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31575",
 		"jp_explainShort": "ターゲットとの距離によって攻撃力が絶大強化",
 		"tr_explainShort": "ATK up x proximity to target",
 		"jp_explainLong": "① ターゲットしている敵との距離が近いほど\n　　 攻撃力を絶大に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by up to 7000 based on\n     how close you are to the target.\n<color=yellow>SP: </color>Increases your ATK by up to 8000 based on\n     how close you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely increases ATK based on how close\n    you are to the target.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31579",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31580",
 		"jp_explainShort": "ＨＰ小回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31583",
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31584",
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs status",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 80% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31585",
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 25% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Raises the activation rate of all Support Chips by\n     50%.\n③  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31586",
 		"jp_explainShort": "攻撃力絶大増加＋消費ＣＰ減少＋発動率上昇",
 		"tr_explainShort": "Dam. boost + CP use down + act. rate up",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 攻撃力を絶大に増加する。\n② 発動率を上昇する。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% x the number of different\n     chip elements equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of different\n     chip elements equipped.\n     <color=yellow>[E-Frame]</color>\n②  Raises the activation rate of all Support Chips by\n     50%.\n③  Reduces CP consumption by 50%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on the number\n    of different chip elements equipped.\n    <color=yellow>[E-Frame]</color>\n② Raises the activation rate of all Support Chips.\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31587",
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 145% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 155% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31588",
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 175% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31591",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ劇的増",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 必殺技にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict random status\n     effects.\n②  Boosts damage by 110% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict random status\n    effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31592",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 必殺技にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict random status\n     effects.\n②  Boosts damage by 150% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 170% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict random status\n    effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31593",
 		"jp_explainShort": "有効弱点属性武器で攻撃力が劇的増加",
 		"tr_explainShort": "Weapon elemental weakness boosted",
 		"jp_explainLong": "① 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80% if the equipped weapon's\n     element matches the target's elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 90% if the equipped weapon's\n     element matches the target's elemental weakness.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage when your\n    weapon's Element matches the target's\n    elemental weakness.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31594",
 		"jp_explainShort": "有効弱点属性武器で攻撃力が劇的増加",
 		"tr_explainShort": "Weapon elemental weakness boosted",
 		"jp_explainLong": "① 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100% if the equipped weapon's\n     element matches the target's elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 110% if the equipped weapon's\n     element matches the target's elemental weakness.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage when your\n    weapon's Element matches the target's\n    elemental weakness.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31595",
 		"jp_explainShort": "攻撃力絶大増＋被状態異常時攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + boost when under status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身が状態異常の場合に攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 130%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 80% while you are affected by\n     a status effect.\n     <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage while you are\n    affected by a status effect.\n    <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31596",
 		"jp_explainShort": "攻撃力絶大増＋被状態異常時攻撃力劇的増",
 		"tr_explainShort": "Dam. boost + boost when under status",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身が状態異常の場合に攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 80% while you are affected by\n     a status effect.\n     <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage while you are\n    affected by a status effect.\n    <color=yellow>[O-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31597",
 		"jp_explainShort": "闇属性上限上昇＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Max Dark up + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against enemies that\n     are weak to Dark by 160%.\n<color=yellow>SP: </color>Boosts damage against enemies that\n     are weak to Dark by 170%.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Dark value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies that\n    are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Dark value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31598",
 		"jp_explainShort": "闇属性上限上昇＋闇弱点時ダメージ絶大増加",
 		"tr_explainShort": "Max Dark up + Dark weakness boosted",
 		"jp_explainLong": "① 攻撃対象の敵が闇属性弱点の場合に\n　　 与えるダメージを絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against enemies that\n     are weak to Dark by 180%.\n<color=yellow>SP: </color>Boosts damage against enemies that\n     are weak to Dark by 190%.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum Dark value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemies that\n    are weak to Dark.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum Dark value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31601",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 85% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 5 every 4.9 seconds.\n<color=yellow>SP: </color>Recovers CP by 7 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31602",
 		"jp_explainShort": "アビリティレベル攻撃絶大増＋定期ＣＰ回復",
 		"tr_explainShort": "Dam. boost x ability level + CP over time",
 		"jp_explainLong": "① アビリティレベルに応じて攻撃力を絶大に増加する。\n② 定期的にＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 95% + 5% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts damage by 105% + 5% x this chip's ability\n     level.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 8 every 4.9 seconds.\n<color=yellow>SP: </color>Recovers CP by 10 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage based on this chip's\n    ability level.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31603",
 		"jp_explainShort": "攻撃力劇的強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 5000.\n<color=yellow>SP: </color>Increases your ATK by 5500.\n②  Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31604",
 		"jp_explainShort": "攻撃力絶大強化＋属性種類数追加大ダメージ",
 		"tr_explainShort": "ATK up + additional damage x # Elems",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 6000.\n<color=yellow>SP: </color>Increases your ATK by 6500.\n②  Deals an additional 10% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely increases ATK.\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31607",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 必殺技に「ミラージュ」効果を与える。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Mirage].\n②  Boosts damage by 90% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31608",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "[Mirage] imbued + dam. boost vs [Mirage]",
 		"jp_explainLong": "① 必殺技に「ミラージュ」効果を与える。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Mirage].\n②  Boosts damage by 110% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Mirage].\n② Greatly boosts damage against enemies\n    affected by [Mirage].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31611",
 		"jp_explainShort": "攻撃大増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55%.\n<color=yellow>SP: </color>Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies\n     x your Lightning Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31612",
 		"jp_explainShort": "攻撃劇的増＋属性追加ダメージ",
 		"tr_explainShort": "Damage boost + add. damage x Lightning",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 雷属性値に応じて敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 75%.\n<color=yellow>SP: </color>Boosts damage by 85%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 0.25% damage to enemies\n     x your Lightning Element.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals massive additional damage to enemies\n    based on your Lightning Element value.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31613",
 		"jp_explainShort": "炎雷風技法威力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 120%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 130%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31614",
 		"jp_explainShort": "炎雷風技法威力絶大増＋大追撃＋消費ＣＰ減",
 		"tr_explainShort": "Fi/Ln/Wi boost + dam. res. + CP usage",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で大ダメージを与える。\n③ 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 140%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 150%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31615",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 抜剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31616",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 抜剣を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with a Sword.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31617",
 		"jp_explainShort": "技法威力絶大強化＋ダメージ減＋ＨＰ小回復",
 		"tr_explainShort": "Tech&PA boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31618",
 		"jp_explainShort": "技法威力絶大強化＋ダメージ減＋ＨＰ小回復",
 		"tr_explainShort": "Tech&PA boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 155%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 165%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31619",
 		"jp_explainShort": "攻撃力絶大増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② チップが発動するたびに、攻撃力をわずかに増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 195%.\n<color=yellow>SP: </color>Boosts damage by 200%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% each time a chip effect\n     activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 3 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31620",
 		"jp_explainShort": "攻撃力超絶増＋チップ発動時効果時間延長",
 		"tr_explainShort": "Dam. boost, longer & higher x chip activs",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② チップが発動するたびに、攻撃力をわずかに増加する。\n③ チップが発動するたびに、効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 205%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 5% each time a chip effect\n     activates.\n     <color=yellow>[E-Frame]</color>\n③  Extends this effect's Effect Duration by 3 seconds\n     each time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly boosts damage each time a chip\n    effect activates.\n    <color=yellow>[E-Frame]</color>\n③ Extends this effect's Effect Duration each\n    time a chip effect activates.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31621",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 240%.\n<color=yellow>SP: </color>Boosts damage by 245%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31622",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31623",
 		"jp_explainShort": "攻撃力超絶増＋技法威力大強化＋ＣＰ消費増",
 		"tr_explainShort": "Dam. boost + PA/Tech boost, CP use up",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 必殺技・法術の威力を大きく強化する。\n③ 必殺技・法術のＣＰ消費量を増加する。\n④ リンクスロットに装備したチップの属性が\n　　 雷属性の場合に③の効果を無効にする。\n⑤ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n③  Increases CP consumption of PAs and Techs by\n     15%.\n④  If there is a Lightning chip in this chip's link slot,\n     the effect of ③ is not applied.\n⑤  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n③ Increases CP consumption of PAs and Techs.\n④ If there is a Lightning chip in this chip's link slot,\n    the effect of ③ is not applied.\n⑤ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31626",
 		"jp_explainShort": "風光闇の技・法の威力絶大増",
 		"tr_explainShort": "Wind/Light/Dark PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Wind, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31627",
 		"jp_explainShort": "風光闇の技・法の威力絶大増",
 		"tr_explainShort": "Wind/Light/Dark PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Wind, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31628",
 		"jp_explainShort": "雷光武器攻撃力絶大増＋ダーカー大ダメージ",
 		"tr_explainShort": "Light/Lightning wep boost + vs Darkers",
 		"jp_explainLong": "① 装備中の武器の属性が雷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② ダーカーに与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120% if using a Lightning or\n     Light weapon.\n<color=yellow>SP: </color>Boosts damage by 140% if using a Lightning or\n     Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Lightning or\n    Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31629",
 		"jp_explainShort": "雷光武器攻撃力絶大増＋ダーカー大ダメージ",
 		"tr_explainShort": "Light/Lightning wep boost + vs Darkers",
 		"jp_explainLong": "① 装備中の武器の属性が雷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② ダーカーに与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 160% if using a Lightning or\n     Light weapon.\n<color=yellow>SP: </color>Boosts damage by 180% if using a Lightning or\n     Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Lightning or\n    Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31630",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31631",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は炎属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     Fire PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Fire PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31632",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が炎属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Fire chip in this chip's\n     link slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Fire chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31636",
 		"jp_explainShort": "攻撃力絶大増加＋ＨＰ小回復＋ＣＰ回復",
 		"tr_explainShort": "Damage boosted + HP & CP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31637",
 		"jp_explainShort": "攻撃力絶大増加＋ＨＰ小回復＋ＣＰ回復",
 		"tr_explainShort": "Damage boosted + HP & CP recovery",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 145%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10%.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31638",
 		"jp_explainShort": "追加特大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 110% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     50%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31639",
 		"jp_explainShort": "追加絶大ダメージ＋追加ダメージ効果大増加",
 		"tr_explainShort": "Additional damage + add. damage boosted",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 装備中チップの追加ダメージ威力を\n　　 それぞれ大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 130% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 140% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Increases the strength of all <color=yellow>[Chase]</color> effects by\n     50%.\n     <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly increases the strength of all <color=yellow>[Chase]</color>\n    effects.\n    <color=yellow>[Chase Boost]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31640",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力小強化",
 		"tr_explainShort": "CP usage down + PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力をわずかに強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 10%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31641",
 		"jp_explainShort": "消費ＣＰ減少＋必殺技と法術の威力強化",
 		"tr_explainShort": "CP usage down + PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 35%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 40%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces CP consumption by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31642",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技大強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を大きく強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 20% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 30% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts PAs based on this chip's ability\n    level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31643",
 		"jp_explainShort": "ＨＰ回復＋アビリティレベル必殺技劇的強化",
 		"tr_explainShort": "HP recovery + PA boost x ability level",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 必殺技の威力を劇的に強化する。\n② ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 40% + 4% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts the power of PAs by 50% + 4% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs based on this chip's\n    ability level.\n    <color=yellow>[A-Frame]</color>\n② Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31648",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加絶大ダメージ",
 		"tr_explainShort": "HP recovery + CP recovery + add. dam.",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 130% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 140% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 8%.\n<color=yellow>SP: </color>Recovers HP by 10%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31649",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加絶大ダメージ",
 		"tr_explainShort": "HP recovery + CP recovery + add. dam.",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 150% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 160% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 12%.\n<color=yellow>SP: </color>Recovers HP by 15%.\n③  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31650",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 27% each time you use a PA\n     or Tech.\n     (Maximum boost: 135%)\n<color=yellow>SP: </color>Boosts damage by 29% each time you use a PA\n     or Tech.\n     (Maximum boost: 145%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31651",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 31% each time you use a PA\n     or Tech.\n     (Maximum boost: 155%)\n<color=yellow>SP: </color>Boosts damage by 33% each time you use a PA\n     or Tech.\n     (Maximum boost: 165%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31654",
 		"jp_explainShort": "炎氷風の技・法の威力劇的増＋大追撃",
 		"tr_explainShort": "Fire/Ice/Wind moves boosted + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Wind PAs and Techs by 70%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 75%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Fire, Ice and Wind PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31655",
 		"jp_explainShort": "炎氷風の技・法の威力劇的増＋大追撃",
 		"tr_explainShort": "Fire/Ice/Wind moves boosted + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・風属性の場合は\n　　 威力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Wind PAs and Techs by 80%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Wind PAs and Techs by 85%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Boosts Fire, Ice and Wind PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31656",
 		"jp_explainShort": "絶大追撃＋海王種大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost vs Oceanids + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 海王種に与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 170% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Oceanids by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31657",
 		"jp_explainShort": "絶大追撃＋海王種大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Add. dam. + boost vs Oceanids + barrier",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 海王種に与えるダメージを大きく増加する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 175% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 180% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Boosts damage against Oceanids by 45%.\n     <color=yellow>[B-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals tremendous additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Greatly boosts damage against Oceanids.\n    <color=yellow>[B-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31658",
 		"jp_explainShort": "技法威力絶大強化＋有効弱点ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を絶大に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 135%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 140%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31659",
 		"jp_explainShort": "技法威力絶大強化＋有効弱点ダメージ劇的増",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を絶大に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 145%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 150%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31660",
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 30% damage to enemies +\n     1% x this chip's ability level.\n     <color=yellow>[Chase]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31661",
 		"jp_explainShort": "アビリティレベル大追撃＋消費ＣＰ減少",
 		"tr_explainShort": "Add. damage x ability + CP usage down",
 		"jp_explainLong": "① アビリティレベルに応じて追加で大ダメージを与える。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 40% damage to enemies +\n     1% x this chip's ability level.\n     <color=yellow>[Chase]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies based\n    on this chip's ability level.\n    <color=yellow>[Chase]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31669",
 		"jp_explainShort": "種族必殺技・法術威力強化＋ダメージ防御",
 		"tr_explainShort": "PA & Tech boost vs Darkers + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 攻撃対象の敵がダーカーの場合\n　　 さらに必殺技・法術の威力を大きく強化する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 90%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 95%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts the power of PAs and Techs by a further\n     45% against Darkers.\n     <color=yellow>[A-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Further greatly boosts PAs and Techs\n    against Darkers.\n    <color=yellow>[A-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31670",
 		"jp_explainShort": "種族必殺技・法術威力強化＋ダメージ防御",
 		"tr_explainShort": "PA & Tech boost vs Darkers + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 攻撃対象の敵がダーカーの場合\n　　 さらに必殺技・法術の威力を大きく強化する。\n③ 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 100%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 105%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts the power of PAs and Techs by a further\n     45% against Darkers.\n     <color=yellow>[A-Frame]</color>\n③  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Further greatly boosts PAs and Techs\n    against Darkers.\n    <color=yellow>[A-Frame]</color>\n③ Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31671",
 		"jp_explainShort": "定期的に攻撃力を増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 190%)\n<color=yellow>SP: </color>Boosts damage by 35% every 3 seconds.\n     (Maximum boost: 210%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Immense)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31672",
 		"jp_explainShort": "定期的に攻撃力を増加",
 		"tr_explainShort": "Damage boosted over time",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：超絶）\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 37% every 3 seconds.\n     (Maximum boost: 220%)\n<color=yellow>SP: </color>Boosts damage by 40% every 3 seconds.\n     (Maximum boost: 240%)\n     <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31675",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ小増加",
 		"tr_explainShort": "Dam. resist + weakness damage boosted",
 		"jp_explainLong": "① 敵からのダメージを軽減する。\n② 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージをわずかに増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 25%.\n②  Boosts damage by 25% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n② Slightly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31676",
 		"jp_explainShort": "ダメージ軽減＋有効弱点時ダメージ増加",
 		"tr_explainShort": "Dam. resist + weakness damage boosted",
 		"jp_explainLong": "① 敵からのダメージを軽減する。\n② 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 35%.\n②  Boosts damage by 25% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n② Boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31679",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力小増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力をわずかに増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 20%.\n<color=yellow>SP: </color>Boosts power by 25%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31680",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 30%.\n<color=yellow>SP: </color>Boosts power by 35%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31681",
 		"jp_explainShort": "攻撃力劇的増加＋覇滅種にダメージ劇的増加",
 		"tr_explainShort": "Dam. boost + dam. boost against Superior",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 覇滅種に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 110% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 115% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Dramatically boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31682",
 		"jp_explainShort": "攻撃力劇的増加＋覇滅種にダメージ絶大増加",
 		"tr_explainShort": "Dam. boost + dam. boost against Superior",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 覇滅種に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 120% against Superior-type\n     enemies.\n<color=yellow>SP: </color>Boosts damage by 125% against Superior-type\n     enemies.\n     <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts damage against\n    Superior-type enemies.\n    <color=yellow>[J-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31683",
 		"jp_explainShort": "技法威力劇的強化＋ダメージ減＋ＨＰ回復",
 		"tr_explainShort": "PA & Tech boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 105%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 110%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31684",
 		"jp_explainShort": "技法威力劇的強化＋ダメージ減＋ＨＰ回復",
 		"tr_explainShort": "PA & Tech boost + dam. res. + HP recov.",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 受けるダメージを軽減する。\n③ ＨＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 115%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 120%.\n     <color=yellow>[A-Frame]</color>\n②  Reduces damage taken from enemies by 35%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 40%.\n③  Recovers HP by 15%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Reduces damage taken from enemies.\n③ Recovers HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31685",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental power by (1 + 0.005% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n<color=yellow>SP: </color>Boosts elemental power by (1 + 0.01% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n     <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31686",
 		"jp_explainShort": "属性種類・全属性値に応じ属性攻撃力超絶増",
 		"tr_explainShort": "Element damage boosted x # elements",
 		"jp_explainLong": "① 装備中チップの属性種類数と全属性の合計値に応じて\n　　 属性攻撃力を超絶に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental power by (1 + 0.015% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n<color=yellow>SP: </color>Boosts elemental power by (1 + 0.02% x the\n     number of different chip elements equipped) x\n     6.3 x the square root of your total Elements\n     (max. total: 1000).\n     <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of different chip elements\n    equipped.\n    <color=yellow>[R-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31687",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 15% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 17% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31688",
 		"jp_explainShort": "属性種類特大追撃＋カウンターダメージ",
 		"tr_explainShort": "Additional damage + countering attacks",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 攻撃対象の敵からダメージを受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 20% damage to enemies x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Deals an additional 22% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n②  When you take damage from the target,\n     responds by dealing 25% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31689",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 200% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 205% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31690",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 215% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 220% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31691",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "Rand. status + dam. status + elem. dam.",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 230% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 235% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all link slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks and PAs a chance to inflict\n    random status effects.\n② Overwhelmingly boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly boosts Lightning elemental damage\n    against enemies weak to Lightning based on the\n    number of Lightning chips in all link slots.\n    <color=yellow>[S-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31692",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 鋼拳を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31693",
 		"jp_explainShort": "消費ＣＰ減少＋攻撃力絶大増＋状態異常無効",
 		"tr_explainShort": "CP usage + dam. boost + status immune",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 消費ＣＰを減少する。\n③ 鋼拳を装備している場合\n　　 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 30%.\n③  Grants immunity to status effects when\n     equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Grants immunity to status effects when\n    equipped with Knuckles.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31694",
 		"jp_explainShort": "攻撃力絶大増＋闇光属性武器で攻撃力大増",
 		"tr_explainShort": "Dam. boost + Light/Dark weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光・闇の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% if equipped with a Light\n     or Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage if equipped with a Light\n    or Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31695",
 		"jp_explainShort": "攻撃力絶大増＋闇光属性武器で攻撃力大増",
 		"tr_explainShort": "Dam. boost + Light/Dark weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が光・闇の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% if equipped with a Light\n     or Dark weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage if equipped with a Light\n    or Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31696",
 		"jp_explainShort": "攻撃力絶大増加＋全アクティブチップ発動",
 		"tr_explainShort": "Damage boosted + all chips activated",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 120%.\n<color=yellow>SP: </color>Boosts damage by 125%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31697",
 		"jp_explainShort": "攻撃力絶大増加＋全アクティブチップ発動",
 		"tr_explainShort": "Damage boosted + all chips activated",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 必殺技・法術以外の全てのアクティブチップを発動する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Activates all active chips, excluding PAs & Techs.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31698",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 必殺技に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Panic].\n② Dramatically boosts damage against enemies\n    affected by [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31699",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "[Panic] imbued + dam. boost vs [Panic]",
 		"jp_explainLong": "① 必殺技に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Panic].\n②  Boosts damage by 110% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Panic].\n② Dramatically boosts damage against enemies\n    affected by [Panic].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31705",
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31706",
 		"jp_explainShort": "アビリティＬｖ光武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Light wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が光属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if equipped with a Light weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Light weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31707",
 		"jp_explainShort": "炎氷光技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Fire/Ice/Light move boost + CP use",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・光属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Light PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Light PAs and Techs by 90%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Fire, Ice and Light PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31708",
 		"jp_explainShort": "炎氷光技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Fire/Ice/Light move boost + CP use",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・光属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Light PAs and Techs by 95%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Light PAs and Techs by 100%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Fire, Ice and Light PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31709",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 35% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31710",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. damage + always JA + quickened",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 45% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies\n    based on the number of different chip elements\n    equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31715",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "Status imbued + dam. boost, res. vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 65% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly reduces damage taken from enemies\n    affected by status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31716",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "Status imbued + dam. boost, res. vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 75% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Dramatically boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n③ Greatly reduces damage taken from enemies\n    affected by status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31717",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Elem weak boost + max CP up & recov.",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 70% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 15.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31718",
 		"jp_explainShort": "有効弱点ダメージ劇的増＋ＣＰ最大増・回復",
 		"tr_explainShort": "Elem weak boost + max CP up & recov.",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを劇的に増加する。\n② ＣＰの最大値を増加する。\n③ ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 80% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Increases your maximum CP by 15.\n③  Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Increases your maximum CP.\n③ Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31719",
 		"jp_explainShort": "大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31720",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. + always JA + quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31721",
 		"jp_explainShort": "ダーカーにダメージ増加＋攻撃力劇的強化",
 		"tr_explainShort": "Damage boost vs Darkers + ATK up",
 		"jp_explainLong": "① ダーカーに与えるダメージを増加する。\n② 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 35%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 40%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your ATK by 5000.\n<color=yellow>SP: </color>Increases your ATK by 5500.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31722",
 		"jp_explainShort": "ダーカーにダメージ大増加＋攻撃力絶大強化",
 		"tr_explainShort": "Damage boost vs Darkers + ATK up",
 		"jp_explainLong": "① ダーカーに与えるダメージを大きく増加する。\n② 攻撃力を絶大に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Darkers by 40%.\n<color=yellow>SP: </color>Boosts damage against Darkers by 45%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your ATK by 6000.\n<color=yellow>SP: </color>Increases your ATK by 6500.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Darkers.\n    <color=yellow>[B-Frame]</color>\n② Immensely increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31723",
 		"jp_explainShort": "氷光武器攻撃力絶大増加＋氷属性上限上昇",
 		"tr_explainShort": "Ice/Light weapons boosted + max Ice up",
 		"jp_explainLong": "① 装備中の武器の属性が氷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 150% if using an Ice or Light\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 160% if using an Ice or Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Ice value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using an Ice or Light\n    weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31724",
 		"jp_explainShort": "氷光武器攻撃力絶大増加＋氷属性上限上昇",
 		"tr_explainShort": "Ice/Light weapons boosted + max Ice up",
 		"jp_explainLong": "① 装備中の武器の属性が氷・光属性の場合\n　　 攻撃力を絶大に増加する。\n② 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 170% if using an Ice or Light\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 180% if using an Ice or Light\n     weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Ice value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using an Ice or Light\n    weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31725",
 		"jp_explainShort": "ダーカー以外にダメージ劇的増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 105%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 125%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31726",
 		"jp_explainShort": "ダーカー以外にダメージ絶大増加",
 		"tr_explainShort": "Damage boosted vs non-Darkers",
 		"jp_explainLong": "① ダーカー以外に与えるダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against non-Darkers by 145%.\n<color=yellow>SP: </color>Boosts damage against non-Darkers by 165%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage against non-Darkers.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31727",
 		"jp_explainShort": "追加特大ダメージ＋ＣＰ回復",
 		"tr_explainShort": "Additional damage + CP recovered",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers CP by 14.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31728",
 		"jp_explainShort": "追加特大ダメージ＋ＣＰ回復",
 		"tr_explainShort": "Additional damage + CP recovered",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＣＰを回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers CP by 15.\n<color=yellow>SP: </color>Recovers CP by 16.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31731",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋ダメージ防御",
 		"tr_explainShort": "PAs & Techs boosted + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 65%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 75%.\n     <color=yellow>[A-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31732",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋ダメージ防御",
 		"tr_explainShort": "PAs & Techs boosted + barrier",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 85%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 95%.\n     <color=yellow>[A-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31736",
 		"jp_explainShort": "定期的に攻撃力を増加＋追加大ダメージ",
 		"tr_explainShort": "Boost over time + add. dam x # Elems",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：絶大）\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% every 3 seconds.\n     (Maximum boost: 180%)\n<color=yellow>SP: </color>Boosts damage by 32% every 3 seconds.\n     (Maximum boost: 190%)\n     <color=yellow>[G-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31737",
 		"jp_explainShort": "定期的に攻撃力を増加＋追加大ダメージ",
 		"tr_explainShort": "Boost over time + add. dam x # Elems",
 		"jp_explainLong": "① 定期的に攻撃力を増加する。（最大時：超絶）\n② 装備中チップの属性種類数に応じて\n　　 敵に追加で大ダメージを与える。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 34% every 3 seconds.\n     (Maximum boost: 200%)\n<color=yellow>SP: </color>Boosts damage by 35% every 3 seconds.\n     (Maximum boost: 210%)\n     <color=yellow>[G-Frame]</color>\n②  Deals an additional 8% damage to enemies x the\n     number of different chip elements equipped.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage at regular intervals.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[G-Frame]</color>\n② Deals heavy additional damage to enemies based\n    on the number of different chip elements equipped.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31738",
 		"jp_explainShort": "必殺技・法術の威力小強化＋ＨＰ小回復",
 		"tr_explainShort": "PAs & Techs boosted + HP recovered",
 		"jp_explainLong": "① 必殺技・法術の威力をわずかに強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 20%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 25%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31739",
 		"jp_explainShort": "必殺技・法術の威力強化＋ＨＰ小回復",
 		"tr_explainShort": "PAs & Techs boosted + HP recovered",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② ＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 30%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 35%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31740",
 		"jp_explainShort": "攻撃力大増加＋属性種類ダメージ軽減",
 		"tr_explainShort": "Dam. boost + dam. res x # Elems",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 5% x\n     the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies based on\n    the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31741",
 		"jp_explainShort": "攻撃力大増加＋属性種類ダメージ軽減",
 		"tr_explainShort": "Dam. boost + dam. res x # Elems",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中チップの属性種類数に応じて\n　 敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 5% x\n     the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies based on\n    the number of different chip elements equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31744",
 		"jp_explainShort": "アビリティＬｖ炎武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Fire weapon boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31745",
 		"jp_explainShort": "アビリティＬｖ炎武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Fire weapon boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31746",
 		"jp_explainShort": "氷光闇の技・法の威力絶大増＋特大追撃",
 		"tr_explainShort": "Ice/Light/Dark move boost + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが氷・光・闇属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice, Light and Dark PAs and Techs by\n     120%.\n<color=yellow>SP: </color>Boosts Ice, Light and Dark PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Ice, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31747",
 		"jp_explainShort": "氷光闇の技・法の威力絶大増＋特大追撃",
 		"tr_explainShort": "Ice/Light/Dark move boost + add. dam.",
 		"jp_explainLong": "① 必殺技・法術チップが氷・光・闇属性の場合は\n　　 威力を絶大に増加する。\n② 敵に追加で特大ダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice, Light and Dark PAs and Techs by\n     140%.\n<color=yellow>SP: </color>Boosts Ice, Light and Dark PAs and Techs by\n     150%.\n     <color=yellow>[K-Frame]</color>\n②  Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Ice, Light and Dark PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n② Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31755",
 		"jp_explainShort": "雷枚数攻撃力超絶強化＋機甲種大ダメージ",
 		"tr_explainShort": "ATK up x # Lightning + boost vs Mech",
 		"jp_explainLong": "① 装備中チップの雷属性チップの枚数に応じて\n　　 攻撃力を超絶に強化する。\n② 機甲種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 8250 + 500 x the\n     number of Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 9250 + 500 x the\n     number of Lightning chips equipped.\n②  Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK based on the\n    number of Lightning chips equipped.\n② Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31756",
 		"jp_explainShort": "雷枚数攻撃力超絶強化＋機甲種大ダメージ",
 		"tr_explainShort": "ATK up x # Lightning + boost vs Mech",
 		"jp_explainLong": "① 装備中チップの雷属性チップの枚数に応じて\n　　 攻撃力を超絶に強化する。\n② 機甲種に与えるダメージを大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 10250 + 500 x the\n     number of Lightning chips equipped.\n<color=yellow>SP: </color>Increases your ATK by 11250 + 500 x the\n     number of Lightning chips equipped.\n②  Boosts damage against Mechs by 50%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK based on the\n    number of Lightning chips equipped.\n② Greatly boosts damage against Mechs.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31761",
 		"jp_explainShort": "追加特大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Additional damage + barrier",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 80% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31762",
 		"jp_explainShort": "追加特大ダメージ＋ダメージ防御",
 		"tr_explainShort": "Additional damage + barrier",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 90% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 100% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31763",
 		"jp_explainShort": "雷風闇技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Ln/Wi/Da boost + CP usage down",
 		"jp_explainLong": "① 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning, Wind and Dark PAs and Techs\n     by 85%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 90%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts Lightning, Wind and Dark\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31764",
 		"jp_explainShort": "雷風闇技法威力劇的増加＋消費ＣＰ減少",
 		"tr_explainShort": "Ln/Wi/Da boost + CP usage down",
 		"jp_explainLong": "① 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を劇的に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning, Wind and Dark PAs and Techs\n     by 95%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 100%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 20%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Lightning, Wind and Dark\n    PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31765",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 255%.\n<color=yellow>SP: </color>Boosts damage by 260%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31766",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 270%.\n<color=yellow>SP: </color>Boosts damage by 275%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Lightning PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31767",
 		"jp_explainShort": "攻撃力超絶増＋定期ＣＰ回復＋攻撃威力強化",
 		"tr_explainShort": "Dam. boost + CP rec. + boost x Wp link",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 定期的にＣＰを回復する。\n③ 全てのリンクスロットに装備した\n　　 ウェポノイドチップの枚数に応じ攻撃の威力を強化する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 295%.\n<color=yellow>SP: </color>Boosts damage by 300%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers CP by 15 every 4.9 seconds.\n③  Boosts attack power by 5% x the number of\n     Weaponoid chips equipped in all link slots.\n     <color=yellow>[Q-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers CP at regular intervals.\n③ Boosts attack power based on the number of\n    Weaponoid chips equipped in all link slots.\n    <color=yellow>[Q-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31768",
 		"jp_explainShort": "アビリティＬｖ風武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Wind wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31769",
 		"jp_explainShort": "アビリティＬｖ風武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Wind wpn. boost x ability + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's ability\n     level if equipped with a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage based on this chip's ability level if\n    equipped with a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31770",
 		"jp_explainShort": "攻撃力増加＋必殺技・法術使用毎に大増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by ??% each time you use a PA or\n     Tech.\n     (Maximum boost: ???%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31771",
 		"jp_explainShort": "攻撃力増加＋必殺技・法術使用毎に大増加",
 		"tr_explainShort": "Damage boost + boost per PA/Tech use",
 		"jp_explainLong": "① 攻撃力を増加する。\n② 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 45% each time you use a PA or\n     Tech.\n     (Maximum boost: 225%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "① Boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage each time you use a PA or\n    Tech.\n    (Maximum Boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31774",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 必殺技に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31775",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増",
 		"tr_explainShort": "[Poison] imbued + dam. boost vs [Poison]",
 		"jp_explainLong": "① 必殺技に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Poison].\n②  Boosts damage by 110% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 120% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Poison].\n② Dramatically boosts damage against enemies\n    affected by [Poison].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31776",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを７５％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Cuts your current HP by 75%.\n②  Increases your ATK by 9750.\n<color=yellow>SP: </color>Increases your ATK by 10500.\n③  Recovers HP by 5% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Cuts your current HP by 75%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31777",
 		"jp_explainShort": "攻撃力を超絶強化＋定期的にＨＰを小回復",
 		"tr_explainShort": "ATK up + HP recovery over time",
 		"jp_explainLong": "① 現在のＨＰを７５％減少させる。\n② 攻撃力を超絶に強化する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Cuts your current HP by 75%.\n②  Increases your ATK by 11250.\n<color=yellow>SP: </color>Increases your ATK by 12000.\n③  Recovers HP by 5% every 2.4 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Cuts your current HP by 75%.\n② Overwhelmingly increases ATK.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31782",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ劇的増",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs [Burn]",
 		"jp_explainLong": "① 必殺技に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Burn].\n②  Boosts damage by 85% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31783",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ劇的増",
 		"tr_explainShort": "[Burn] imbued + dam. boost vs [Burn]",
 		"jp_explainLong": "① 必殺技に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives PAs a chance to inflict [Burn].\n②  Boosts damage by 95% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Gives PAs a chance to inflict [Burn].\n② Dramatically boosts damage against enemies\n    affected by [Burn].\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31784",
 		"jp_explainShort": "技法威力小強化＋有効弱点ダメージ大増加",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 必殺技・法術の威力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 45% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31785",
 		"jp_explainShort": "技法威力小強化＋有効弱点ダメージ大増加",
 		"tr_explainShort": "Weakness boosted + PAs/Techs boosted",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを大きく増加する。\n② 必殺技・法術の威力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 50% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 55% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Boosts the power of PAs and Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemy elemental\n    weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Slightly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31786",
 		"jp_explainShort": "威力増加＋光武器攻撃力増加＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. boost + Light wep boost + CP regen",
 		"jp_explainLong": "① 威力を増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 35%.\n<color=yellow>SP: </color>Boosts power by 40%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 10% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 2 every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31787",
 		"jp_explainShort": "威力大増加＋光武器攻撃力増加＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. boost + Light wep boost + CP regen",
 		"jp_explainLong": "① 威力を大きく増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 40%.\n<color=yellow>SP: </color>Boosts power by 45%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 10% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 2 every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31792",
 		"jp_explainShort": "光闇属性武器で攻撃力劇的増",
 		"tr_explainShort": "Light/Dark weapons boosted",
 		"jp_explainLong": "① 装備中の武器の属性が光・闇の場合\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 110% if using a Light or Dark\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 115% if using a Light or Dark\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage if using a Light or\n    Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31793",
 		"jp_explainShort": "光闇属性武器で攻撃力劇的増",
 		"tr_explainShort": "Light/Dark weapons boosted",
 		"jp_explainLong": "① 装備中の武器の属性が光・闇の場合\n　　 攻撃力を劇的に増加する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 115% if using a Light or Dark\n     weapon.\n<color=yellow>SP: </color>Boosts damage by 120% if using a Light or Dark\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage if using a Light or\n    Dark weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31796",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 70%.\n<color=yellow>SP: </color>Boosts power by 80%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31797",
 		"jp_explainShort": "定期的にＨＰ小回復＋威力劇的増加",
 		"tr_explainShort": "HP recovery over time + power boost",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 90%.\n<color=yellow>SP: </color>Boosts power by 100%.\n     <color=yellow>[F-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31798",
 		"jp_explainShort": "属性ダメージ＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを劇的に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental damage by 115% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 135% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31799",
 		"jp_explainShort": "属性ダメージ＋一定確率回避",
 		"tr_explainShort": "Weakness boosted + evading",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性による\n　　 ダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental damage by 155% against\n     enemies weak to that element.\n<color=yellow>SP: </color>Boosts elemental damage by 175% against\n     enemies weak to that element.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts elemental damage against\n    enemies weak to that element.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31800",
 		"jp_explainShort": "ＪＡ威力絶大増加＋ＪＡ成功３回毎にＣＰ回復",
 		"tr_explainShort": "JA boost x elems + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を絶大に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Just Attacks by 30% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 35% x the number of\n     different chip elements equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31801",
 		"jp_explainShort": "ＪＡ威力超絶増加＋ＪＡ成功３回毎にＣＰ回復",
 		"tr_explainShort": "JA boost x elems + 3 JAs = CP recovery",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Just Attacks by 35% x the number of\n     different chip elements equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 40% x the number of\n     different chip elements equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers CP by 5 each time you successfully\n     perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of different chip elements equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers CP each time you successfully\n    perform 3 Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31802",
 		"jp_explainShort": "アビリティＬｖ闇武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Dark wep boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's\n     ability level if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's\n     ability level if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31803",
 		"jp_explainShort": "アビリティＬｖ闇武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Dark wep boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's\n     ability level if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's\n     ability level if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 25.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31804",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31805",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    Wind PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31806",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "Dam. boost + CP rec. up + elem. match",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's link slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts CP recovery from normal attacks.\n③ Boosts damage if the equipped weapon's element\n    matches the element of the chip in this chip's\n    link slot.\n    <color=yellow>[H-Frame]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31807",
 		"jp_explainShort": "威力劇的増＋光闇技法威力小増＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. + Light/Dark move boost + CP recov.",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 必殺技・法術チップが光・闇属性の場合は\n　　 威力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 110%.\n<color=yellow>SP: </color>Boosts power by 115%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts Light and Dark PAs and Techs by 20%.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 3 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts Light and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31808",
 		"jp_explainShort": "威力劇的増＋光闇技法威力小増＋定期ＣＰ回復",
 		"tr_explainShort": "Pow. + Light/Dark move boost + CP recov.",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 必殺技・法術チップが光・闇属性の場合は\n　　 威力をわずかに増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 115%.\n<color=yellow>SP: </color>Boosts power by 120%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts Light and Dark PAs and Techs by 20%.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 3 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts Light and Dark PAs and Techs.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31809",
 		"jp_explainShort": "必殺技・法術使用毎に威力小増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 27% each time you use a PA\n     or Tech.\n     (Maximum boost: 135%)\n<color=yellow>SP: </color>Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage each time you use a PA\n    or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31810",
 		"jp_explainShort": "必殺技・法術使用毎に威力増加",
 		"tr_explainShort": "Damage boost per PA/Tech use",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% each time you use a PA\n     or Tech.\n     (Maximum boost: 150%)\n<color=yellow>SP: </color>Boosts damage by 33% each time you use a PA\n     or Tech.\n     (Maximum boost: 165%)\n     <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Boosts damage each time you use a PA or Tech.\n    (Maximum boost: Immense)\n    <color=yellow>[L-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31811",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 700 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n<color=yellow>SP: </color>Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n②  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Immense)\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31812",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "① Dramatically increases ATK every 3 times you\n    use an active chip or a normal attack.\n    (Maximum increase: Overwhelming)\n② Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31813",
 		"jp_explainShort": "攻撃力絶大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status immunity",
+		"tr_explainShort": "Damage boosted + status cured",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 135%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31814",
 		"jp_explainShort": "攻撃力絶大増加＋状態異常無効",
-		"tr_explainShort": "Damage boosted + status immunity",
+		"tr_explainShort": "Damage boosted + status cured",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身を状態異常にならなくする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140%.\n<color=yellow>SP: </color>Boosts damage by 145%.\n     <color=yellow>[E-Frame]</color>\n②  Grants immunity to status effects.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Cures all status effects on yourself.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31815",
 		"jp_explainShort": "攻撃力絶大強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を絶大に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃ヒット時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 6600.\n<color=yellow>SP: </color>Increases your ATK by 6900.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Immensely increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31816",
 		"jp_explainShort": "攻撃力超絶強化＋ＣＰ回復速度強化",
 		"tr_explainShort": "ATK up + CP regeneration up",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 7200.\n<color=yellow>SP: </color>Increases your ATK by 7500.\n②  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31817",
 		"jp_explainShort": "攻撃ダメージ増＋弱属武器攻撃力増＋定期ＣＰ回復",
 		"tr_explainShort": "Attack boost + weak wep. boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 装備中の武器の属性が氷属性か攻撃対象の\n　　 敵の弱点に有効な属性の場合、攻撃力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 30% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 31% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if the equipped weapon's element\n    is Ice, or if it matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31818",
 		"jp_explainShort": "攻撃ダメージ増＋弱属武器攻撃力増＋定期ＣＰ回復",
 		"tr_explainShort": "Attack boost + weak wep. boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 装備中の武器の属性が氷属性か攻撃対象の\n　　 敵の弱点に有効な属性の場合、攻撃力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 32% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n<color=yellow>SP: </color>Boosts damage by 33% if the equipped weapon's\n     element is Ice, or if it matches the target's\n     elemental weakness.\n     <color=yellow>[H-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if the equipped weapon's element\n    is Ice, or if it matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31819",
 		"jp_explainShort": "威力劇的増＋属性ダメージ＋定期ＨＰ回復",
 		"tr_explainShort": "Pow. boost + elem. dam. boost + HP regen",
 		"jp_explainLong": "① 威力を劇的に増加する。\n② 装備中チップの属性種類数に応じて\n　　 属性によるダメージを大きく増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 100%.\n<color=yellow>SP: </color>Boosts power by 110%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts elemental damage by 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[S-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n② Boosts elemental damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[S-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31820",
 		"jp_explainShort": "威力絶大増＋属性ダメージ＋定期ＨＰ回復",
 		"tr_explainShort": "Pow. boost + elem. dam. boost + HP regen",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中チップの属性種類数に応じて\n　　 属性によるダメージを大きく増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 130%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts elemental damage by 10% x the number of\n     different chip elements equipped.\n     <color=yellow>[S-Frame]</color>\n③  Recovers HP by 5% every 4.91 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Boosts elemental damage based on the number of\n    different chip elements equipped.\n    <color=yellow>[S-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31821",
 		"jp_explainShort": "攻撃力劇的増加＋雷風闇の技法威力絶大増",
 		"tr_explainShort": "Damage boosted + Fi/Ic/Wi moves boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Lightning, Wind and Dark PAs and Techs\n     by 130%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n     by 135%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Lightning, Wind and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31822",
 		"jp_explainShort": "攻撃力劇的増加＋雷風闇の技法威力絶大増",
 		"tr_explainShort": "Damage boosted + Fi/Ic/Wi moves boosted",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 必殺技・法術チップが雷・風・闇属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 65%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts Lightning, Wind and Dark PAs and Techs\n   by 140%.\n<color=yellow>SP: </color>Boosts Lightning, Wind and Dark PAs and Techs\n   by 145%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Immensely boosts Lightning, Wind and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31825",
 		"jp_explainShort": "アビリティＬｖ氷武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Ice wep. boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10% + 3% x this chip's\n     ability level if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 15% + 3% x this chip's\n     ability level if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31826",
 		"jp_explainShort": "アビリティＬｖ氷武器攻撃力増＋ＣＰ最大増",
 		"tr_explainShort": "Ice wep. boost x ab. lv. + max CP up",
 		"jp_explainLong": "① 装備中の武器の属性が氷属性の場合\n　　 アビリティレベルに応じて、攻撃力を大きく増加する。\n② ＣＰの最大値を増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% + 3% x this chip's\n     ability level if using an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% + 3% x this chip's\n     ability level if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum CP by 15.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage based on this chip's ability\n    level if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum CP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31827",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 235%.\n<color=yellow>SP: </color>Boosts damage by 240%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31828",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31829",
 		"jp_explainShort": "攻撃力超絶増＋消費ＣＰ減＋特定条件時追撃",
 		"tr_explainShort": "Dam. boost + CP use down + add. dam.",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 消費ＣＰを減少する。\n③ リンクスロットに装備したチップのクラスボーナスが\n　　 ハンターかブレイバーの場合、追加ダメージを与える。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 275%.\n<color=yellow>SP: </color>Boosts damage by 280%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 25%.\n③  Deals an additional 30% damage to enemies if the\n     class bonus of the chip in this chip's link slot is\n     Hunter or Braver.\n     <color=yellow>[Chase]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n③ Deals additional damage to enemies if the\n    class bonus of the chip in this chip's link slot\n    is Hunter or Braver.\n    <color=yellow>[Chase]</color>\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31832",
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. x # Light + all JAs + quickened",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 205% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 210% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals overwhelming additional damage to enemies\n    based on the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31833",
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "Add. dam. x # Light + all JAs + quickened",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 215% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 220% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals overwhelming additional damage to enemies\n    based on the number of Light chips equipped.\n    <color=yellow>[Chase]</color>\n② All normal attacks, PAs and Techs become\n    Just Attacks.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31836",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "PA&Tech boost + weak elem. wep. boost",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly boosts damage if the equipped weapon's\n    element matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31837",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "PA&Tech boost + weak elem. wep. boost",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Greatly boosts damage if the equipped weapon's\n    element matches one of the targeted enemy's\n    elemental weaknesses.\n    <color=yellow>[H-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31838",
 		"jp_explainShort": "風光闇技法攻撃力超絶増＋消費ＣＰ減",
 		"tr_explainShort": "Wi/Li/Da PA&Tech boost + CP use down",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     265%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     270%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Wind, Light and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31839",
 		"jp_explainShort": "風光闇技法攻撃力超絶増＋消費ＣＰ減",
 		"tr_explainShort": "Wi/Li/Da PA&Tech boost + CP use down",
 		"jp_explainLong": "① 必殺技・法術チップが風・光・闇属性の場合は\n　　 威力を超絶に増加する。\n② 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind, Light and Dark PAs and Techs by\n     275%.\n<color=yellow>SP: </color>Boosts Wind, Light and Dark PAs and Techs by\n     280%.\n     <color=yellow>[K-Frame]</color>\n②  Reduces CP consumption by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Wind, Light and Dark PAs\n    and Techs.\n    <color=yellow>[K-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31854",
 		"jp_explainShort": "アビＬｖ風技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Wind boost x ab. lv. + extension x # Wind",
 		"jp_explainLong": "① 必殺技・法術チップが風属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Wind PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Wind Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wind PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Wind Support\n    Chips' abilities based on the number of Wind chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31855",
 		"jp_explainShort": "アビＬｖ風技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Wind boost x ab. lv. + extension x # Wind",
 		"jp_explainLong": "① 必殺技・法術チップが風属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の風属性チップの枚数に応じて\n　　 風属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Wind PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Wind PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Wind Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Wind PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Wind Support\n    Chips' abilities based on the number of Wind chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31856",
 		"jp_explainShort": "アビＬｖ雷技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Thun. boost x ab. lv. + extension x # Thun.",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Lightning PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Lightning Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Lightning PAs and Techs\n    based on this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Lightning Support\n    Chips' abilities based on the number of Lightning\n    chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31857",
 		"jp_explainShort": "アビＬｖ雷技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Thun. boost x ab. lv. + extension x # Thun.",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Lightning PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Lightning Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Lightning PAs and Techs\n    based on this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Lightning Support\n    Chips' abilities based on the number of Lightning\n    chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31860",
 		"jp_explainShort": "威力を劇的増加",
 		"tr_explainShort": "Power boosted",
 		"jp_explainLong": "① 威力を劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 100%.\n<color=yellow>SP: </color>Boosts power by 110%.\n     <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts power.\n    <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31861",
 		"jp_explainShort": "威力を絶大増加",
 		"tr_explainShort": "Power boosted",
 		"jp_explainLong": "① 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 120%.\n<color=yellow>SP: </color>Boosts power by 130%.\n     <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31862",
 		"jp_explainShort": "炎雷風の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fi/Ln/Wi PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 125%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31863",
 		"jp_explainShort": "炎雷風の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fi/Ln/Wi PAs & Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・雷・風属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Lightning and Wind PAs and Techs\n     by 135%.\n<color=yellow>SP: </color>Boosts Fire, Lightning and Wind PAs and Techs\n     by 140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Lightning and Wind PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31866",
 		"jp_explainShort": "攻撃力絶大増＋炎氷属性武器で攻撃力大増",
 		"tr_explainShort": "Damage boost + Ice/Fire weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎・氷の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 135%.\n<color=yellow>SP: </color>Boosts damage by 140%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% when using an Ice or Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage when using an Ice or Fire\n    weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31867",
 		"jp_explainShort": "攻撃力絶大増＋炎氷属性武器で攻撃力大増",
 		"tr_explainShort": "Damage boost + Ice/Fire weapon boost",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 装備中の武器の属性が炎・氷の場合\n　　 攻撃力を大きく増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 145%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by 40% when using an Ice or Fire\n     weapon.\n     <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly boosts damage when using an Ice or Fire\n    weapon.\n    <color=yellow>[H-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31868",
 		"jp_explainShort": "アビＬｖ炎技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Fire boost x ab. lv. + extension x # Fire",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Fire PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Fire Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Fire PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Fire Support Chips'\n    abilities based on the number of Fire chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31869",
 		"jp_explainShort": "アビＬｖ炎技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Fire boost x ab. lv. + extension x # Fire",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の炎属性チップの枚数に応じて\n　　 炎属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Fire PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Fire Support\n     Chips' abilities by 2 seconds x the number of\n     Wind chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Fire PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Fire Support Chips'\n    abilities based on the number of Fire chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31870",
 		"jp_explainShort": "アビＬｖ闇技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Dark boost x ab. lv. + extension x # Dark",
 		"jp_explainLong": "① 必殺技・法術チップが闇属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Dark PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Dark PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Dark Support\n     Chips' abilities by 2 seconds x the number of\n     Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dark PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Dark Support Chips'\n    abilities based on the number of Dark chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31871",
 		"jp_explainShort": "アビＬｖ闇技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Dark boost x ab. lv. + extension x # Dark",
 		"jp_explainLong": "① 必殺技・法術チップが闇属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の闇属性チップの枚数に応じて\n　　 闇属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Dark PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Dark PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Dark Support\n     Chips' abilities by 2 seconds x the number of\n     Dark chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Dark PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Dark Support Chips'\n    abilities based on the number of Dark chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31872",
 		"jp_explainShort": "攻撃ダメージ増＋弱属技法威力増＋定期ＣＰ回復",
 		"tr_explainShort": "Boost + weak PA&Tech boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 必殺技・法術チップが攻撃対象の敵の弱点に\n　　 有効な属性の場合、威力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts the power of PAs and Techs by 30% if\n     their element matches the targeted enemy's\n     weakness element.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 31% if\n     their element matches the targeted enemy's\n     weakness element.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts PAs and Techs if their element matches\n    the targeted enemy's weakness element.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31873",
 		"jp_explainShort": "攻撃ダメージ増＋弱属技法威力増＋定期ＣＰ回復",
 		"tr_explainShort": "Boost + weak PA&Tech boost + CP regen",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 必殺技・法術チップが攻撃対象の敵の弱点に\n　　 有効な属性の場合、威力を増加する。\n③ 定期的にＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts the power of PAs and Techs by 32% if\n     their element matches the targeted enemy's\n     weakness element.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 33% if\n     their element matches the targeted enemy's\n     weakness element.\n     <color=yellow>[K-Frame]</color>\n③  Recovers CP by 5 every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts PAs and Techs if their element matches\n    the targeted enemy's weakness element.\n    <color=yellow>[K-Frame]</color>\n③ Slightly recovers CP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31874",
 		"jp_explainShort": "必殺技・法術威力超絶強化＋一定確率で回避",
 		"tr_explainShort": "PA & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 240%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 250%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 35% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 40% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31875",
 		"jp_explainShort": "必殺技・法術威力超絶強化＋一定確率で回避",
 		"tr_explainShort": "PA & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を超絶に強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 260%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 270%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 45% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31876",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 345%.\n<color=yellow>SP: </color>Boosts damage by 355%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31877",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 365%.\n<color=yellow>SP: </color>Boosts damage by 375%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31878",
 		"jp_explainShort": "攻撃力極度増＋定期ＨＰ小回復＋効果時間延長",
 		"tr_explainShort": "Dam. boost + HP over time + ext. effects",
 		"jp_explainLong": "① 攻撃力を極度に増加する。\n② 定期的にＨＰをわずかに回復する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 チップ発動時のアビリティ効果時間を延長する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 390%.\n<color=yellow>SP: </color>Boosts damage by 400%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 4.9 seconds.\n③  Extends the Effect Duration of chips' abilities by\n     10 seconds if there is a Dark chip in this chip's link\n     slot.\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n③ Extends the Effect Duration of chips' abilities if\n    there is a Dark chip in this chip's link slot.\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31879",
 		"jp_explainShort": "アビＬｖ光技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Light boost x ab. lv. + extension x # Light",
 		"jp_explainLong": "① 必殺技・法術チップが光属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Light PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Light PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Light Support\n     Chips' abilities by 2 seconds x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Light PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Light Support Chips'\n    abilities based on the number of Light chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31880",
 		"jp_explainShort": "アビＬｖ光技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Light boost x ab. lv. + extension x # Light",
 		"jp_explainLong": "① 必殺技・法術チップが光属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 光属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Light PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Light PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Light Support\n     Chips' abilities by 2 seconds x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Light PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Light Support Chips'\n    abilities based on the number of Light chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31883",
 		"jp_explainShort": "威力絶大増＋炎武器攻撃力大増＋炎属性上限上昇",
 		"tr_explainShort": "Pow. boost + Fire weapon boost + max Fire up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 攻撃力を大きく増加する。\n③ 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 130%.\n<color=yellow>SP: </color>Boosts power by 140%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31884",
 		"jp_explainShort": "威力絶大増＋炎武器攻撃力大増＋炎属性上限上昇",
 		"tr_explainShort": "Pow. boost + Fire weapon boost + max Fire up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が炎属性の場合\n　　 攻撃力を大きく増加する。\n③ 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 150%.\n<color=yellow>SP: </color>Boosts power by 160%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 50% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Fire value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Greatly boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31889",
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "Dam. effect boost x JA + actions quickened",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects for each successful\n    Just Attack.\n    <color=yellow>[Z-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31890",
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "Dam. effect boost x JA + actions quickened",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects for each successful\n    Just Attack.\n    <color=yellow>[Z-Frame]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31891",
 		"jp_explainShort": "雷属性ダメージ＋回避",
 		"tr_explainShort": "Lightning elem. boosted + chance to evade",
 		"jp_explainLong": "① 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning elemental damage by 145%\n     against enemies weak to Lightning.\n<color=yellow>SP: </color>Boosts Lightning elemental damage by 150%\n     against enemies weak to Lightning.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Lightning elemental damage\n    against enemies weak to Lightning.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31892",
 		"jp_explainShort": "雷属性ダメージ＋回避",
 		"tr_explainShort": "Lightning elem. boosted + chance to evade",
 		"jp_explainLong": "① 雷属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning elemental damage by 155%\n     against enemies weak to Lightning.\n<color=yellow>SP: </color>Boosts Lightning elemental damage by 160%\n     against enemies weak to Lightning.\n     <color=yellow>[S-Frame]</color>\n②  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Lightning elemental damage\n    against enemies weak to Lightning.\n    <color=yellow>[S-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31893",
 		"jp_explainShort": "必殺技・法術の威力大強化＋加速",
 		"tr_explainShort": "PAs & Techs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技・法術の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31894",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋加速",
 		"tr_explainShort": "PAs & Techs boosted + actions quickened",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31895",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 105% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 10%.\n<color=yellow>SP: </color>Recovers HP by 12%.\n③  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Deals dramatic additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31896",
 		"jp_explainShort": "ＨＰ回復＋ＣＰ回復＋追加特大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. damage",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② ＨＰを回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Deals an additional 115% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 120% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 18%.\n③  Recovers CP by 12.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Deals dramatic additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31897",
 		"jp_explainShort": "全地形で攻撃力超絶増加＋弱点属性強化",
 		"tr_explainShort": "Dam. boost in all areas + weak elements up",
 		"jp_explainLong": "① 全てのエリアの戦闘で攻撃力を超絶に増加する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 240% when fighting in any\n     area.\n<color=yellow>SP: </color>Boosts damage by 250% when fighting in any\n     area.\n     <color=yellow>[I-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 20.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage when fighting in\n    all areas.\n    <color=yellow>[I-Frame]</color>\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31898",
 		"jp_explainShort": "全地形で攻撃力超絶増加＋弱点属性強化",
 		"tr_explainShort": "Dam. boost in all areas + weak elements up",
 		"jp_explainLong": "① 全てのエリアの戦闘で攻撃力を超絶に増加する。\n② 攻撃対象の敵の弱点属性を強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 260% when fighting in any\n     area.\n<color=yellow>SP: </color>Boosts damage by 270% when fighting in any\n     area.\n     <color=yellow>[I-Frame]</color>\n②  Increases all Elements that the target is weak\n     to by 20.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts damage when fighting in\n    all areas.\n    <color=yellow>[I-Frame]</color>\n② Increases elements that the targeted enemy is\n    weak to.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31905",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack power by 105% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 110% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31906",
 		"jp_explainShort": "装備ウェポノイドチップ数威力強化＋ダメージ防御",
 		"tr_explainShort": "Attack power boost x # Weaponoids + barrier",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を絶大に強化する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack power by 115% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 120% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     30% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts attack power based on the\n    number of Weaponoid chips equipped.\n    <color=yellow>[Q-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31910",
 		"jp_explainShort": "アビＬｖ氷技法攻撃力大増＋効果時間延長",
 		"tr_explainShort": "Ice boost x ab. lv. + extension x # Ice",
 		"jp_explainLong": "① 必殺技・法術チップが氷属性の場合は\n　　 アビリティレベルに応じて威力を大きく増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice PAs and Techs by 12% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Ice PAs and Techs by 22% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Ice Support\n     Chips' abilities by 2 seconds x the number of\n     Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Ice PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Ice Support Chips'\n    abilities based on the number of Ice chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31911",
 		"jp_explainShort": "アビＬｖ氷技法攻撃力劇的増＋効果時間延長",
 		"tr_explainShort": "Ice boost x ab. lv. + extension x # Ice",
 		"jp_explainLong": "① 必殺技・法術チップが氷属性の場合は\n　　 アビリティレベルに応じて威力を劇的に増加する。\n② 装備中の氷属性チップの枚数に応じて\n　　 氷属性のサポートチップ発動時の効果時間を延長する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Ice PAs and Techs by 32% + 4% x\n     this chip's ability level.\n<color=yellow>SP: </color>Boosts Ice PAs and Techs by 42% + 4% x\n     this chip's ability level.\n     <color=yellow>[K-Frame]</color>\n②  Extends the Effect Duration of Ice Support\n     Chips' abilities by 2 seconds x the number of\n     Ice chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts Ice PAs and Techs based on\n    this chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Extends the Effect Duration of Ice Support Chips'\n    abilities based on the number of Ice chips\n    equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31912",
 		"jp_explainShort": "闇属性ダメージ＋ダメージ防御＋ポイズン付与",
 		"tr_explainShort": "Dark elem. boosted + barrier + counter-Poison",
 		"jp_explainLong": "① 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Dark elemental damage by 150%\n     against enemies weak to Dark.\n<color=yellow>SP: </color>Boosts Dark elemental damage by 155%\n     against enemies weak to Dark.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Dark elemental damage\n    against enemies weak to Dark.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31913",
 		"jp_explainShort": "闇属性ダメージ＋ダメージ防御＋ポイズン付与",
 		"tr_explainShort": "Dark elem. boosted + barrier + counter-Poison",
 		"jp_explainLong": "① 闇属性が弱点の敵に対して\n　　 その属性によるダメージを絶大に増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Dark elemental damage by 160%\n     against enemies weak to Dark.\n<color=yellow>SP: </color>Boosts Dark elemental damage by 165%\n     against enemies weak to Dark.\n     <color=yellow>[S-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Dark elemental damage\n    against enemies weak to Dark.\n    <color=yellow>[S-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31914",
 		"jp_explainShort": "攻撃ダメージ増＋特定属性チップ装備攻撃力増",
 		"tr_explainShort": "Attack damage boost + weakness chip boost",
 		"jp_explainLong": "① 攻撃ダメージを劇的に増加する。\n② 敵の弱点に有効な属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n③ ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 65%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 140% when equipped with a\n     chip of an element the target is weak to.\n<color=yellow>SP: </color>Boosts damage by 145% when equipped with a\n     chip of an element the target is weak to.\n     <color=yellow>[2A-Frame]</color>\n③  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Immensely boosts damage when equipped with a\n    chip of an element the targeted enemy is weak to.\n    <color=yellow>[2A-Frame]</color>\n③ Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31915",
 		"jp_explainShort": "攻撃ダメージ増＋特定属性チップ装備攻撃力増",
 		"tr_explainShort": "Attack damage boost + weakness chip boost",
 		"jp_explainLong": "① 攻撃ダメージを劇的に増加する。\n② 敵の弱点に有効な属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n③ ＣＰの回復速度を劇的に強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 65%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 150% when equipped with a\n     chip of an element the target is weak to.\n<color=yellow>SP: </color>Boosts damage by 155% when equipped with a\n     chip of an element the target is weak to.\n     <color=yellow>[2A-Frame]</color>\n③  Boosts your CP regeneration speed by 100%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Immensely boosts damage when equipped with a\n    chip of an element the targeted enemy is weak to.\n    <color=yellow>[2A-Frame]</color>\n③ Dramatically increases CP regeneration.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31916",
 		"jp_explainShort": "攻撃力増＋雷属性上限上昇＋定期的にＨＰ小回復",
 		"tr_explainShort": "Lightning chip boost + max up x # Lightning",
 		"jp_explainLong": "① 雷属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 145% when equipped with a\n     Lightning chip.\n<color=yellow>SP: </color>Boosts damage by 150% when equipped with a\n     Lightning chip.\n     <color=yellow>[2A-Frame]</color>\n②  Increases your maximum Lightning by 10 x the\n     number of Lightning chips equipped.\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage when equipped with a\n    Lightning chip.\n    <color=yellow>[2A-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31917",
 		"jp_explainShort": "攻撃力増＋雷属性上限上昇＋定期的にＨＰ小回復",
 		"tr_explainShort": "Lightning chip boost + max up x # Lightning",
 		"jp_explainLong": "① 雷属性のチップを装備している場合\n　　 攻撃力を絶大に増加する。\n② 装備中の雷属性チップの枚数に応じて\n　　 雷属性の上限値が大きく上昇する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 155% when equipped with a\n     Lightning chip.\n<color=yellow>SP: </color>Boosts damage by 160% when equipped with a\n     Lightning chip.\n     <color=yellow>[2A-Frame]</color>\n②  Increases your maximum Lightning by 10 x the\n     number of Lightning chips equipped.\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage when equipped with a\n    Lightning chip.\n    <color=yellow>[2A-Frame]</color>\n② Greatly increases your maximum Lightning value\n    based on the number of Lightning chips equipped.\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31918",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＨＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Ice/Wind/Light + HP regen",
 		"jp_explainLong": "① アビリティレベルと氷・風・光属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental power by 5% + 8% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 9% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts elemental power based on this\n    chip's ability level and the total value of your Ice,\n    Wind and Light elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31919",
 		"jp_explainShort": "属性攻撃力を絶大増加＋定期的にＨＰ小回復",
 		"tr_explainShort": "Boost x ab. lv. x Ice/Wind/Light + HP regen",
 		"jp_explainLong": "① アビリティレベルと氷・風・光属性の合計値に応じて\n　　 属性攻撃力を絶大に増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental power by 5% + 10% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n<color=yellow>SP: </color>Boosts elemental power by 5% + 11% x this chip's\n     ability level x your total Ice, Wind and Light\n     elements (max. total: 750) / 750.\n     <color=yellow>[R-Frame]</color>\n②  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts elemental power based on this\n    chip's ability level and the total value of your Ice,\n    Wind and Light elements.\n    <color=yellow>[R-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31920",
 		"jp_explainShort": "闇武器攻撃力絶大増加＋闇属性上限上昇",
 		"tr_explainShort": "Dark weapons boosted + max Dark up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Dark Element by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Dark element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31921",
 		"jp_explainShort": "闇武器攻撃力絶大増加＋闇属性上限上昇",
 		"tr_explainShort": "Dark weapons boosted + max Dark up",
 		"jp_explainLong": "① 装備中の武器の属性が闇属性の場合\n　　 攻撃力を絶大に増加する。\n② 闇属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140% if using a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Dark Element by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Dark weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Dark element value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31924",
 		"jp_explainShort": "氷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＨＰ回復",
 		"tr_explainShort": "JAs boosted x # Ice + 3 JAs = HP recovery",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Just Attacks by 35% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 40% x the number of\n     Ice chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers HP by 5% every time you successfully\n     perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts Just Attacks based on the\n    number of Ice chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers HP every time you successfully\n    perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31925",
 		"jp_explainShort": "氷枚数ＪＡ威力超絶増加＋ＪＡ成功３回毎ＨＰ回復",
 		"tr_explainShort": "JAs boosted x # Ice + 3 JAs = HP recovery",
 		"jp_explainLong": "① 装備中の氷属性チップの枚数に応じて\n　　 ジャストアタックの威力を超絶に増加する。\n② ジャストアタックを３回成功させるごとに\n　　 ＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Just Attacks by 45% x the number of\n     Ice chips equipped.\n<color=yellow>SP: </color>Boosts Just Attacks by 50% x the number of\n     Ice chips equipped.\n     <color=yellow>[T-Frame]</color>\n②  Recovers HP by 5% every time you successfully\n     perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Maximally boosts Just Attacks based on the\n    number of Ice chips equipped.\n    <color=yellow>[T-Frame]</color>\n② Slightly recovers HP every time you successfully\n    perform three Just Attacks.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31926",
 		"jp_explainShort": "アビＬｖ技法大強化＋炎枚数炎属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Fire act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 大きく強化する。\n② 装備中の炎属性チップの枚数に応じて、炎属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 炎属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts PAs and Techs by 15% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 25% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Fire\n     Support Chips by 2% x the number of Fire\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Fire Support Chips\n    based on the number of Fire chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Fire chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31927",
 		"jp_explainShort": "アビＬｖ技法劇的強化＋炎枚数炎属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Fire act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 劇的に強化する。\n② 装備中の炎属性チップの枚数に応じて、炎属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 炎属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts PAs and Techs by 35% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 45% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Fire\n     Support Chips by 2% x the number of Fire\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Fire Support Chips\n    based on the number of Fire chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Fire chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31928",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Dam. boost vs weakness + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 145% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 150% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 10%.\n<color=yellow>SP: </color>Reduces CP consumption by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31929",
 		"jp_explainShort": "消費ＣＰ減少＋有効弱点時ダメージ絶大増",
 		"tr_explainShort": "Dam. boost vs weakness + CP use down",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 155% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 160% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Reduces CP consumption by 20%.\n<color=yellow>SP: </color>Reduces CP consumption by 25%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31930",
 		"jp_explainShort": "アビＬｖ技法増加＋ダメージ防御＋バーン付与",
 		"tr_explainShort": "PA&Tech boost + barrier + counter-Burn",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「バーン」効果を与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts all PAs and Techs by 2% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 3% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     3% of your maximum HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts all PAs and Techs based on this chip's\n    ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31931",
 		"jp_explainShort": "アビＬｖ技法大増加＋ダメージ防御＋バーン付与",
 		"tr_explainShort": "PA&Tech boost + barrier + counter-Burn",
 		"jp_explainLong": "① アビリティレベルに応じて必殺技・法術チップの\n　　 威力を大きく増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「バーン」効果を与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts all PAs and Techs by 4% x this chip's ability\n     level.\n<color=yellow>SP: </color>Boosts all PAs and Techs by 5% x this chip's ability\n     level.\n     <color=yellow>[K-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     3% of your maximum HP x this chip's ability level.\n③  Responds to damage from the targeted enemy\n     with a 100% chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts all PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[K-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Responds to damage from the targeted enemy\n    with a fixed chance to inflict [Burn].\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31932",
 		"jp_explainShort": "全クエストダメージ増＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost in all quests + Wind CP use down",
 		"jp_explainLong": "① 全てのクエストで敵に与えるダメージを\n　　 アビリティレベルに応じて増加する。\n② リンクスロットに装備したチップの属性が\n　　 風属性の場合、風属性チップの消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against enemies in all quests by\n     2% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against enemies in all quests by\n     3% x this chip's ability level.\n     <color=yellow>[X-Frame]</color>\n②  Decreases the CP consumption of Wind chips by\n     10% if there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts damage against enemies in all quests based\n    on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n② Decreases the CP consumption of Wind chips if\n    there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31933",
 		"jp_explainShort": "全クエストダメージ増＋消費ＣＰ減",
 		"tr_explainShort": "Dam. boost in all quests + Wind CP use down",
 		"jp_explainLong": "① 全てのクエストで敵に与えるダメージを\n　　 アビリティレベルに応じて大きく増加する。\n② リンクスロットに装備したチップの属性が\n　　 風属性の場合、風属性チップの消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against enemies in all quests by\n     4% x this chip's ability level.\n<color=yellow>SP: </color>Boosts damage against enemies in all quests by\n     5% x this chip's ability level.\n     <color=yellow>[X-Frame]</color>\n②  Decreases the CP consumption of Wind chips by\n     10% if there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts damage against enemies in all\n    quests based on this chip's ability level.\n    <color=yellow>[X-Frame]</color>\n② Decreases the CP consumption of Wind chips if\n    there is a Wind chip in this chip's link slot.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31934",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ小回復＋追加ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. dam.",
 		"jp_explainLong": "① 敵に追加でダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰをわずかに回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 5%.\n<color=yellow>SP: </color>Recovers HP by 6%.\n③  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 6.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Slightly recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31935",
 		"jp_explainShort": "ＨＰ小回復＋ＣＰ回復＋追加大ダメージ",
 		"tr_explainShort": "HP recov. + CP recov. + add. dam.",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② ＨＰをわずかに回復する。\n③ ＣＰを回復する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Recovers HP by 7%.\n<color=yellow>SP: </color>Recovers HP by 8%.\n③  Recovers CP by 7.\n<color=yellow>SP: </color>Recovers CP by 8.\n[Activation Trigger] Landing an attack\n[Cooldown] 1 second"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Slightly recovers HP.\n③ Recovers CP.\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "31936",
 		"jp_explainShort": "炎武器攻撃力絶大増加＋炎属性上限上昇",
 		"tr_explainShort": "Fire weapons boosted + max Fire up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Fire value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31937",
 		"jp_explainShort": "炎武器攻撃力絶大増加＋炎属性上限上昇",
 		"tr_explainShort": "Fire weapons boosted + max Fire up",
 		"jp_explainLong": "① 装備中の武器の属性が炎属性の場合\n　　 攻撃力を絶大に増加する。\n② 炎属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140% if using a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Fire weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Fire value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Fire weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Fire value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31940",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 140% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n②  Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31941",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 150% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 160% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n② Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    Dark PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31942",
 		"jp_explainShort": "弱属ダメージ絶大増＋発動率上昇",
 		"tr_explainShort": "Weakness damage boost + activ. rate up",
 		"jp_explainLong": "① 攻撃対象の敵の弱点に有効な属性で\n　　 攻撃した場合に与えるダメージを絶大に増加する。\n② ボス戦とタワークエストで\n　　 装備中の闇属性チップの枚数に応じて\n　　 ①の効果のダメージをさらに超絶に増加する。\n③ リンクスロットに装備したチップの属性が闇属性の場合\n　　 闇属性のチップの発動率を上昇する。\n　　 このチップ発動時にも、この効果が適用される。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 170% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts damage by 180% against enemy\n     elemental weaknesses.\n     <color=yellow>[D-Frame]</color>\n② Further boosts the effect of ① by 40% x the\n     number of Dark chips equipped in boss battles\n     and Tower Quests.\n③  Increases the activation rate of Dark chips by\n     40% if there is a Dark chip in this chip's Link Slot.\n     (Even applies to this chip's activation rate)\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage against enemy\n    elemental weaknesses.\n    <color=yellow>[D-Frame]</color>\n② Further overwhelmingly boosts the effect of ① in\n    boss battles and Tower Quests based on the\n    number of Dark chips equipped.\n③ Increases the activation rate of Dark chips if\n    there is a Dark chip in this chip's Link Slot.\n    (Even applies to this chip's activation rate)\n④ While this chip is equipped, the equip costs of\n    all PAs and Techs are reduced.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31945",
 		"jp_explainShort": "風武器攻撃力絶大増加＋風属性上限上昇",
 		"tr_explainShort": "Wind weapons boosted + max Wind up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 攻撃力を絶大に増加する。\n② 風属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130% if using a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 135% if using a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Wind value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Wind value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31946",
 		"jp_explainShort": "風武器攻撃力絶大増加＋風属性上限上昇",
 		"tr_explainShort": "Wind weapons boosted + max Wind up",
 		"jp_explainLong": "① 装備中の武器の属性が風属性の場合\n　　 攻撃力を絶大に増加する。\n② 風属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 140% if using a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 145% if using a Wind weapon.\n     <color=yellow>[H-Frame]</color>\n②  Increases your maximum Wind value by 20.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage if using a Wind weapon.\n    <color=yellow>[H-Frame]</color>\n② Increases your maximum Wind value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31947",
 		"jp_explainShort": "属性種類数ダメージ増＋ダメージ防御＋防御効果",
 		"tr_explainShort": "Dam. boost x # elems + barrier + defenses",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 与えるダメージを極度に増加する。\n② 装備中チップの属性種類数に応じて\n　　 ダメージを防ぐ効果をＨＰに上乗せする。\n③ 装備中チップの属性種類数が\n　　 1以上の場合、敵から受けるダメージを軽減する。\n　　 2以上の場合、のけぞり無効となる効果を付与する。\n　　 3以上の場合、ダウン無効となる効果を付与する。\n　　 4以上の場合、自身を状態異常にならなくする。\n　　 5以上の場合、敵からの攻撃を一定確率で回避する。\n　　 6の場合、スライド操作時の無敵時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage dealt by 230% + 20% x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage dealt by 240% + 20% x the\n     number of different chip elements equipped.\n     <color=yellow>[2B-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% x the number of different chip\n     elements equipped.\n③  Depends on the number of chip elements equipped:\n     1 or more: Reduces damage taken by 30%.\n     2 or more: Grants flinching immunity.\n     3 or more: Grants knockdown immunity.\n     4 or more: Makes you immune to status effects.\n     5 or more: Grants a 50% evasion chance.\n     6: Extends dodge invincibility by 0.83 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Maximally boosts damage dealt based on the\n    number of different chip elements equipped.\n    <color=yellow>[2B-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Depends on the number of chip elements equipped:\n    1 or more: Reduces damage taken from enemies.\n    2 or more: Grants flinching immunity.\n    3 or more: Grants knockdown immunity.\n    4 or more: Makes you immune to status effects.\n    5 or more: Grants a chance to evade damage.\n    6: Extends invincibility time of Slide Actions.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31948",
 		"jp_explainShort": "属性種類数ダメージ増＋ダメージ防御＋防御効果",
 		"tr_explainShort": "Dam. boost x # elems + barrier + defenses",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 与えるダメージを極度に増加する。\n② 装備中チップの属性種類数に応じて\n　　 ダメージを防ぐ効果をＨＰに上乗せする。\n③ 装備中チップの属性種類数が\n　　 1以上の場合、敵から受けるダメージを軽減する。\n　　 2以上の場合、のけぞり無効となる効果を付与する。\n　　 3以上の場合、ダウン無効となる効果を付与する。\n　　 4以上の場合、自身を状態異常にならなくする。\n　　 5以上の場合、敵からの攻撃を一定確率で回避する。\n　　 6の場合、スライド操作時の無敵時間を延長する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage dealt by 250% + 20% x the\n     number of different chip elements equipped.\n<color=yellow>SP: </color>Boosts damage dealt by 260% + 20% x the\n     number of different chip elements equipped.\n     <color=yellow>[2B-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% x the number of different chip\n     elements equipped.\n③  Depends on the number of chip elements equipped:\n     1 or more: Reduces damage taken by 30%.\n     2 or more: Grants flinching immunity.\n     3 or more: Grants knockdown immunity.\n     4 or more: Makes you immune to status effects.\n     5 or more: Grants a 50% evasion chance.\n     6: Extends dodge invincibility by 0.83 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Maximally boosts damage dealt based on the\n    number of different chip elements equipped.\n    <color=yellow>[2B-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on the number of different chip elements\n    equipped.\n③ Depends on the number of chip elements equipped:\n    1 or more: Reduces damage taken from enemies.\n    2 or more: Grants flinching immunity.\n    3 or more: Grants knockdown immunity.\n    4 or more: Makes you immune to status effects.\n    5 or more: Grants a chance to evade damage.\n    6: Extends invincibility time of Slide Actions.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31955",
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31956",
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "Damage effects boosted + evading attacks",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Immensely boosts damage effects.\n    <color=yellow>[Z-Frame]</color>\n② Slightly boosts damage effects each time you use\n    an active chip or a normal attack.\n    <color=yellow>[Z-Frame]</color>\n③ Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31957",
 		"jp_explainShort": "攻撃力強化＋攻撃力増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "ATK up + low HP damage boost + one survival",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 自身のＨＰが５０％以下の場合に\n　　 攻撃力を大きく増加する。\n③ 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 12000.\n<color=yellow>SP: </color>Increases your ATK by 13000.\n②  Boosts damage by 50% when your HP is below\n     50%.\n     <color=yellow>[O-Frame]</color>\n③  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly boosts damage when your HP is below\n    50%.\n    <color=yellow>[O-Frame]</color>\n③ Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31958",
 		"jp_explainShort": "攻撃力強化＋攻撃力増加＋一回だけ戦闘不能回避",
 		"tr_explainShort": "ATK up + low HP damage boost + one survival",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 自身のＨＰが５０％以下の場合に\n　　 攻撃力を大きく増加する。\n③ 効果中一度だけ戦闘不能にならない。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 14000.\n<color=yellow>SP: </color>Increases your ATK by 15000.\n②  Boosts damage by 50% when your HP is below\n     50%.\n     <color=yellow>[O-Frame]</color>\n③  Allows you to survive incapacitation with 1 HP,\n     once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly boosts damage when your HP is below\n    50%.\n    <color=yellow>[O-Frame]</color>\n③ Allows you to survive incapacitation with 1 HP,\n    once per activation.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31959",
 		"jp_explainShort": "技・法威力大強化＋氷弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + dam. boost vs Ice weak",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 75% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Boosts PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31960",
 		"jp_explainShort": "技・法威力大強化＋氷弱点時ダメージ劇的増",
 		"tr_explainShort": "PA/Tech boost + dam. boost vs Ice weak",
 		"jp_explainLong": "① 攻撃対象の敵が氷属性弱点の場合に\n　　 与えるダメージを劇的に増加する。\n② 必殺技・法術の威力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 85% against enemies that are\n     weak to Ice.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies that are\n     weak to Ice.\n     <color=yellow>[D-Frame]</color>\n②  Boosts PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against enemies\n    that are weak to Ice.\n    <color=yellow>[D-Frame]</color>\n② Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31961",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が超絶強化",
 		"tr_explainShort": "Damage taken reduced + ATK increased",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 11000.\n<color=yellow>SP: </color>Increases your ATK by 13000.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31962",
 		"jp_explainShort": "ダメージ大軽減＋攻撃力が超絶強化",
 		"tr_explainShort": "Damage taken reduced + ATK increased",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② 敵から受けるダメージを大きく軽減する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 14000.\n<color=yellow>SP: </color>Increases your ATK by 16000.\n②  Reduces damage taken from enemies by 50%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Overwhelmingly increases ATK.\n② Greatly reduces damage taken from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31969",
 		"jp_explainShort": "アビＬｖ技法大強化＋氷枚数氷属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Ice act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 大きく強化する。\n② 装備中の氷属性チップの枚数に応じて、氷属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 氷属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts PAs and Techs by 15% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 25% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Ice\n     Support Chips by 2% x the number of Ice\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Ice Support chips\n    based on the number of Ice chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Ice chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "31970",
 		"jp_explainShort": "アビＬｖ技法劇的強化＋氷枚数氷属性発動率上昇",
 		"tr_explainShort": "PAs&Techs boost x ab. lv. + Ice act. rates up",
 		"jp_explainLong": "① 必殺技・法術の威力をアビリティレベルに応じて\n　　 劇的に強化する。\n② 装備中の氷属性チップの枚数に応じて、氷属性の\n　　 チップの発動率を上昇する。\n③ 発動率上昇の効果を持つチップと組み合わせた場合\n　　 氷属性のチップの発動率上昇の効果を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts PAs and Techs by 35% + 2% x this\n     chip's ability level.\n<color=yellow>SP: </color>Boosts PAs and Techs by 45% + 2% x this\n     chip's ability level.\n     <color=yellow>[A-Frame]</color>\n②  Increases the activation rates of Ice\n     Support Chips by 2% x the number of Ice\n     chips equipped.\n     (Stacks with other activation rate increases)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts PAs and Techs based on this\n    chip's ability level.\n    <color=yellow>[A-Frame]</color>\n② Increases activation rate of Ice Support chips\n    based on the number of Ice chips equipped.\n③ When combined with a chip that has an effect that\n    raises activation rates, enhances that effect to\n    raise the activation rates of Ice chips.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31971",
 		"jp_explainShort": "攻撃ダメージ増＋光属武器攻撃力増＋定期ＨＰ回復",
 		"tr_explainShort": "Attk. boost + Light wep. boost + HP over time",
 		"jp_explainLong": "① 攻撃ダメージを絶大に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 180%.\n<color=yellow>SP: </color>Boosts attack damage by 190%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 30% if using a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 31% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31972",
 		"jp_explainShort": "攻撃ダメージ増＋光属武器攻撃力増＋定期ＨＰ回復",
 		"tr_explainShort": "Attk. boost + Light wep. boost + HP over time",
 		"jp_explainLong": "① 攻撃ダメージを超絶に増加する。\n② 装備中の武器の属性が光属性の場合\n　　 攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack damage by 200%.\n<color=yellow>SP: </color>Boosts attack damage by 210%.\n     <color=yellow>[W-Frame]</color>\n②  Boosts damage by 32% if using a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 33% if using a Light weapon.\n     <color=yellow>[H-Frame]</color>\n③  Recovers HP by 5% every 4.9 seconds.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts attack damage.\n    <color=yellow>[W-Frame]</color>\n② Boosts damage if using a Light weapon.\n    <color=yellow>[H-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31975",
 		"jp_explainShort": "光枚数属性攻撃力を絶大増加＋光枚数消費ＣＰ減少",
 		"tr_explainShort": "Elem. pow. boost & CP cost down x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 属性攻撃力を絶大に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental power  by 135% + 10% x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Boosts elemental power  by 145% + 10% x the\n     number of Light chips equipped.\n     <color=yellow>[R-Frame]</color>\n②  Reduces CP consumption by 5% x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts elemental power based on the\n    number of Light chips equipped.\n    <color=yellow>[R-Frame]</color>\n② Reduces CP consumption based on the number of\n    Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31976",
 		"jp_explainShort": "光枚数属性攻撃力を超絶増加＋光枚数消費ＣＰ減少",
 		"tr_explainShort": "Elem. pow. boost & CP cost down x # Light",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 属性攻撃力を超絶に増加する。\n② 装備中の光属性チップの枚数に応じて\n　　 消費ＣＰを減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental power  by 155% + 10% x the\n     number of Light chips equipped.\n<color=yellow>SP: </color>Boosts elemental power  by 165% + 10% x the\n     number of Light chips equipped.\n     <color=yellow>[R-Frame]</color>\n②  Reduces CP consumption by 5% x the number of\n     Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Overwhelmingly boosts elemental power based\n    on the number of Light chips equipped.\n    <color=yellow>[R-Frame]</color>\n② Reduces CP consumption based on the number of\n    Light chips equipped.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31982",
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31983",
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "Status imbued + damage boost vs status",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict random\n    status effects.\n② Immensely boosts damage against enemies\n    affected by status effects.\n    <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31984",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増＋雷属性上限上昇",
 		"tr_explainShort": "Dam. boost x PA/Tech uses + max Ltn up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：超絶）\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 56% each time you use a PA\n     or Tech.\n     (Maximum boost: 280%)\n<color=yellow>SP: </color>Boosts damage by 58% each time you use a PA\n     or Tech.\n     (Maximum boost: 290%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum Lightning by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Greatly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Overwhelming)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31985",
 		"jp_explainShort": "必殺技・法術使用毎に威力大増＋雷属性上限上昇",
 		"tr_explainShort": "Dam. boost x PA/Tech uses + max Ltn up",
 		"jp_explainLong": "① 必殺技・法術を使用するごとに\n　　 威力を大きく増加する。（最大時：極度）\n② 雷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 60% each time you use a PA\n     or Tech.\n     (Maximum boost: 300%)\n<color=yellow>SP: </color>Boosts damage by 62% each time you use a PA\n     or Tech.\n     (Maximum boost: 310%)\n     <color=yellow>[L-Frame]</color>\n②  Increases your maximum Lightning by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "① Greatly boosts damage each time you use a PA\n    or Tech.\n    (Maximum Boost: Maximal)\n    <color=yellow>[L-Frame]</color>\n② Increases your maximum Lightning value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "31986",
 		"jp_explainShort": "炎氷雷の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fire/Ice/Lightning PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・雷属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Lightning PAs and Techs by\n     125%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Lightning PAs and Techs by\n     130%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Ice and Lightning PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31987",
 		"jp_explainShort": "炎氷雷の技・法の攻撃力絶大増",
 		"tr_explainShort": "Fire/Ice/Lightning PAs/Techs boosted",
 		"jp_explainLong": "① 必殺技・法術チップが炎・氷・雷属性の場合は\n　　 威力を絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire, Ice and Lightning PAs and Techs by\n     135%.\n<color=yellow>SP: </color>Boosts Fire, Ice and Lightning PAs and Techs by\n     140%.\n     <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts Fire, Ice and Lightning PAs and\n    Techs.\n    <color=yellow>[K-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31988",
 		"jp_explainShort": "追加大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dealing additional damage + quickened",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31989",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dealing additional damage + quickened",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Deals massive additional damage to enemies.\n    <color=yellow>[Chase]</color>\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31990",
 		"jp_explainShort": "威力絶大増＋氷武器攻撃力小増＋氷属性上限上昇",
 		"tr_explainShort": "Power boost + Ice weapon boost + max Ice up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 攻撃力をわずかに増加する。\n③ 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 140%.\n<color=yellow>SP: </color>Boosts power by 1505%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 25% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "31991",
 		"jp_explainShort": "威力絶大増＋氷武器攻撃力小増＋氷属性上限上昇",
 		"tr_explainShort": "Power boost + Ice weapon boost + max Ice up",
 		"jp_explainLong": "① 威力を絶大に増加する。\n② 装備中の武器の属性が氷属性の場合\n　　 攻撃力をわずかに増加する。\n③ 氷属性の上限値が上昇する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power by 160%.\n<color=yellow>SP: </color>Boosts power by 170%.\n     <color=yellow>[F-Frame]</color>\n②  Boosts damage by 25% if using an Ice weapon.\n     <color=yellow>[H-Frame]</color>\n③  Increases your maximum Ice value by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Immensely boosts power.\n    <color=yellow>[F-Frame]</color>\n② Slightly boosts damage if using an Ice weapon.\n    <color=yellow>[H-Frame]</color>\n③ Increases your maximum Ice value.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "2210",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 670.\n<color=yellow>SP: </color>Increases your ATK by 690.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "2220",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 720.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "2310",
 		"jp_explainShort": "ＨＰが回復する",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers HP by 15%.\n<color=yellow>SP: </color>Recovers HP by 17%.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Recovers HP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "2320",
 		"jp_explainShort": "ＨＰが回復する",
 		"tr_explainShort": "HP recovery",
 		"jp_explainLong": "① ＨＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers HP by 18%.\n<color=yellow>SP: </color>Recovers HP by 20%.\n[Activation Trigger] Successful Just Attack"
+		"tr_explainLong": "① Recovers HP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "80110",
 		"jp_explainShort": "一定以下になった際、ＨＰ・ＣＰが大回復",
 		"tr_explainShort": "HP and CP recovery at low HP",
 		"jp_explainLong": "① ＨＰを大きく回復する。\n② ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時",
-		"tr_explainLong": "①  Recovers HP by 70%.\n<color=yellow>SP: </color>Recovers HP by 75%.\n②  Recovers CP by 70.\n<color=yellow>SP: </color>Recovers CP by 75.\n[Activation Trigger] Damaged to below 50% HP\n[Cooldown] 15 seconds"
+		"tr_explainLong": "① Greatly recovers HP.\n② Greatly recovers CP.\n[Activation Trigger] Damaged to a certain HP level"
 	},
 	{
 		"assign": "80120",
 		"jp_explainShort": "一定以下になった際、ＨＰ・ＣＰが劇的回復",
 		"tr_explainShort": "HP and CP recovery at low HP",
 		"jp_explainLong": "① ＨＰを劇的に回復する。\n② ＣＰを劇的に回復する。\n[発動条件]敵からの攻撃でＨＰが一定以下になった時",
-		"tr_explainLong": "①  Recovers HP by 80%.\n<color=yellow>SP: </color>Recovers HP by 85%.\n②  Recovers CP by 80.\n<color=yellow>SP: </color>Recovers CP by 85.\n[Activation Trigger] Damaged to below 50% HP\n[Cooldown] 15 seconds"
+		"tr_explainLong": "① Dramatically recovers HP.\n② Dramatically recovers CP.\n[Activation Trigger] Damaged to a certain HP level"
 	},
 	{
 		"assign": "80310",
 		"jp_explainShort": "攻撃力が大強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 670.\n<color=yellow>SP: </color>Increases your ATK by 690.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "80320",
 		"jp_explainShort": "攻撃力が劇的強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 720.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "80610",
 		"jp_explainShort": "龍族に対してダメージが大増加",
 		"tr_explainShort": "Damage boosted against Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを大きく増加する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 45%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 55%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Greatly boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Short"
 	},
 	{
 		"assign": "80620",
 		"jp_explainShort": "龍族に対してダメージが劇的増加",
 		"tr_explainShort": "Damage boosted against Dragonkin",
 		"jp_explainLong": "① 龍族に与えるダメージを劇的に増加する。\n[発動条件]龍族に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Dragonkin by 65%.\n<color=yellow>SP: </color>Boosts damage against Dragonkin by 75%.\n     <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Dramatically boosts damage against Dragonkin.\n    <color=yellow>[B-Frame]</color>\n[Activation Trigger] Landing attacks on Dragonkin\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "81310",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 7.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 2 seconds"
+		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "81320",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 12.\n<color=yellow>SP: </color>Recovers CP by 15.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 2 seconds"
+		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "81410",
 		"jp_explainShort": "敵から受けるダメージが大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]必殺技チップ発動時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 50%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 55%.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Short"
 	},
 	{
 		"assign": "81420",
 		"jp_explainShort": "敵から受けるダメージが大軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]必殺技チップ発動時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 60%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 65%.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Short"
 	},
 	{
 		"assign": "81510",
 		"jp_explainShort": "ＣＰが大回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でダウンした時",
-		"tr_explainLong": "①  Recovers CP by 40.\n<color=yellow>SP: </color>Recovers CP by 50.\n[Activation Trigger] Knocked down by an enemy"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Knocked down by an enemy"
 	},
 	{
 		"assign": "81520",
 		"jp_explainShort": "ＣＰが大回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からの攻撃でダウンした時",
-		"tr_explainLong": "①  Recovers CP by 50.\n<color=yellow>SP: </color>Recovers CP by 60.\n[Activation Trigger] Knocked down by an enemy"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Knocked down by an enemy"
 	},
 	{
 		"assign": "40001",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40002",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40003",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40004",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40005",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40006",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40007",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40008",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40009",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40010",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40011",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40012",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40013",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40014",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40015",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40016",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40017",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40018",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40019",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40020",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40021",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40022",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40023",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40024",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40025",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40026",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40027",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40028",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40029",
 		"jp_explainShort": "定期的にＨＰが小回復＋炎の法術が強化",
 		"tr_explainShort": "HP over time + Fire Techs boosted",
 		"jp_explainLong": "① 炎属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Fire Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Fire Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Fire Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40030",
 		"jp_explainShort": "定期的にＨＰが小回復＋炎の法術が大強化",
 		"tr_explainShort": "HP over time + Fire Techs boosted",
 		"jp_explainLong": "① 炎属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Fire Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Fire Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Fire Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40031",
 		"jp_explainShort": "定期的にＨＰが小回復＋氷の法術が強化",
 		"tr_explainShort": "HP over time + Ice Techs boosted",
 		"jp_explainLong": "① 氷属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Ice Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Ice Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Ice Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40032",
 		"jp_explainShort": "定期的にＨＰが小回復＋氷の法術が大強化",
 		"tr_explainShort": "HP over time + Ice Techs boosted",
 		"jp_explainLong": "① 氷属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Ice Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Ice Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Ice Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40033",
 		"jp_explainShort": "定期的にＨＰが小回復＋風の法術が強化",
 		"tr_explainShort": "HP over time + Wind Techs boosted",
 		"jp_explainLong": "① 風属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wind Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40034",
 		"jp_explainShort": "定期的にＨＰが小回復＋風の法術が大強化",
 		"tr_explainShort": "HP over time + Wind Techs boosted",
 		"jp_explainLong": "① 風属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wind Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wind Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wind Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40035",
 		"jp_explainShort": "定期的にＨＰが小回復＋雷の法術が強化",
 		"tr_explainShort": "HP over time + Lightning Techs boosted",
 		"jp_explainLong": "① 雷属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Lightning Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Lightning Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Lightning Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40036",
 		"jp_explainShort": "定期的にＨＰが小回復＋雷の法術が大強化",
 		"tr_explainShort": "HP over time + Lightning Techs boosted",
 		"jp_explainLong": "① 雷属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Lightning Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Lightning Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Lightning Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40037",
 		"jp_explainShort": "定期的にＨＰが小回復＋光の法術が強化",
 		"tr_explainShort": "HP over time + Light Techs boosted",
 		"jp_explainLong": "① 光属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Light Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Light Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40038",
 		"jp_explainShort": "定期的にＨＰが小回復＋光の法術が大強化",
 		"tr_explainShort": "HP over time + Light Techs boosted",
 		"jp_explainLong": "① 光属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Light Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Light Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Light Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40039",
 		"jp_explainShort": "定期的にＨＰが小回復＋闇の法術が強化",
 		"tr_explainShort": "HP over time + Dark Techs boosted",
 		"jp_explainLong": "① 闇属性の法術の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dark Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dark Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40040",
 		"jp_explainShort": "定期的にＨＰが小回復＋闇の法術が大強化",
 		"tr_explainShort": "HP over time + Dark Techs boosted",
 		"jp_explainLong": "① 闇属性の法術の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dark Techs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dark Techs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dark Techs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40041",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40042",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40043",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40044",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40045",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40046",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40047",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40048",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40049",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40050",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40051",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40052",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40053",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40054",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40055",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40056",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40057",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40058",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40059",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40060",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40061",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40062",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40063",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40064",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40065",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40066",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40067",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40068",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40069",
@@ -6003,1022 +6003,1022 @@
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Sword.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Sword.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40082",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Sword.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Sword.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40083",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 自在槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Wired Lances.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Wired Lances.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40084",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 自在槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Wired Lances.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Wired Lances.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40085",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Partizan.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40086",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長槍装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Partizan.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Partizan.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40087",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双小剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Twin Daggers.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Daggers.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40088",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双小剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Twin Daggers.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Daggers.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40089",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 両剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Double Saber.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Double Saber.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40090",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 両剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Double Saber.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Double Saber.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40091",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 鋼拳装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Knuckles.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Knuckles.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40092",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 鋼拳装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Knuckles.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Knuckles.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40093",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 銃剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Gunslash.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Gunslash.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40094",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 銃剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Gunslash.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Gunslash.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40095",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     an Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     an Assault Rifle.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    an Assault Rifle.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40096",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     an Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     an Assault Rifle.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    an Assault Rifle.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40097",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大砲装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Launcher.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Launcher.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40098",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 大砲装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Launcher.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Launcher.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40099",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双機銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Twin Machineguns.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Machineguns.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40100",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 双機銃装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Twin Machineguns.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Twin Machineguns.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40101",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Rod.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Rod.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40102",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 長杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Rod.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Rod.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40103",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 導具装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Talis.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Talis.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40104",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 導具装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Talis.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Talis.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40105",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 短杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Wand.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Wand.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40106",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 短杖装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]法術チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Wand.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Wand.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40107",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 抜剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Katana.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40108",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 抜剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Katana.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Katana.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40109",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 強弓装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     a Bullet Bow.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Bullet Bow.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40110",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 強弓装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     a Bullet Bow.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    a Bullet Bow.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40111",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 魔装脚装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップもしくは法術チップ使用時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Jet Boots.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Jet Boots.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40112",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 魔装脚装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップもしくは法術チップ使用時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Jet Boots.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Jet Boots.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA or Tech chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40113",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 飛翔剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40% when equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 50% when equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Dual Blades.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40114",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "Damage boosted + HP recov. over time",
 		"jp_explainLong": "① 飛翔剣装備時に攻撃力を大きく増加する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60% when equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 70% when equipped with\n     Dual Blades.\n     <color=yellow>[E-Frame]</color>\n②  Recovers HP by 10% every 10 seconds.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Greatly boosts damage when equipped with\n    Dual Blades.\n    <color=yellow>[E-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40115",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40116",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40117",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40118",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40119",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40120",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40121",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40122",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40123",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40124",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40125",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40126",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40127",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40128",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40129",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40130",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40131",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40132",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40133",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40134",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40135",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40136",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40137",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40138",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40139",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40140",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40141",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40142",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40143",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40144",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40145",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40146",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40147",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40148",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40149",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40150",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40151",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40152",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40153",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40154",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40155",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40156",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40157",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40158",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40159",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40160",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40161",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40162",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40163",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40164",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40165",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40166",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40167",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40168",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40169",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40170",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40171",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40172",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40173",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40174",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40175",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40176",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40177",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40178",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40179",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40180",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40181",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40182",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40183",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40184",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40185",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40186",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Assault Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40187",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40188",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40189",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40190",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40191",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40192",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40193",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40194",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40195",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40196",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40197",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40198",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40199",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40200",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が大強化",
 		"tr_explainShort": "HP up over time + Sword PA boost",
 		"jp_explainLong": "① 大剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Sword PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Sword PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Sword PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40201",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40202",
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "HP up over time + Wired Lance PA boost",
 		"jp_explainLong": "① 自在槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Wired Lance PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Wired Lance PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Wired Lance PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40203",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40204",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "HP up over time + Partizan PA boost",
 		"jp_explainLong": "① 長槍の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Partizan PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Partizan PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Partizan PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40205",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40206",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "HP up over time + Twin Dagger PA boost",
 		"jp_explainLong": "① 双小剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Dagger PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Twin Dagger PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Dagger PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40207",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40208",
 		"jp_explainShort": "定期的にＨＰが小回復＋両剣の技が大強化",
 		"tr_explainShort": "HP up over time + Double Saber PA boost",
 		"jp_explainLong": "① 両剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Double Saber PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Double Saber PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Double Saber PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40209",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40210",
 		"jp_explainShort": "定期的にＨＰが小回復＋鋼拳の技が大強化",
 		"tr_explainShort": "HP up over time + Knuckles PA boost",
 		"jp_explainLong": "① 鋼拳の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Knuckles PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Knuckles PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Knuckles PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40211",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40212",
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "HP up over time + Gunslash PA boost",
 		"jp_explainLong": "① 銃剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Gunslash PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40213",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "HP up over time + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40214",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が大強化",
 		"tr_explainShort": "HP up over time + Rifle PA boost",
 		"jp_explainLong": "① 長銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Assault Rifle PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Assault Rifle PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Assault Rifle PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40215",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40216",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "HP up over time + Launcher PA boost",
 		"jp_explainLong": "① 大砲の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Launcher PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Launcher PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Launcher PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40217",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     40%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40218",
 		"jp_explainShort": "定期的にＨＰが小回復＋双機銃の技が大強化",
 		"tr_explainShort": "HP up over time + TMG PA boost",
 		"jp_explainLong": "① 双機銃の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Twin Machinegun PAs by\n     60%.\n<color=yellow>SP: </color>Boosts the power of Twin Machinegun PAs by\n     70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Twin Machinegun PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40219",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40220",
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "HP up over time + Katana PA boost",
 		"jp_explainLong": "① 抜剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Katana PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Katana PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Katana PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40221",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40222",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が大強化",
 		"tr_explainShort": "HP up over time + Bullet Bow PA boost",
 		"jp_explainLong": "① 強弓の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Bullet Bow PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40223",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40224",
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "HP up over time + Jet Boots PA boost",
 		"jp_explainLong": "① 魔装脚の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Jet Boots PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Jet Boots PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Jet Boots PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40225",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 40%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 50%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40226",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "HP up over time + Dual Blades PA boost",
 		"jp_explainLong": "① 飛翔剣の必殺技の威力を大きく強化する。\n② 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Dual Blades PAs by 60%.\n<color=yellow>SP: </color>Boosts the power of Dual Blades PAs by 70%.\n     <color=yellow>[A-Frame]</color>\n②  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts Dual Blades PAs.\n    <color=yellow>[A-Frame]</color>\n② Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40227",
@@ -7039,28 +7039,28 @@
 		"jp_explainShort": "氷属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Sword boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40230",
 		"jp_explainShort": "氷属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Sword boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40231",
 		"jp_explainShort": "雷属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Sword boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40232",
 		"jp_explainShort": "雷属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Sword boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40233",
@@ -7081,14 +7081,14 @@
 		"jp_explainShort": "光属性時小増＋大剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Sword boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 大剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40236",
 		"jp_explainShort": "光属性時増＋大剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Sword boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 大剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Sword.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Sword.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Sword.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40237",
@@ -7123,14 +7123,14 @@
 		"jp_explainShort": "氷属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & W. Lance boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40242",
 		"jp_explainShort": "氷属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & W. Lance boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40243",
@@ -7151,14 +7151,14 @@
 		"jp_explainShort": "風属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & W. Lance boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40246",
 		"jp_explainShort": "風属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & W. Lance boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40247",
@@ -7179,28 +7179,28 @@
 		"jp_explainShort": "闇属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & W. Lance boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 自在槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40250",
 		"jp_explainShort": "闇属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & W. Lance boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 自在槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Wired Lances.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Wired Lances.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Wired Lances.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40251",
 		"jp_explainShort": "炎属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Partizan boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40252",
 		"jp_explainShort": "炎属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Partizan boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40253",
@@ -7235,28 +7235,28 @@
 		"jp_explainShort": "風属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Partizan boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40258",
 		"jp_explainShort": "風属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Partizan boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40259",
 		"jp_explainShort": "光属性時小増＋長槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Partizan boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 長槍の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40260",
 		"jp_explainShort": "光属性時増＋長槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Partizan boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 長槍の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Partizan.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Partizan.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Partizan.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40261",
@@ -7319,56 +7319,56 @@
 		"jp_explainShort": "風属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40270",
 		"jp_explainShort": "風属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40271",
 		"jp_explainShort": "光属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40272",
 		"jp_explainShort": "光属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40273",
 		"jp_explainShort": "闇属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 双小剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40274",
 		"jp_explainShort": "闇属性時増＋双小剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & T. Dagger boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 双小剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Daggers.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Daggers.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Daggers.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40275",
 		"jp_explainShort": "炎属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & D. Saber boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40276",
 		"jp_explainShort": "炎属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & D. Saber boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40277",
@@ -7417,42 +7417,42 @@
 		"jp_explainShort": "光属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & D. Saber boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40284",
 		"jp_explainShort": "光属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & D. Saber boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40285",
 		"jp_explainShort": "闇属性時小増＋両剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & D. Saber boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 両剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40286",
 		"jp_explainShort": "闇属性時増＋両剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & D. Saber boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 両剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Double Saber.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Double Saber.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Double Saber.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40287",
 		"jp_explainShort": "炎属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Knuckles boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40288",
 		"jp_explainShort": "炎属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Knuckles boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40289",
@@ -7473,14 +7473,14 @@
 		"jp_explainShort": "雷属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Knuckles boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40292",
 		"jp_explainShort": "雷属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Knuckles boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40293",
@@ -7515,42 +7515,42 @@
 		"jp_explainShort": "闇属性時小増＋鋼拳時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Knuckles boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 鋼拳の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40298",
 		"jp_explainShort": "闇属性時増＋鋼拳時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Knuckles boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 鋼拳の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Knuckles.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Knuckles.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Knuckles.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40299",
 		"jp_explainShort": "炎属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Gunslash boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40300",
 		"jp_explainShort": "炎属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Gunslash boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40301",
 		"jp_explainShort": "氷属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Gunslash boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40302",
 		"jp_explainShort": "氷属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Gunslash boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40303",
@@ -7571,14 +7571,14 @@
 		"jp_explainShort": "風属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Gunslash boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 銃剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40306",
 		"jp_explainShort": "風属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Gunslash boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 銃剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Gunslash.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Gunslash.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Gunslash.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40307",
@@ -7613,14 +7613,14 @@
 		"jp_explainShort": "炎属性時小増＋抜剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Katana boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 抜剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40312",
 		"jp_explainShort": "炎属性時増＋抜剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Katana boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 抜剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40313",
@@ -7641,14 +7641,14 @@
 		"jp_explainShort": "雷属性時小増＋抜剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Katana boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 抜剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40316",
 		"jp_explainShort": "雷属性時増＋抜剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Katana boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 抜剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Katana.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Katana.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Katana.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40317",
@@ -7711,14 +7711,14 @@
 		"jp_explainShort": "氷属性時小増＋飛翔剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 飛翔剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40326",
 		"jp_explainShort": "氷属性時増＋飛翔剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 飛翔剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40327",
@@ -7739,14 +7739,14 @@
 		"jp_explainShort": "風属性時小増＋飛翔剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 飛翔剣の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40330",
 		"jp_explainShort": "風属性時増＋飛翔剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Dual Blades boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 飛翔剣の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Dual Blades.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Dual Blades.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Dual Blades.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40331",
@@ -7781,14 +7781,14 @@
 		"jp_explainShort": "炎属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rifle boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40336",
 		"jp_explainShort": "炎属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rifle boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40337",
@@ -7823,14 +7823,14 @@
 		"jp_explainShort": "風属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Rifle boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40342",
 		"jp_explainShort": "風属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Rifle boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40343",
@@ -7851,14 +7851,14 @@
 		"jp_explainShort": "闇属性時小増＋長銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rifle boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 長銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40346",
 		"jp_explainShort": "闇属性時増＋長銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rifle boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 長銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with an\n     Assault Rifle.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with an\n     Assault Rifle.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with an\n    Assault Rifle.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40347",
@@ -7879,42 +7879,42 @@
 		"jp_explainShort": "氷属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Launcher boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40350",
 		"jp_explainShort": "氷属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Launcher boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40351",
 		"jp_explainShort": "雷属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Launcher boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40352",
 		"jp_explainShort": "雷属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Launcher boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40353",
 		"jp_explainShort": "風属性時小増＋大砲時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Launcher boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 大砲の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40354",
 		"jp_explainShort": "風属性時増＋大砲時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Launcher boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 大砲の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Launcher.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Launcher.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Launcher.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40355",
@@ -7949,28 +7949,28 @@
 		"jp_explainShort": "炎属性時小増＋双機銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & TMG boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 双機銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40360",
 		"jp_explainShort": "炎属性時増＋双機銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & TMG boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 双機銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40361",
 		"jp_explainShort": "氷属性時小増＋双機銃時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 双機銃の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40362",
 		"jp_explainShort": "氷属性時増＋双機銃時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & TMG boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 双機銃の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Twin Machineguns.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Twin Machineguns.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Twin Machineguns.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40363",
@@ -8061,14 +8061,14 @@
 		"jp_explainShort": "雷属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40376",
 		"jp_explainShort": "雷属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40377",
@@ -8089,28 +8089,28 @@
 		"jp_explainShort": "光属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40380",
 		"jp_explainShort": "光属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40381",
 		"jp_explainShort": "闇属性時小増＋強弓時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 強弓の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40382",
 		"jp_explainShort": "闇属性時増＋強弓時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Bullet Bow boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 強弓の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Bullet Bow.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Bullet Bow.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Bullet Bow.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40383",
@@ -8145,14 +8145,14 @@
 		"jp_explainShort": "雷属性時小増＋魔装脚時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & J. Boots boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 魔装脚の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40388",
 		"jp_explainShort": "雷属性時増＋魔装脚時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & J. Boots boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 魔装脚の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40389",
@@ -8173,14 +8173,14 @@
 		"jp_explainShort": "光属性時小増＋魔装脚時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Jet Boots boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 魔装脚の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40392",
 		"jp_explainShort": "光属性時増＋魔装脚時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Jet Boots boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 魔装脚の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     Jet Boots.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     Jet Boots.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    Jet Boots.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40393",
@@ -8201,28 +8201,28 @@
 		"jp_explainShort": "炎属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rod boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40396",
 		"jp_explainShort": "炎属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Fire & Rod boost + HP over time",
 		"jp_explainLong": "① 炎属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Fire weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Fire weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Fire weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40397",
 		"jp_explainShort": "氷属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Rod boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40398",
 		"jp_explainShort": "氷属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Rod boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40399",
@@ -8271,14 +8271,14 @@
 		"jp_explainShort": "闇属性時小増＋長杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rod boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 長杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40406",
 		"jp_explainShort": "闇属性時増＋長杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Rod boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 長杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Rod.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Rod.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Rod.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40407",
@@ -8299,14 +8299,14 @@
 		"jp_explainShort": "氷属性時小増＋導具時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Talis boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力をわずかに増加する。\n② 導具の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40410",
 		"jp_explainShort": "氷属性時増＋導具時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Ice & Talis boost + HP over time",
 		"jp_explainLong": "① 氷属性の武器の場合に威力を増加する。\n② 導具の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     an Ice weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     an Ice weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    an Ice weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40411",
@@ -8341,14 +8341,14 @@
 		"jp_explainShort": "光属性時小増＋導具時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Talis boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力をわずかに増加する。\n② 導具の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40416",
 		"jp_explainShort": "光属性時増＋導具時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Light & Talis boost + HP over time",
 		"jp_explainLong": "① 光属性の武器の場合に威力を増加する。\n② 導具の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Light weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Light weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Talis.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Talis.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Light weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Talis.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40417",
@@ -8397,28 +8397,28 @@
 		"jp_explainShort": "雷属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Wand boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40424",
 		"jp_explainShort": "雷属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Lightning & Wand boost + HP over time",
 		"jp_explainLong": "① 雷属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Lightning weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Lightning weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Lightning weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40425",
 		"jp_explainShort": "風属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Wand boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40426",
 		"jp_explainShort": "風属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Wind & Wand boost + HP over time",
 		"jp_explainLong": "① 風属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Wind weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wind weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Wind weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40427",
@@ -8439,182 +8439,182 @@
 		"jp_explainShort": "闇属性時小増＋短杖時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Wand boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力をわずかに増加する。\n② 短杖の場合に攻撃力をわずかに増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 20% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 25% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Slightly boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "40430",
 		"jp_explainShort": "闇属性時増＋短杖時増＋定期ＨＰ小回復",
 		"tr_explainShort": "Dark & Wand boost + HP over time",
 		"jp_explainLong": "① 闇属性の武器の場合に威力を増加する。\n② 短杖の場合に攻撃力を増加する。\n③ 定期的にＨＰをわずかに回復する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 30% if equipped with\n     a Dark weapon.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Dark weapon.\n     <color=yellow>[M-Frame]</color>\n②  Boosts damage by 30% if equipped with\n     a Wand.\n<color=yellow>SP: </color>Boosts damage by 35% if equipped with\n     a Wand.\n     <color=yellow>[N-Frame]</color>\n③  Recovers HP by 10% every 6 seconds.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage if equipped with\n    a Dark weapon.\n    <color=yellow>[M-Frame]</color>\n② Boosts damage if equipped with\n    a Wand.\n    <color=yellow>[N-Frame]</color>\n③ Slightly recovers HP at regular intervals.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "21310",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 10.\n<color=yellow>SP: </color>Increases your Fire Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21410",
 		"jp_explainShort": "炎属性が強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Fire Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21510",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 10.\n<color=yellow>SP: </color>Increases your Ice Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21610",
 		"jp_explainShort": "氷属性が強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 20.\n<color=yellow>SP: </color>Increases your Ice Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Ice Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21710",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 10.\n<color=yellow>SP: </color>Increases your Lightning Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21810",
 		"jp_explainShort": "雷属性が強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 20.\n<color=yellow>SP: </color>Increases your Lightning Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Lightning Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "21910",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 10.\n<color=yellow>SP: </color>Increases your Wind Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "22010",
 		"jp_explainShort": "風属性が強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 20.\n<color=yellow>SP: </color>Increases your Wind Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Wind Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "22110",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 10.\n<color=yellow>SP: </color>Increases your Light Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "22210",
 		"jp_explainShort": "光属性が強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 20.\n<color=yellow>SP: </color>Increases your Light Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Light Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "22310",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 10.\n<color=yellow>SP: </color>Increases your Dark Element by 12.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "22410",
 		"jp_explainShort": "闇属性が強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性を強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 20.\n<color=yellow>SP: </color>Increases your Dark Element by 24.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Increases Dark Element.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3410",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 45.\n<color=yellow>SP: </color>Increases your ATK by 50.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
 	},
 	{
 		"assign": "3420",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 60.\n<color=yellow>SP: </color>Increases your ATK by 72.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
 	},
 	{
 		"assign": "3510",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 2.\n<color=yellow>SP: </color>Increases your Dark Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3520",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 4.\n<color=yellow>SP: </color>Increases your Dark Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3610",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 4.\n<color=yellow>SP: </color>Increases your Dark Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3620",
 		"jp_explainShort": "闇属性が小強化",
 		"tr_explainShort": "Dark Element up",
 		"jp_explainLong": "① 闇属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Dark Element by 7.\n<color=yellow>SP: </color>Increases your Dark Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Dark Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "3710",
 		"jp_explainShort": "一定確率で「ポイズン」状態にする",
 		"tr_explainShort": "[Poison] imbued",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "3720",
 		"jp_explainShort": "一定確率で「ポイズン」状態にする",
 		"tr_explainShort": "[Poison] imbued",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4210",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 72.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
 	},
 	{
 		"assign": "4220",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]バトル開始時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your DEF by 78.\n<color=yellow>SP: </color>Increases your DEF by 93.\n[Activation Trigger] Start of battle\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Start of battle\n[Effect Duration] Long"
 	},
 	{
 		"assign": "4410",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 7% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 10% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4420",
 		"jp_explainShort": "追加で小ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で小ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 12% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4610",
@@ -8635,210 +8635,210 @@
 		"jp_explainShort": "闇属性が強化＋攻撃力が小強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 100.\n<color=yellow>SP: </color>Increases your ATK by 110.\n②  Increases your Dark Element by 30.\n<color=yellow>SP: </color>Increases your Dark Element by 35.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Increases Dark Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "4720",
 		"jp_explainShort": "闇属性が強化＋攻撃力が小強化",
 		"tr_explainShort": "Dark Element up + ATK up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 闇属性を強化する。\n[発動条件]必殺技チップ発動時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 120.\n<color=yellow>SP: </color>Increases your ATK by 130.\n②  Increases your Dark Element by 40.\n<color=yellow>SP: </color>Increases your Dark Element by 45.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Increases Dark Element.\n[Activation Trigger] Activating a PA chip\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20001",
 		"jp_explainShort": "攻撃力と防御力が小強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 防御力をわずかに強化する。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 200.\n<color=yellow>SP: </color>Increases your ATK by 240.\n②  Increases your DEF by 200.\n<color=yellow>SP: </color>Increases your DEF by 240.\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Slightly increases DEF.\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20002",
 		"jp_explainShort": "攻撃力と防御力が小強化",
 		"tr_explainShort": "ATK & DEF up",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② 防御力をわずかに強化する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 250.\n<color=yellow>SP: </color>Increases your ATK by 300.\n②  Increases your DEF by 250.\n<color=yellow>SP: </color>Increases your DEF by 300.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Slightly increases DEF.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "5210",
 		"jp_explainShort": "ダーカーから受けるダメージが軽減",
 		"tr_explainShort": "Damage from Darkers reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]ダーカーからダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Darkers\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Darkers"
 	},
 	{
 		"assign": "5220",
 		"jp_explainShort": "ダーカーから受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Darkers reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]ダーカーからダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Darkers\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Darkers"
 	},
 	{
 		"assign": "20013",
 		"jp_explainShort": "攻撃力小増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 12%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 10% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20014",
 		"jp_explainShort": "攻撃力小増加＋一定確率で回避",
 		"tr_explainShort": "Damage boost + chance to avoid damage",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Grants a 10% chance to avoid damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20015",
 		"jp_explainShort": "攻撃力小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]バトル開始時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 5%.\n<color=yellow>SP: </color>Boosts damage by 6%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% damage dealt as HP.\n     (Maximum recovery: 1% of your max HP).\n[Activation Trigger] Start of battle\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Start of battle\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20016",
 		"jp_explainShort": "攻撃力小増加＋ダメージの一部ＨＰ回復",
 		"tr_explainShort": "Damage boosted + damage HP recovery",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 与えたダメージの一部を自身のＨＰとして回復する。\n[発動条件]バトル開始時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 8%.\n<color=yellow>SP: </color>Boosts damage by 10%.\n     <color=yellow>[E-Frame]</color>\n②  Recovers 1% damage dealt as HP.\n     (Maximum recovery: 1% of your max HP).\n[Activation Trigger] Start of battle\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Recovers a fraction of damage dealt as HP.\n[Activation Trigger] Start of battle\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20041",
 		"jp_explainShort": "攻撃力小増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boosted + CP consumption down",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 5%.\n<color=yellow>SP: </color>Boosts damage by 8%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 5%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20042",
 		"jp_explainShort": "攻撃力小増加＋消費ＣＰ減少",
 		"tr_explainShort": "Damage boosted + CP consumption down",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 消費ＣＰを減少する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 11%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces CP consumption by 5%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces CP consumption.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20047",
 		"jp_explainShort": "攻撃力小増加＋追加小ダメージ＋加速",
 		"tr_explainShort": "Dam. boost + add. dam. + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20048",
 		"jp_explainShort": "攻撃力小増加＋追加小ダメージ＋加速",
 		"tr_explainShort": "Dam. boost + add. dam. + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "5610",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 2.\n<color=yellow>SP: </color>Increases your Wind Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5620",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 4.\n<color=yellow>SP: </color>Increases your Wind Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5710",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 4.\n<color=yellow>SP: </color>Increases your Wind Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5720",
 		"jp_explainShort": "風属性が小強化",
 		"tr_explainShort": "Wind Element up",
 		"jp_explainLong": "① 風属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 7.\n<color=yellow>SP: </color>Increases your Wind Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Wind Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5810",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5820",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 50.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "5910",
 		"jp_explainShort": "敵からのダメージが軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 20%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 25%.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "5920",
 		"jp_explainShort": "敵からのダメージが軽減",
 		"tr_explainShort": "Damage taken reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken from enemies by 30%.\n<color=yellow>SP: </color>Reduces damage taken from enemies by 35%.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies"
 	},
 	{
 		"assign": "6210",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 2.\n<color=yellow>SP: </color>Increases your Ice Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "6220",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 4.\n<color=yellow>SP: </color>Increases your Ice Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "6310",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 4.\n<color=yellow>SP: </color>Increases your Ice Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "6320",
 		"jp_explainShort": "氷属性が小強化",
 		"tr_explainShort": "Ice Element up",
 		"jp_explainLong": "① 氷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Ice Element by 7.\n<color=yellow>SP: </color>Increases your Ice Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Ice Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "6510",
 		"jp_explainShort": "追加で中ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で中ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "6520",
 		"jp_explainShort": "追加で大ダメージ",
 		"tr_explainShort": "Additional damage to enemies",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Deals heavy additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "6910",
 		"jp_explainShort": "原生種から受けるダメージが軽減",
 		"tr_explainShort": "Damage from Natives reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]原生種からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Natives\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Natives"
 	},
 	{
 		"assign": "6920",
 		"jp_explainShort": "原生種から受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Natives reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]原生種からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Natives\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Natives"
 	},
 	{
 		"assign": "7610",
@@ -8859,433 +8859,433 @@
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "7720",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your DEF by 80.\n<color=yellow>SP: </color>Increases your DEF by 100.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "7810",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "7820",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 45.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "7910",
 		"jp_explainShort": "ＣＰが小回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "7920",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "8010",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 4.\n<color=yellow>SP: </color>Increases your Fire Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8020",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 7.\n<color=yellow>SP: </color>Increases your Fire Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8110",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 2.\n<color=yellow>SP: </color>Increases your Fire Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8120",
 		"jp_explainShort": "炎属性が小強化",
 		"tr_explainShort": "Fire Element up",
 		"jp_explainLong": "① 炎属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 4.\n<color=yellow>SP: </color>Increases your Fire Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Fire Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8210",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your DEF by 60.\n<color=yellow>SP: </color>Increases your DEF by 70.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "8220",
 		"jp_explainShort": "防御力が小強化",
 		"tr_explainShort": "DEF up",
 		"jp_explainLong": "① 防御力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your DEF by 80.\n<color=yellow>SP: </color>Increases your DEF by 100.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases DEF.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "8310",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 20.\n<color=yellow>SP: </color>Increases your ATK by 30.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "8320",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 45.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "8410",
 		"jp_explainShort": "ＣＰが小回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰをわずかに回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 5.\n<color=yellow>SP: </color>Recovers CP by 7.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Slightly recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "8420",
 		"jp_explainShort": "ＣＰが回復",
 		"tr_explainShort": "CP recovery",
 		"jp_explainLong": "① ＣＰを回復する。\n[発動条件]ジャストアタック成功時",
-		"tr_explainLong": "①  Recovers CP by 8.\n<color=yellow>SP: </color>Recovers CP by 10.\n[Activation Trigger] Successful Just Attack\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Recovers CP.\n[Activation Trigger] Successful Just Attack"
 	},
 	{
 		"assign": "8510",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 4.\n<color=yellow>SP: </color>Increases your Light Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8520",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 7.\n<color=yellow>SP: </color>Increases your Light Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8610",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 2.\n<color=yellow>SP: </color>Increases your Light Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8620",
 		"jp_explainShort": "光属性が小強化",
 		"tr_explainShort": "Light Element up",
 		"jp_explainLong": "① 光属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Light Element by 4.\n<color=yellow>SP: </color>Increases your Light Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Light Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "8810",
 		"jp_explainShort": "龍族から受けるダメージが軽減",
 		"tr_explainShort": "Reduces damage from Dragonkin",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]龍族からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Dragonkin\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Dragonkin"
 	},
 	{
 		"assign": "8820",
 		"jp_explainShort": "龍族から受けるダメージが大軽減",
 		"tr_explainShort": "Reduces damage from Dragonkin",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]龍族からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Dragonkin\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Dragonkin"
 	},
 	{
 		"assign": "9010",
 		"jp_explainShort": "一定確率で「パニック」状態にする",
 		"tr_explainShort": "[Panic] imbued",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "9020",
 		"jp_explainShort": "一定確率で「パニック」状態にする",
 		"tr_explainShort": "[Panic] imbued",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "① Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "20023",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost + barrier",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 12%.\n<color=yellow>SP: </color>Boosts damage by 18%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     35% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     40% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20024",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御",
 		"tr_explainShort": "Damage boost + barrier",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 24%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage up to\n     45% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage up to\n     50% of your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] Long"
 	},
 	{
 		"assign": "20029",
 		"jp_explainShort": "攻撃力が小強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 250.\n<color=yellow>SP: </color>Increases your ATK by 300.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20030",
 		"jp_explainShort": "攻撃力が強化＋ダウン無効",
 		"tr_explainShort": "ATK up + knockdown immunity",
 		"jp_explainLong": "① 攻撃力を強化する。\n② ダウンしなくなる。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 350.\n<color=yellow>SP: </color>Increases your ATK by 400.\n②  Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Increases ATK.\n② Grants knockdown immunity.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20031",
 		"jp_explainShort": "光属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Light Element up + actions quickened",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Light Element by 60.\n<color=yellow>SP: </color>Increases your Light Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly increases Light Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20032",
 		"jp_explainShort": "光属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Light Element up + actions quickened",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly increases Light Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "9510",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 2.\n<color=yellow>SP: </color>Increases your Lightning Element by 3.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "9520",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]敵からダメージを受けた時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 4.\n<color=yellow>SP: </color>Increases your Lightning Element by 6.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Short"
 	},
 	{
 		"assign": "9610",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 4.\n<color=yellow>SP: </color>Increases your Lightning Element by 6.\n[Activation Trigger] Landing an attack\n[Effect Duration] 8 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "9620",
 		"jp_explainShort": "雷属性が小強化",
 		"tr_explainShort": "Lightning Element up",
 		"jp_explainLong": "① 雷属性をわずかに強化する。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 7.\n<color=yellow>SP: </color>Increases your Lightning Element by 10.\n[Activation Trigger] Landing an attack\n[Effect Duration] 12 seconds"
+		"tr_explainLong": "① Slightly increases Lightning Element.\n[Activation Trigger] Landing an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "9710",
 		"jp_explainShort": "機甲種から受けるダメージが軽減",
 		"tr_explainShort": "Damage from Mechs reduced",
 		"jp_explainLong": "① 敵から受けるダメージを軽減する。\n[発動条件]機甲種からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 35%.\n<color=yellow>SP: </color>Reduces damage taken by 45%.\n[Activation Trigger] Taking damage from Mechs\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Mechs"
 	},
 	{
 		"assign": "9720",
 		"jp_explainShort": "機甲種から受けるダメージが大軽減",
 		"tr_explainShort": "Damage from Mechs reduced",
 		"jp_explainLong": "① 敵から受けるダメージを大きく軽減する。\n[発動条件]機甲種からダメージを受けた時",
-		"tr_explainLong": "①  Reduces damage taken by 50%.\n<color=yellow>SP: </color>Reduces damage taken by 60%.\n[Activation Trigger] Taking damage from Mechs\n[Cooldown] 5 seconds"
+		"tr_explainLong": "① Greatly reduces damage taken from enemies.\n[Activation Trigger] Taking damage from Mechs"
 	},
 	{
 		"assign": "20033",
 		"jp_explainShort": "攻撃３回毎に攻撃力小強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 15% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 20% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Great)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20034",
 		"jp_explainShort": "攻撃３回毎に攻撃力小強化＋追加小ダメージ",
 		"tr_explainShort": "3 actions = ATK up + additional damage",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly increases ATK every 3 times you use an\n    active chip or a normal attack.\n    (Maximum increase: Great)\n② Deals minor additional damage to enemies.\n    <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20039",
 		"jp_explainShort": "攻撃力小増加＋ダメージ大軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + down + knockback immune",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20040",
 		"jp_explainShort": "攻撃力小増加＋ダメージ大軽減＋ダウン無効",
 		"tr_explainShort": "Dam. boost + down + knockback immune",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを大きく軽減する。\n③ ダウンしなくなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 40%.\n③  Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Greatly reduces damage taken from enemies.\n③ Grants knockdown immunity.\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "25310",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② チップ強化の素材に使うと効果大。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 40.\n<color=yellow>SP: </color>Increases your ATK by 50.\n②  A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "25410",
 		"jp_explainShort": "攻撃力が小強化",
 		"tr_explainShort": "ATK increased",
 		"jp_explainLong": "① 攻撃力をわずかに強化する。\n② チップ強化の素材に使うと効果大。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 60.\n<color=yellow>SP: </color>Increases your ATK by 70.\n②  A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly increases ATK.\n② A very effective material for Chip Grinding.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20003",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your ATK by 75% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 85% against enemy\n     elemental weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20004",
 		"jp_explainShort": "弱点属性で攻撃時にダメージ量が増加",
 		"tr_explainShort": "Elemental weakness damage boosted",
 		"jp_explainLong": "① 敵の弱点に有効な属性でのダメージを増加する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts your ATK by 100% against enemy\n     elemental weaknesses.\n<color=yellow>SP: </color>Boosts your ATK by 120% against enemy\n     elemental weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against enemy elemental\n    weaknesses.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20021",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "①  Recovers CP by 50.\n<color=yellow>SP: </color>Recovers CP by 60.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
 	},
 	{
 		"assign": "20022",
 		"jp_explainShort": "ＣＰ大回復",
 		"tr_explainShort": "Large CP recovery",
 		"jp_explainLong": "① ＣＰを大きく回復する。\n[発動条件]敵からダメージを受けた時",
-		"tr_explainLong": "①  Recovers CP by 70.\n<color=yellow>SP: </color>Recovers CP by 80.\n[Activation Trigger] Taking damage from enemies"
+		"tr_explainLong": "① Greatly recovers CP.\n[Activation Trigger] Taking damage"
 	},
 	{
 		"assign": "20045",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 1%.\n<color=yellow>SP: </color>Boosts damage by 3%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 1% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Taking an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Short"
 	},
 	{
 		"assign": "20046",
 		"jp_explainShort": "攻撃力小増加＋カウンターダメージ",
 		"tr_explainShort": "Damage boosted + countering attacks",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 攻撃対象の敵から攻撃を受けた時\n　　 そのダメージに応じたカウンターを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 6%.\n<color=yellow>SP: </color>Boosts damage by 10%.\n     <color=yellow>[E-Frame]</color>\n②  When you take damage from the target,\n     responds by dealing 1% of that damage back\n     to the target.\n     (Maximum counterattack damage: 500,000)\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Responds to damage from the targeted enemy\n    with a proportional counterattack.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20051",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 5% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage\n     up to 10% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20052",
 		"jp_explainShort": "攻撃力小増加＋ダメージ防御＋加速",
 		"tr_explainShort": "Dam. boost + barrier + quickened",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a barrier that prevents damage\n     up to 10% of your maximum HP.\n<color=yellow>SP: </color>Grants you a barrier that prevents damage\n     up to 15% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Taking an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Grants you a barrier that prevents damage\n    based on your maximum HP.\n③ Increases speed of movement and normal attacks.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20055",
 		"jp_explainShort": "必殺技・法術威力強化＋一定確率で回避",
 		"tr_explainShort": "PAs & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 30%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 35%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 15% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 20% chance to avoid damage from\n     enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20056",
 		"jp_explainShort": "必殺技・法術威力大強化＋一定確率で回避",
 		"tr_explainShort": "PAs & Techs boosted + chance to evade",
 		"jp_explainLong": "① 必殺技・法術の威力を大きく強化する。\n② 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 40%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 45%.\n     <color=yellow>[A-Frame]</color>\n②  Grants a 25% chance to avoid damage from\n     enemies.\n<color=yellow>SP: </color>Grants a 30% chance to avoid damage from\n     enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Greatly boosts PAs and Techs.\n    <color=yellow>[A-Frame]</color>\n② Grants a chance to avoid damage from enemies.\n[Activation Trigger] Taking an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20057",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 海岸か海底での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% when fighting in\n     the Coast or the Seabed.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    the Coast or the Seabed.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20058",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 海岸か海底での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Further boosts damage by 50% when fighting in\n     the Coast or the Seabed.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    the Coast or the Seabed.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20061",
 		"jp_explainShort": "闇属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dark Element up + actions quickened",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly increases Dark Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20062",
 		"jp_explainShort": "闇属性が大強化＋通常攻撃と移動が加速",
 		"tr_explainShort": "Dark Element up + actions quickened",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Greatly increases Dark Element.\n② Increases speed of movement and normal attacks.\n[Activation Trigger] Slide Action\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20063",
 		"jp_explainShort": "攻撃力小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted + damage reduced",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20064",
 		"jp_explainShort": "攻撃力小増加＋ダメージ軽減",
 		"tr_explainShort": "Damage boosted + damage reduced",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵から受けるダメージを軽減する。\n[発動条件]敵からダメージを受けた時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Reduces damage taken from enemies by 30%.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Reduces damage taken from enemies.\n[Activation Trigger] Taking damage from enemies\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20067",
 		"jp_explainShort": "黒の民にダメージ小増加＋闇属性強化",
 		"tr_explainShort": "Dam. boost vs Kuronites + Dark elem. up",
 		"jp_explainLong": "① 黒の民に与えるダメージをわずかに増加する。\n② 闇属性を強化する。\n[発動条件]黒の民に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Kuronites by 15%.\n<color=yellow>SP: </color>Boosts damage against Kuronites by 20%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Dark Element by 20.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "① Slightly boosts damage against Kuronites.\n    <color=yellow>[B-Frame]</color>\n② Increases Dark Element.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20068",
 		"jp_explainShort": "黒の民にダメージ増加＋闇属性強化",
 		"tr_explainShort": "Dam. boost vs Kuronites + Dark elem. up",
 		"jp_explainLong": "① 黒の民に与えるダメージを増加する。\n② 闇属性を強化する。\n[発動条件]黒の民に攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage against Kuronites by 25%.\n<color=yellow>SP: </color>Boosts damage against Kuronites by 30%.\n     <color=yellow>[B-Frame]</color>\n②  Increases your Dark Element by 20.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Boosts damage against Kuronites.\n    <color=yellow>[B-Frame]</color>\n② Increases Dark Element.\n[Activation Trigger] Landing attacks on Kuronites\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20069",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 黒ノ領域での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 15%.\n<color=yellow>SP: </color>Boosts damage by 20%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when fighting in\n     Kuron.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    Kuron.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	},
 	{
 		"assign": "20070",
 		"jp_explainShort": "攻撃力小増加＋特定地形で攻撃力大増加",
 		"tr_explainShort": "Dam. boost + dam. boost in specific area",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 黒ノ領域での戦闘で\n　　 さらに攻撃力を大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 25%.\n<color=yellow>SP: </color>Boosts damage by 30%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 50% when fighting in\n     Kuron.\n     <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "① Slightly boosts damage.\n    <color=yellow>[E-Frame]</color>\n② Further boosts damage when fighting in\n    Kuron.\n    <color=yellow>[I-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] Medium"
 	}
 ]

--- a/json/Item_Stack_LobbyAction.txt
+++ b/json/Item_Stack_LobbyAction.txt
@@ -3637,14 +3637,14 @@
 		"jp_text": "515「飛行ポーズ」",
 		"tr_text": "515 \"Flying Pose\"",
 		"jp_explain": "ロビアク『飛行ポーズ』\nを全キャラクターで使用可能になる。\n対応機能：ボタン派生",
-		"tr_explain": "Unlocks the new lobby action\n\"Flying Pose\"."
+		"tr_explain": "Unlocks the new lobby action\n\"Flying Pose\".\nUse action buttons for extra actions."
 	},
 	{
 		"assign": "3230530",
 		"jp_text": "516「気を高める」",
 		"tr_text": "516 \"Raise Spirit\"",
 		"jp_explain": "ロビアク『気を高める』\nを全キャラクターで使用可能になる。\n対応機能：リアクション",
-		"tr_explain": "Unlocks the new lobby action\n\"Raise Spirit\"."
+		"tr_explain": "Unlocks the new lobby action\n\"Raise Spirit\".\nReaction has extra actions."
 	},
 	{
 		"assign": "3230531",

--- a/json/Leisure_PhotonDice_SpeakText.txt
+++ b/json/Leisure_PhotonDice_SpeakText.txt
@@ -1951,7 +1951,7 @@
 		],
 		"tr_patterns": [
 			"Our time together will continue...",
-			"...I saw your serious side.\r\nNext time...I'll be serious too..."
+			"...I saw your serious side.\r\nNext time... I'll be serious too..."
 		]
 	},
 	{

--- a/json/Leisure_PhotonDice_SpeakText.txt
+++ b/json/Leisure_PhotonDice_SpeakText.txt
@@ -1940,7 +1940,7 @@
 		],
 		"tr_patterns": [
 			"I lost.\r\nNext time, I must do better...",
-			"Amazing... As expected of you, Leader."
+			"Amazing...\nAs expected of you, Leader."
 		]
 	},
 	{

--- a/json/Name_Chip_ActiveName.txt
+++ b/json/Name_Chip_ActiveName.txt
@@ -1697,7 +1697,7 @@
 	{
 		"assign": "31963",
 		"jp_text": "我ら、オラクル戦隊セイガーズ！",
-		"tr_text": "Let's go, Oracle Squadron, Seigas!"
+		"tr_text": "Let's go, Oracle Squadron Seigas!"
 	},
 	{
 		"assign": "31964",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -21857,7 +21857,7 @@
 	{
 		"assign": "chip_awake_dialog_b_done_chiplv",
 		"jp_text": "最大チップLv.",
-		"tr_text": ""
+		"tr_text": "Max Chip Lv."
 	},
 	{
 		"assign": "chip_awake_dialog_b_done_skilllv",
@@ -21867,7 +21867,7 @@
 	{
 		"assign": "chip_awake_dialog_button_close",
 		"jp_text": "閉じる",
-		"tr_text": ""
+		"tr_text": "Close"
 	},
 	{
 		"assign": "chip_awake_skill_dialog_t_done",
@@ -21892,12 +21892,12 @@
 	{
 		"assign": "chip_awake_skill_dialog_button_close",
 		"jp_text": "閉じる",
-		"tr_text": ""
+		"tr_text": "Close"
 	},
 	{
 		"assign": "chip_details_chip_awake_head",
 		"jp_text": "特装プラグ",
-		"tr_text": ""
+		"tr_text": "Plug Details"
 	},
 	{
 		"assign": "chip_details_chip_awake_skilllv",
@@ -21907,7 +21907,7 @@
 	{
 		"assign": "chip_details_chip_awake_lv0",
 		"jp_text": "未習得",
-		"tr_text": ""
+		"tr_text": "Lv. 0"
 	},
 	{
 		"assign": "window_help_LM39",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -2117,7 +2117,7 @@
 	{
 		"assign": "labo_dialog_b_01",
 		"jp_text": "選択した素材チップに\n★７以上のものが含まれています。\n強化の素材にしたチップは失われますが\nよろしいですか？",
-		"tr_text": "One or more of the materials\nhas a rarity of ★７+ stars。\nThese will be lost upon use.\nAre you sure?"
+		"tr_text": "One or more of the materials\nhas a rarity of ★７+ stars.\nThese will be lost upon use.\nAre you sure?"
 	},
 	{
 		"assign": "labo_dialog_t_02",
@@ -2177,7 +2177,7 @@
 	{
 		"assign": "labo_dialog_b_05",
 		"jp_text": "使用する素材チップに\n★７以上のものが含まれています。\n解放の素材にしたチップは失われますが、\nよろしいですか？",
-		"tr_text": "One or more of the materials\nhas a rarity of ★７+ stars。\nThese will be lost upon use.\nAre you sure?"
+		"tr_text": "One or more of the materials\nhas a rarity of ★７+ stars.\nThese will be lost upon use.\nAre you sure?"
 	},
 	{
 		"assign": "labo_dialog_t_06",
@@ -21772,17 +21772,17 @@
 	{
 		"assign": "chip_awake_dialog_b_decide",
 		"jp_text": "<color=yellow>使用する素材チップに★７以上のものが含まれています。</color>\n次の素材チップとメセタを消費して、チップ特装を実行します。\nよろしいですか？",
-		"tr_text": "<color=yellow>One or more of the materials\nhas a rarity of ★７+ stars。</color>\nThese will be lost upon use.\nAre you sure?"
+		"tr_text": "<color=yellow>One or more of the materials has a rarity of ★７+ stars.</color>\nThese will be lost upon use.\nAre you sure?"
 	},
 	{
 		"assign": "chip_awake_dialog_b_decide_t_material",
 		"jp_text": "消費素材チップ",
-		"tr_text": ""
+		"tr_text": "Consumed Material Chips"
 	},
 	{
 		"assign": "chip_awake_dialog_b_decide_t_details",
 		"jp_text": "特装効果",
-		"tr_text": ""
+		"tr_text": "Specialization Details"
 	},
 	{
 		"assign": "chip_awake_dialog_b_decide_b_chiplv",
@@ -21817,7 +21817,7 @@
 	{
 		"assign": "chip_awake_skill_dialog_b_decide",
 		"jp_text": "<color=yellow>使用する素材チップに★７以上のものが含まれています。</color>\n次の素材チップとメセタを消費して、プラグ強化を実行します。\nよろしいですか？",
-		"tr_text": "<color=yellow>One or more of the materials\nhas a rarity of ★７+ stars。</color>\nThese will be lost upon use.\nAre you sure?"
+		"tr_text": "<color=yellow>One or more of the materials\nhas a rarity of ★７+ stars.</color>\nThese will be lost upon use.\nAre you sure?"
 	},
 	{
 		"assign": "chip_awake_skill_dialog_b_decide_t_material",


### PR DESCRIPTION
Replaces Sega's vague, adjective-based chip descriptions with full and precise formulae including exactly how much ATK and element they add and by how much they boost damage.

Doesn't include PAs and Techs, does include damage bombs.