### PR TITLE
Standardize "Custom Type" item names.

### DIFF
--- a/json/Item_Stack_PaidPass.txt
+++ b/json/Item_Stack_PaidPass.txt
@@ -576,42 +576,42 @@
 	{
 		"assign": "3210119",
 		"jp_text": "カスタムタイプ１＋１０％",
-		"tr_text": "Custom Type 1+10%",
+		"tr_text": "Custom Type 1 +10%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ１の効果値を\n１０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 1 effect boosted\nby 10%."
 	},
 	{
 		"assign": "3210120",
 		"jp_text": "カスタムタイプ１＋２０％",
-		"tr_text": "Custom Type 1+20%",
+		"tr_text": "Custom Type 1 +20%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ１の効果値を\n２０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 1 effect boosted\nby 20%."
 	},
 	{
 		"assign": "3210121",
 		"jp_text": "カスタムタイプ１＋３０％",
-		"tr_text": "Custom Type 1+30%",
+		"tr_text": "Custom Type 1 +30%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ１の効果値を\n３０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 1 effect boosted\nby 30%."
 	},
 	{
 		"assign": "3210124",
 		"jp_text": "カスタムタイプ２＋１０％",
-		"tr_text": "Custom Type 2+10%",
+		"tr_text": "Custom Type 2 +10%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ２の効果値を\n１０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 2 effect boosted\nby 10%."
 	},
 	{
 		"assign": "3210125",
 		"jp_text": "カスタムタイプ２＋２０％",
-		"tr_text": "Custom Type 2+20%",
+		"tr_text": "Custom Type 2 +20%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ２の効果値を\n２０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 2 effect boosted\nby 20%."
 	},
 	{
 		"assign": "3210126",
 		"jp_text": "カスタムタイプ２＋３０％",
-		"tr_text": "Custom Type 2+30%",
+		"tr_text": "Custom Type 2 +30%",
 		"jp_explain": "カスタマイズ実行時に\nカスタムタイプ２の効果値を\n３０％向上させる。",
 		"tr_explain": "Used during customization crafts.\nCustom Type 2 effect boosted\nby 30%."
 	},


### PR DESCRIPTION
Add in some extra spaces to match how percentages in item names are used elsewhere.