### PR TITLE
Fix "★12 Weapon Exchange Pass" Inconsistency

### DIFF
--- a/json/Item_Stack_PaidPass.txt
+++ b/json/Item_Stack_PaidPass.txt
@@ -226,7 +226,7 @@
 	{
 		"assign": "321035",
 		"jp_text": "★１２武器購入パス",
-		"tr_text": "★12 Weapon Exchange Pass",
+		"tr_text": "12★ Weapon Exchange Pass",
 		"jp_explain": "特定レアリティ武器の購入パス。\nマイショップで【★１２】武器を\n購入する際に消費される。",
 		"tr_explain": "A pass that grants the purchase\nof 12★ weapons from My Shop."
 	},


### PR DESCRIPTION
All the other pass names are set to [number]★, except this one.